### PR TITLE
Fix error loading text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] SearchPage error transparency and PageBuilder bg colors of sections.
+  [#139](https://github.com/sharetribe/web-template/pull/139)
 - [fix] EditListingDetailsForm: set listingFieldsConfig default prop to empty array to fix a bug
   with initial null value not getting a default in props destructuring.
   [#138](https://github.com/sharetribe/web-template/pull/138)

--- a/src/containers/PageBuilder/SectionBuilder/SectionContainer/SectionContainer.module.css
+++ b/src/containers/PageBuilder/SectionBuilder/SectionContainer/SectionContainer.module.css
@@ -8,7 +8,7 @@
   position: relative;
 
   &:nth-of-type(odd) {
-    background-color: #fafafa;
+    background-color: var(--colorWhite);
   }
 }
 

--- a/src/containers/SearchPage/SearchPage.module.css
+++ b/src/containers/SearchPage/SearchPage.module.css
@@ -183,8 +183,6 @@
 
 .error {
   color: var(--colorFail);
-  padding-left: 24px;
-  padding-right: 24px;
 }
 
 .searchString {
@@ -243,6 +241,10 @@
   flex-grow: 1;
   display: flex;
   flex-direction: column;
+}
+
+.listingsForGridVariant {
+  composes: listings;
 }
 
 .listingsForMapVariant {

--- a/src/containers/SearchPage/SearchPageWithGrid.js
+++ b/src/containers/SearchPage/SearchPageWithGrid.js
@@ -376,8 +376,8 @@ export class SearchPageComponent extends Component {
                 noResultsInfo={noResultsInfo}
               />
               <div
-                className={classNames(css.listings, {
-                  [css.newSearchInProgress]: !listingsAreLoaded,
+                className={classNames(css.listingsForGridVariant, {
+                  [css.newSearchInProgress]: !(listingsAreLoaded || searchListingsError),
                 })}
               >
                 {searchListingsError ? (

--- a/src/containers/SearchPage/SearchPageWithMap.js
+++ b/src/containers/SearchPage/SearchPageWithMap.js
@@ -492,7 +492,7 @@ export class SearchPageComponent extends Component {
             ) : (
               <div
                 className={classNames(css.listingsForMapVariant, {
-                  [css.newSearchInProgress]: !listingsAreLoaded,
+                  [css.newSearchInProgress]: !(listingsAreLoaded || searchListingsError),
                 })}
               >
                 {searchListingsError ? (


### PR DESCRIPTION
- SearchPage: error should not be transparent (which is used for in-progress fetch).
- PageBuilder: odd sections should have different background than the default page bg color