### PR TITLE
Fix EditListingDetailsForm default prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
-- [fix] EditListingDetailsForm: set listingFieldsConfig default prop to empty array to fix a bug with initial null value not getting a default in props destructuring.
+- [fix] EditListingDetailsForm: set listingFieldsConfig default prop to empty array to fix a bug
+  with initial null value not getting a default in props destructuring.
   [#138](https://github.com/sharetribe/web-template/pull/138)
 - [change] Update helmet library from v4.6.0 to v6.0.1. This causes some breaking changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
-- [fix] EditListingDetailsForm: set listingFieldsConfig default prop to empty array.
+- [fix] EditListingDetailsForm: set listingFieldsConfig default prop to empty array to fix a bug with initial null value not getting a default in props destructuring.
   [#138](https://github.com/sharetribe/web-template/pull/138)
 - [change] Update helmet library from v4.6.0 to v6.0.1. This causes some breaking changes:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] EditListingDetailsForm: set listingFieldsConfig default prop to empty array.
+  [#138](https://github.com/sharetribe/web-template/pull/138)
 - [change] Update helmet library from v4.6.0 to v6.0.1. This causes some breaking changes:
 
   - https://github.com/helmetjs/helmet/blob/main/CHANGELOG.md#500---2022-01-02

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsForm.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsForm.js
@@ -116,7 +116,7 @@ const FieldSelectListingType = props => {
 
 // Add collect data for listing fields (both publicData and privateData) based on configuration
 const AddListingFields = props => {
-  const { listingType, listingFieldsConfig = [], intl } = props;
+  const { listingType, listingFieldsConfig, intl } = props;
   const fields = listingFieldsConfig.reduce((pickedFields, fieldConfig) => {
     const { key, includeForListingTypes, schemaType, scope } = fieldConfig || {};
 

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsForm.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsForm.js
@@ -258,7 +258,7 @@ EditListingDetailsFormComponent.defaultProps = {
   fetchErrors: null,
   onProcessChange: null,
   hasExistingListingType: false,
-  listingFieldsConfig: null,
+  listingFieldsConfig: [],
 };
 
 EditListingDetailsFormComponent.propTypes = {


### PR DESCRIPTION
EditListingDetailsForm: set listingFieldsConfig default prop to empty array to fix a bug with initial null value not getting a default in props destructuring.