### PR TITLE
Update helmet: from v4.6.0 to v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [change] Update helmet library from v4.6.0 to v6.0.1. This causes some breaking changes:
+
+  - https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#500---2022-01-02
+  - https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#600---2022-08-26
+
+  From these, we turned the _crossOriginEmbedderPolicy_ off due to issue with Youtube embed and
+  _useDefault_ flag too as these are tracked explicitly in csp.js
+
+  [#137](https://github.com/sharetribe/web-template/pull/137)
+
 - [change] Split redirection use case away from REACT_APP_SHARETRIBE_USING_SSL into
   SERVER_SHARETRIBE_REDIRECT_SSL environment variable.
   [#136](https://github.com/sharetribe/web-template/pull/136)

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "final-form": "^4.20.7",
     "final-form-arrays": "^3.0.2",
     "full-icu": "^1.4.0",
-    "helmet": "^4.6.0",
+    "helmet": "^6.0.1",
     "jose": "4.9.2",
     "lodash": "^4.17.21",
     "mapbox-gl-multitouch": "^1.0.3",

--- a/public/index.html
+++ b/public/index.html
@@ -174,7 +174,7 @@
 
          https://stripe.com/docs/stripe.js#including-stripejs
        -->
-    <script src="https://js.stripe.com/v3/"></script>
+    <script src="https://js.stripe.com/v3/" crossorigin></script>
     <!--!preloadedStateScript-->
 
     <!--!ssrScripts-->

--- a/server/csp.js
+++ b/server/csp.js
@@ -42,6 +42,7 @@ const defaultDirectives = {
     '*.stripe.com',
   ],
   fontSrc: [self, data, 'assets-sharetribecom.sharetribe.com', 'fonts.gstatic.com'],
+  formAction: [self],
   frameSrc: [self, '*.stripe.com', '*.youtube-nocookie.com'],
   imgSrc: [
     self,
@@ -92,13 +93,10 @@ const defaultDirectives = {
  * @param {String} reportUri URL where the browser will POST the
  * policy violation reports
  *
- * @param {Boolean} enforceSsl When SSL is enforced, all mixed content
- * is blocked/reported by the policy
- *
  * @param {Boolean} reportOnly In the report mode, requests are only
  * reported to the report URL instead of blocked
  */
-module.exports = (reportUri, enforceSsl, reportOnly) => {
+module.exports = (reportUri, reportOnly) => {
   // ================ START CUSTOM CSP URLs ================ //
 
   // Add custom CSP whitelisted URLs here. See commented example
@@ -122,12 +120,13 @@ module.exports = (reportUri, enforceSsl, reportOnly) => {
   // https://github.com/helmetjs/helmet/blob/bdb09348c17c78698b0c94f0f6cc6b3968cd43f9/middlewares/content-security-policy/index.ts#L51
 
   const directives = Object.assign({ reportUri: [reportUri] }, defaultDirectives, customDirectives);
-  if (enforceSsl) {
-    directives.blockAllMixedContent = [];
+  if (!reportOnly) {
+    directives.upgradeInsecureRequests = [];
   }
 
   // See: https://helmetjs.github.io/docs/csp/
   return helmet.contentSecurityPolicy({
+    useDefaults: false,
     directives,
     reportOnly,
   });

--- a/server/index.js
+++ b/server/index.js
@@ -109,7 +109,7 @@ if (cspEnabled) {
   // That's why we need to create own middleware function that calls the Helmet's middleware function
   const reportOnly = CSP === 'report';
   app.use((req, res, next) => {
-    csp(cspReportUrl, USING_SSL, reportOnly)(req, res, next);
+    csp(cspReportUrl, reportOnly)(req, res, next);
   });
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -85,6 +85,9 @@ app.use(log.requestHandler());
 app.use(
   helmet({
     contentSecurityPolicy: false,
+    // This seems to cause problems with Youtube player
+    // Issue tracker: https://issuetracker.google.com/issues/240387105
+    crossOriginEmbedderPolicy: false,
   })
 );
 

--- a/src/components/Map/StaticGoogleMap.js
+++ b/src/components/Map/StaticGoogleMap.js
@@ -95,7 +95,11 @@ class StaticGoogleMap extends Component {
     });
 
     return (
-      <img src={`https://maps.googleapis.com/maps/api/staticmap?${srcParams}`} alt={address} />
+      <img
+        src={`https://maps.googleapis.com/maps/api/staticmap?${srcParams}`}
+        alt={address}
+        crossOrigin="anonymous"
+      />
     );
   }
 }

--- a/src/components/Map/StaticMapboxMap.js
+++ b/src/components/Map/StaticMapboxMap.js
@@ -51,7 +51,7 @@ const StaticMapboxMap = props => {
     `/${width}x${height}` +
     `?access_token=${mapsConfig.mapboxAccessToken}`;
 
-  return <img src={src} alt={address} />;
+  return <img src={src} alt={address} crossOrigin="anonymous" />;
 };
 
 StaticMapboxMap.defaultProps = {

--- a/src/containers/PageBuilder/Primitives/Image/Image.js
+++ b/src/containers/PageBuilder/Primitives/Image/Image.js
@@ -11,7 +11,7 @@ export const MarkdownImage = React.forwardRef((props, ref) => {
   const { className, rootClassName, ...otherProps } = props;
   const classes = classNames(rootClassName || css.markdownImage, className);
 
-  return <img className={classes} {...otherProps} ref={ref} />;
+  return <img className={classes} {...otherProps} ref={ref} crossOrigin="anonymous" />;
 });
 
 MarkdownImage.displayName = 'MarkdownImage';

--- a/src/util/includeScripts.js
+++ b/src/util/includeScripts.js
@@ -42,6 +42,7 @@ export const IncludeScripts = props => {
         key="mapbox_GL_CSS"
         href="https://api.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.css"
         rel="stylesheet"
+        crossOrigin
       />
     );
     // Add Mapbox library
@@ -50,6 +51,7 @@ export const IncludeScripts = props => {
         id={MAPBOX_SCRIPT_ID}
         key="mapbox_GL_JS"
         src="https://api.mapbox.com/mapbox-gl-js/v1.0.0/mapbox-gl.js"
+        crossOrigin
       ></script>
     );
   } else if (isGoogleMapsInUse) {
@@ -59,6 +61,7 @@ export const IncludeScripts = props => {
         id={GOOGLE_MAPS_SCRIPT_ID}
         key="GoogleMapsApi"
         src={`https://maps.googleapis.com/maps/api/js?key=${googleMapsAPIKey}&libraries=places`}
+        crossOrigin
       ></script>
     );
   }
@@ -74,6 +77,7 @@ export const IncludeScripts = props => {
         key="gtag.js"
         async
         src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsId}`}
+        crossOrigin
       ></script>
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6946,10 +6946,10 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-helmet@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/helmet/-/helmet-4.6.0.tgz#579971196ba93c5978eb019e4e8ec0e50076b4df"
-  integrity sha512-HVqALKZlR95ROkrnesdhbbZJFi/rIVSoNq6f3jA/9u6MIbTsPh3xZwihjeI5+DO/2sOV6HMHooXcEOuwskHpTg==
+helmet@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-6.0.1.tgz#52ec353638b2e87f14fe079d142b368ac11e79a4"
+  integrity sha512-8wo+VdQhTMVBMCITYZaGTbE4lvlthelPYSvoyNvk4RECTmrVjMerp9RfUOQXZWLvCcAn1pKj7ZRxK4lI9Alrcw==
 
 history@^4.9.0:
   version "4.9.0"


### PR DESCRIPTION
This introduces breaking changes:
- [v5.0.0](https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#500---2022-01-02)
- [v6.0.0](https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#600---2022-08-26)

However, we turned the _crossOriginEmbedderPolicy_ off due to an issue with the [Youtube embed](https://issuetracker.google.com/issues/240387105) and _useDefault_ flag too as those are tracked explicitly in csp.js