### PR TITLE
Add env variable to prevent data loading in SSR

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -55,3 +55,6 @@ REACT_APP_CSP=report
 # You should also turn "Enhanced measurements" off from GA.
 # https://support.google.com/analytics/answer/9216061
 # REACT_APP_GOOGLE_ANALYTICS_ID=change-me
+
+# Debugging and reducing load from server
+# PREVENT_DATA_LOADING_IN_SSR=true


### PR DESCRIPTION
This might help certain temporary scenarios, where a DDOS attack adds load to a server or when debugging against a hosted environment.

Note: This is not a meaningful mitigation against DDOS attacks.
          Consider adding some kind of edge protection and rate limiter.