### PR TITLE
wip: poc translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "redux": "^4.1.2",
     "redux-thunk": "^2.4.1",
     "seedrandom": "^3.0.5",
-    "sharetribe-flex-sdk": "^1.15.0",
+    "sharetribe-flex-sdk": "git+https://github.com/sharetribe/flex-sdk-js/#9a66e2f48e71f8e0be82c0b7728125cd2403528a",
     "sharetribe-scripts": "5.0.1",
     "smoothscroll-polyfill": "^0.4.0",
     "source-map-support": "^0.5.21",

--- a/server/csp.js
+++ b/server/csp.js
@@ -8,6 +8,8 @@ const data = 'data:';
 const blob = 'blob:';
 const devImagesMaybe = dev ? ['*.localhost:8000'] : [];
 const baseUrl = process.env.REACT_APP_SHARETRIBE_SDK_BASE_URL || 'https://flex-api.sharetribe.com';
+const assetCdnBaseUrl =
+  process.env.REACT_APP_SHARETRIBE_SDK_ASSET_CDN_BASE_URL || 'https://cdn.st-api.com';
 
 // Default CSP whitelist.
 //
@@ -20,6 +22,7 @@ const defaultDirectives = {
   connectSrc: [
     self,
     baseUrl,
+    assetCdnBaseUrl,
     'maps.googleapis.com',
     '*.tiles.mapbox.com',
     'api.mapbox.com',

--- a/server/dataLoader.js
+++ b/server/dataLoader.js
@@ -1,10 +1,12 @@
 const url = require('url');
 const log = require('./log');
 
-exports.loadData = function(requestUrl, sdk, matchPathname, configureStore, routeConfiguration) {
+exports.loadData = function(requestUrl, sdk, appInfo) {
+  const { matchPathname, configureStore, routeConfiguration, config, fetchAppAssets } = appInfo;
   const { pathname, query } = url.parse(requestUrl);
   const matchedRoutes = matchPathname(pathname, routeConfiguration());
 
+  let translations = {};
   const store = configureStore({}, sdk);
 
   const dataLoadingCalls = matchedRoutes.reduce((calls, match) => {
@@ -15,9 +17,14 @@ exports.loadData = function(requestUrl, sdk, matchPathname, configureStore, rout
     return calls;
   }, []);
 
-  return Promise.all(dataLoadingCalls)
+  return store
+    .dispatch(fetchAppAssets(config.appCdnAssets))
+    .then(fetchedAssets => {
+      translations = fetchedAssets?.translations?.data || {};
+      return Promise.all(dataLoadingCalls);
+    })
     .then(() => {
-      return store.getState();
+      return { preloadedState: store.getState(), translations };
     })
     .catch(e => {
       log.error(e, 'server-side-data-load-failed');

--- a/server/index.js
+++ b/server/index.js
@@ -49,6 +49,7 @@ const dev = process.env.REACT_APP_ENV === 'development';
 const PORT = parseInt(process.env.PORT, 10);
 const CLIENT_ID = process.env.REACT_APP_SHARETRIBE_SDK_CLIENT_ID;
 const BASE_URL = process.env.REACT_APP_SHARETRIBE_SDK_BASE_URL;
+const ASSET_CDN_BASE_URL = process.env.REACT_APP_SHARETRIBE_SDK_ASSET_CDN_BASE_URL;
 const TRANSIT_VERBOSE = process.env.REACT_APP_SHARETRIBE_SDK_TRANSIT_VERBOSE === 'true';
 const USING_SSL = process.env.REACT_APP_SHARETRIBE_USING_SSL === 'true';
 const TRUST_PROXY = process.env.SERVER_SHARETRIBE_TRUST_PROXY || null;
@@ -199,6 +200,7 @@ app.get('*', (req, res) => {
   });
 
   const baseUrl = BASE_URL ? { baseUrl: BASE_URL } : {};
+  const assetCdnBaseUrl = ASSET_CDN_BASE_URL ? { assetCdnBaseUrl: ASSET_CDN_BASE_URL } : {};
 
   const sdk = sharetribeSdk.createInstance({
     transitVerbose: TRANSIT_VERBOSE,
@@ -208,6 +210,7 @@ app.get('*', (req, res) => {
     tokenStore,
     typeHandlers: sdkUtils.typeHandlers,
     ...baseUrl,
+    ...assetCdnBaseUrl,
   });
 
   // Until we have a better plan for caching dynamic content and we
@@ -221,12 +224,12 @@ app.get('*', (req, res) => {
 
   // Server-side entrypoint provides us the functions for server-side data loading and rendering
   const nodeEntrypoint = nodeExtractor.requireEntrypoint();
-  const { default: renderApp, matchPathname, configureStore, routeConfiguration } = nodeEntrypoint;
+  const { default: renderApp, ...appInfo } = nodeEntrypoint;
 
   dataLoader
-    .loadData(req.url, sdk, matchPathname, configureStore, routeConfiguration)
-    .then(preloadedState => {
-      const html = renderer.render(req.url, context, preloadedState, renderApp, webExtractor);
+    .loadData(req.url, sdk, appInfo)
+    .then(data => {
+      const html = renderer.render(req.url, context, data, renderApp, webExtractor);
 
       if (dev) {
         const debugData = {

--- a/server/renderer.js
+++ b/server/renderer.js
@@ -90,11 +90,19 @@ const replacer = (key = null, value) => {
   return types.replacer(key, cleanedValue);
 };
 
-exports.render = function(requestUrl, context, preloadedState, renderApp, webExtractor) {
+exports.render = function(requestUrl, context, data, renderApp, webExtractor) {
+  const { preloadedState, translations } = data;
+
   // Bind webExtractor as "this" for collectChunks call.
   const collectWebChunks = webExtractor.collectChunks.bind(webExtractor);
 
-  const { head, body } = renderApp(requestUrl, context, preloadedState, collectWebChunks);
+  const { head, body } = renderApp(
+    requestUrl,
+    context,
+    preloadedState,
+    translations,
+    collectWebChunks
+  );
 
   // Preloaded state needs to be passed for client side too.
   // For security reasons we ensure that preloaded state is considered as a string

--- a/src/app.js
+++ b/src/app.js
@@ -86,10 +86,14 @@ const setupLocale = () => {
 };
 
 export const ClientApp = props => {
-  const { store } = props;
+  const { store, hostedTranslations = {} } = props;
   setupLocale();
   return (
-    <IntlProvider locale={config.locale} messages={localeMessages} textComponent="span">
+    <IntlProvider
+      locale={config.locale}
+      messages={{ ...localeMessages, ...hostedTranslations }}
+      textComponent="span"
+    >
       <Provider store={store}>
         <HelmetProvider>
           <IncludeMapLibraryScripts />
@@ -107,11 +111,15 @@ const { any, string } = PropTypes;
 ClientApp.propTypes = { store: any.isRequired };
 
 export const ServerApp = props => {
-  const { url, context, helmetContext, store } = props;
+  const { url, context, helmetContext, store, hostedTranslations = {} } = props;
   setupLocale();
   HelmetProvider.canUseDOM = false;
   return (
-    <IntlProvider locale={config.locale} messages={localeMessages} textComponent="span">
+    <IntlProvider
+      locale={config.locale}
+      messages={{ ...localeMessages, ...hostedTranslations }}
+      textComponent="span"
+    >
       <Provider store={store}>
         <HelmetProvider context={helmetContext}>
           <IncludeMapLibraryScripts />
@@ -136,7 +144,13 @@ ServerApp.propTypes = { url: string.isRequired, context: any.isRequired, store: 
  *  - {String} body: Rendered application body of the given route
  *  - {Object} head: Application head metadata from react-helmet
  */
-export const renderApp = (url, serverContext, preloadedState, collectChunks) => {
+export const renderApp = (
+  url,
+  serverContext,
+  preloadedState,
+  hostedTranslations,
+  collectChunks
+) => {
   // Don't pass an SDK instance since we're only rendering the
   // component tree with the preloaded store state and components
   // shouldn't do any SDK calls in the (server) rendering lifecycle.
@@ -148,7 +162,13 @@ export const renderApp = (url, serverContext, preloadedState, collectChunks) => 
   // This is needed to figure out correct chunks/scripts to be included to server-rendered page.
   // https://loadable-components.com/docs/server-side-rendering/#3-setup-chunkextractor-server-side
   const WithChunks = collectChunks(
-    <ServerApp url={url} context={serverContext} helmetContext={helmetContext} store={store} />
+    <ServerApp
+      url={url}
+      context={serverContext}
+      helmetContext={helmetContext}
+      store={store}
+      hostedTranslations={hostedTranslations}
+    />
   );
   const body = ReactDOMServer.renderToString(WithChunks);
   const { helmet: head } = helmetContext;

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -6,6 +6,12 @@ import { subUnitDivisors, currencyConfiguration } from './currency-config';
 const env = process.env.REACT_APP_ENV;
 const dev = process.env.REACT_APP_ENV === 'development';
 
+// CDN assets for the app. Configurable through Flex Console.
+// Currently, only translation.json is available.
+const appCdnAssets = {
+  translations: 'config/translations.json',
+};
+
 // If you want to change the language, remember to also change the
 // locale data and the messages in the app.js file.
 const locale = 'en';
@@ -71,6 +77,7 @@ const dayCountAvailableForBooking = 90;
 // exposing server secrets to the client side.
 const sdkClientId = process.env.REACT_APP_SHARETRIBE_SDK_CLIENT_ID;
 const sdkBaseUrl = process.env.REACT_APP_SHARETRIBE_SDK_BASE_URL;
+const sdkAssetCdnBaseUrl = process.env.REACT_APP_SHARETRIBE_SDK_ASSET_CDN_BASE_URL;
 const sdkTransitVerbose = process.env.REACT_APP_SHARETRIBE_SDK_TRANSIT_VERBOSE === 'true';
 
 // Marketplace currency.
@@ -221,6 +228,7 @@ const maps = {
 const config = {
   env,
   dev,
+  appCdnAssets,
   locale,
   lineItemUnitType,
   listingManagementType,
@@ -229,6 +237,7 @@ const config = {
   sdk: {
     clientId: sdkClientId,
     baseUrl: sdkBaseUrl,
+    assetCdnBaseUrl: sdkAssetCdnBaseUrl,
     transitVerbose: sdkTransitVerbose,
   },
   mainSearchType,

--- a/src/containers/LandingPage/SectionHero/SectionHero.js
+++ b/src/containers/LandingPage/SectionHero/SectionHero.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { string } from 'prop-types';
 import classNames from 'classnames';
 
@@ -8,20 +8,28 @@ import { NamedLink } from '../../../components';
 import css from './SectionHero.module.css';
 
 const SectionHero = props => {
+  const [mounted, setMounted] = useState(false);
   const { rootClassName, className } = props;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   const classes = classNames(rootClassName || css.root, className);
 
   return (
     <div className={classes}>
       <div className={css.heroContent}>
-        <h1 className={css.heroMainTitle}>
+        <h1 className={classNames(css.heroMainTitle, { [css.heroMainTitleFEDelay]: mounted })}>
           <FormattedMessage id="SectionHero.title" />
         </h1>
-        <h2 className={css.heroSubTitle}>
+        <h2 className={classNames(css.heroSubTitle, { [css.heroSubTitleFEDelay]: mounted })}>
           <FormattedMessage id="SectionHero.subTitle" />
         </h2>
-        <NamedLink name="SearchPage" className={css.heroButton}>
+        <NamedLink
+          name="SearchPage"
+          className={classNames(css.heroButton, { [css.heroButtonFEDelay]: mounted })}
+        >
           <FormattedMessage id="SectionHero.browseButton" />
         </NamedLink>
       </div>

--- a/src/containers/LandingPage/SectionHero/SectionHero.module.css
+++ b/src/containers/LandingPage/SectionHero/SectionHero.module.css
@@ -21,6 +21,7 @@
   animation-duration: 0.5s;
   animation-timing-function: ease-out;
   -webkit-animation-fill-mode: forwards;
+  animation-delay: 3s;
 
   visibility: hidden;
   opacity: 1;
@@ -70,13 +71,14 @@
 .heroMainTitle {
   @apply --marketplaceHeroTitleFontStyles;
   color: var(--matterColorLight);
-
   composes: animation;
-  animation-delay: 0.5s;
 
   @media (--viewportMedium) {
     max-width: var(--SectionHero_desktopTitleMaxWidth);
   }
+}
+.heroMainTitleFEDelay {
+  animation-delay: 0s;
 }
 
 .heroSubTitle {
@@ -84,24 +86,26 @@
 
   color: var(--matterColorLight);
   margin: 0 0 32px 0;
-
   composes: animation;
-  animation-delay: 0.65s;
 
   @media (--viewportMedium) {
     max-width: var(--SectionHero_desktopTitleMaxWidth);
     margin: 0 0 47px 0;
   }
 }
+.heroSubTitleFEDelay {
+  animation-delay: 0.15s;
+}
 
 .heroButton {
   @apply --marketplaceButtonStyles;
   composes: animation;
 
-  animation-delay: 0.8s;
-
   @media (--viewportMedium) {
     display: block;
     width: 260px;
   }
+}
+.heroButtonFEDelay {
+  animation-delay: 0.3s;
 }

--- a/src/ducks/hostedAssets.duck.js
+++ b/src/ducks/hostedAssets.duck.js
@@ -1,0 +1,84 @@
+import { storableError } from '../util/errors';
+import * as log from '../util/log';
+
+// ================ Action types ================ //
+
+export const ASSETS_REQUEST = 'app/assets/REQUEST';
+export const ASSETS_SUCCESS = 'app/assets/SUCCESS';
+export const ASSETS_ERROR = 'app/assets/ERROR';
+
+// ================ Reducer ================ //
+
+const initialState = {
+  assets: {},
+  version: null,
+  inProgress: false,
+  error: null,
+};
+
+export default function assetReducer(state = initialState, action = {}) {
+  const { type, payload } = action;
+  switch (type) {
+    case ASSETS_REQUEST:
+      return { ...state, inProgress: true, error: null };
+    case ASSETS_SUCCESS:
+      return {
+        ...state,
+        assets: payload.assets,
+        version: payload.version,
+        inProgress: false,
+      };
+    case ASSETS_ERROR:
+      return { ...state, inProgress: true, error: payload };
+
+    default:
+      return state;
+  }
+}
+
+// ================ Action creators ================ //
+
+export const assetsRequested = () => ({ type: ASSETS_REQUEST });
+export const assetsSuccess = (assets, version) => ({
+  type: ASSETS_SUCCESS,
+  payload: { assets, version },
+});
+export const assetsError = error => ({
+  type: ASSETS_ERROR,
+  payload: error,
+});
+
+// ================ Thunks ================ //
+
+export const fetchAppAssets = (assets, version) => (dispatch, getState, sdk) => {
+  dispatch(assetsRequested());
+
+  const fetchAssets = version
+    ? assetPath => sdk.assetByVersion({ path: assetPath, version })
+    : assetPath => sdk.assetByAlias({ path: assetPath, alias: 'latest' });
+  const assetEntries = Object.entries(assets);
+  const sdkAssets = assetEntries.map(([key, assetPath]) => fetchAssets(assetPath));
+
+  return Promise.all(sdkAssets)
+    .then(responses => {
+      const version = responses[0]?.data?.meta?.version;
+      dispatch(assetsSuccess(assets, version));
+
+      // E.g.
+      // {
+      //    translations:
+      //      {
+      //        path: 'translations.json',
+      //        data, // translation key & value pairs
+      //      },
+      // }
+      return assetEntries.reduce((collectedAssets, assetEntry, i) => {
+        const [name, path] = assetEntry;
+        return { ...collectedAssets, [name]: { path, data: responses[i].data.data } };
+      }, {});
+    })
+    .catch(e => {
+      log.error(e, 'app-asset-fetch-failed', { assets, version });
+      dispatch(assetsError(storableError(e)));
+    });
+};

--- a/src/ducks/index.js
+++ b/src/ducks/index.js
@@ -9,6 +9,7 @@ import EmailVerification from './EmailVerification.duck';
 import LocationFilter from './LocationFilter.duck';
 import Routing from './Routing.duck';
 import UI from './UI.duck';
+import hostedAssets from './hostedAssets.duck';
 import marketplaceData from './marketplaceData.duck';
 import paymentMethods from './paymentMethods.duck';
 import stripe from './stripe.duck';
@@ -21,6 +22,7 @@ export {
   LocationFilter,
   Routing,
   UI,
+  hostedAssets,
   marketplaceData,
   paymentMethods,
   stripe,

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ import * as sample from './util/sample';
 import * as apiUtils from './util/api';
 import config from './config';
 import { authInfo } from './ducks/Auth.duck';
+import { fetchAppAssets } from './ducks/hostedAssets.duck';
 import { fetchCurrentUser } from './ducks/user.duck';
 import routeConfiguration from './routing/routeConfiguration';
 import * as log from './util/log';
@@ -39,18 +40,30 @@ const render = (store, shouldHydrate) => {
   // If the server already loaded the auth information, render the app
   // immediately. Otherwise wait for the flag to be loaded and render
   // when auth information is present.
-  const authInfoLoaded = store.getState().Auth.authInfoLoaded;
+  const state = store.getState();
+  const cdnAssetsVersion = state.hostedAssets.version;
+  const authInfoLoaded = state.Auth.authInfoLoaded;
   const info = authInfoLoaded ? Promise.resolve({}) : store.dispatch(authInfo());
   info
     .then(() => {
       store.dispatch(fetchCurrentUser());
-      return loadableReady();
+      return Promise.all([
+        loadableReady(),
+        store.dispatch(fetchAppAssets(config.appCdnAssets, cdnAssetsVersion)),
+      ]);
     })
-    .then(() => {
+    .then(([_, fetchedAssets]) => {
+      const translations = fetchedAssets?.translations?.data || {};
       if (shouldHydrate) {
-        ReactDOM.hydrate(<ClientApp store={store} />, document.getElementById('root'));
+        ReactDOM.hydrate(
+          <ClientApp store={store} hostedTranslations={translations} />,
+          document.getElementById('root')
+        );
       } else {
-        ReactDOM.render(<ClientApp store={store} />, document.getElementById('root'));
+        ReactDOM.render(
+          <ClientApp store={store} hostedTranslations={translations} />,
+          document.getElementById('root')
+        );
       }
     })
     .catch(e => {
@@ -87,6 +100,9 @@ if (typeof window !== 'undefined') {
   log.setup();
 
   const baseUrl = config.sdk.baseUrl ? { baseUrl: config.sdk.baseUrl } : {};
+  const assetCdnBaseUrl = config.sdk.assetCdnBaseUrl
+    ? { assetCdnBaseUrl: config.sdk.assetCdnBaseUrl }
+    : {};
 
   // eslint-disable-next-line no-underscore-dangle
   const preloadedState = window.__PRELOADED_STATE__ || '{}';
@@ -97,6 +113,7 @@ if (typeof window !== 'undefined') {
     secure: config.usingSSL,
     typeHandlers: apiUtils.typeHandlers,
     ...baseUrl,
+    ...assetCdnBaseUrl,
   });
   const analyticsHandlers = setupAnalyticsHandlers();
   const store = configureStore(initialState, sdk, analyticsHandlers);
@@ -137,4 +154,4 @@ export default renderApp;
 // exporting matchPathname and configureStore for server side rendering.
 // matchPathname helps to figure out which route is called and if it has preloading needs
 // configureStore is used for creating initial store state for Redux after preloading
-export { matchPathname, configureStore, routeConfiguration, config };
+export { matchPathname, configureStore, routeConfiguration, config, fetchAppAssets };

--- a/yarn.lock
+++ b/yarn.lock
@@ -12844,10 +12844,9 @@ shallowequal@^1.1.0:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
-sharetribe-flex-sdk@^1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/sharetribe-flex-sdk/-/sharetribe-flex-sdk-1.15.0.tgz#847ca0d4ee45618532f82755c552b9ada8876105"
-  integrity sha512-J8kCzQfqf0L8d6VqrpCMqz589smsQeWDYjvQ9hoGcai7SOH/LlLZ2NFH2DgVMCvxnkImO2qplteLgfn89yYbVQ==
+"sharetribe-flex-sdk@git+https://github.com/sharetribe/flex-sdk-js/#9a66e2f48e71f8e0be82c0b7728125cd2403528a":
+  version "1.16.0"
+  resolved "git+https://github.com/sharetribe/flex-sdk-js/#9a66e2f48e71f8e0be82c0b7728125cd2403528a"
   dependencies:
     axios "^0.21.1"
     js-cookie "^2.1.3"


### PR DESCRIPTION
Note: there's still 5 min cache!

Current setup:
1. SSR: initialize the store
2. SSR: fetch 'latest' alias of 'config/translations.json' asset with `sdk.assetByAlias`
3. SSR: asset version is saved to the store and passed to the browser through the "preloadedState".
4. SSR: render the `<ServerApp>` and pass translations as props.
5. Browser: initialize the store with a preloaded state
6. Browser: fetch assets
    - if the asset version exists, call `sdk.assetByVersion`.
    - if the asset version doesn't exist, call `sdk.assetByAlias` 
    (This is for **dev** mode against _localhost:3000_)
7. Browser: hydrate or render the `<ClientApp>` and pass translations as props.