### PR TITLE
Fix layout-breaking condition in purchase templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] Email templates: fix layout-breaking condition in purchase templates.
+  [141](https://github.com/sharetribe/web-template/pull/141)
 - [fix] SearchPage error transparency and PageBuilder bg colors of sections.
   [#139](https://github.com/sharetribe/web-template/pull/139)
 - [fix] EditListingDetailsForm: set listingFieldsConfig default prop to empty array to fix a bug

--- a/ext/transaction-processes/default-purchase/templates/purchase-shipping-reminder/purchase-shipping-reminder-html.html
+++ b/ext/transaction-processes/default-purchase/templates/purchase-shipping-reminder/purchase-shipping-reminder-html.html
@@ -3,7 +3,7 @@
 
   <head>
     <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
-  </head>{{#with transaction}}{{#eq "shipping" protected-data.deliveryMethod}}
+  </head>{{#with transaction}}
       <table style="background-color:#FFF;margin:0 auto;padding:24px 12px 0;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif" align="center" border="0" cellPadding="0" cellSpacing="0" role="presentation" width="100%">
         <tbody>
           <tr>
@@ -11,6 +11,7 @@
               <table align="center" role="presentation" cellSpacing="0" cellPadding="0" border="0" width="100%" style="max-width:600px;margin:0 auto">
                 <tr style="width:100%">
                   <td>
+                    {{#eq "shipping" protected-data.deliveryMethod}}
                     <h1 style="color:#484848;font-size:26px;line-height:1.3;font-weight:700">Remember to ship {{listing.title}}</h1>
                     <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">You received an order for {{listing.title}} from {{customer.display-name}} three days ago. Please remember to ship the item and mark it as shipped from <a target="_blank" style="color:#007DF2;text-decoration:none" href="{{marketplace.url}}/sale/{{url-encode id}}/">order details</a> to receive your payment.</p>
                     <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">If the order has not been marked as shipped within two weeks from the original purchase, it will expire automatically and you won't get paid.</p>

--- a/ext/transaction-processes/default-purchase/templates/purchase-shipping-time-expired-customer/purchase-shipping-time-expired-customer-html.html
+++ b/ext/transaction-processes/default-purchase/templates/purchase-shipping-time-expired-customer/purchase-shipping-time-expired-customer-html.html
@@ -3,7 +3,7 @@
 
   <head>
     <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
-  </head>{{#with transaction}}{{#eq "shipping" protected-data.deliveryMethod}}
+  </head>{{#with transaction}}
       <table style="background-color:#FFF;margin:0 auto;padding:24px 12px 0;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif" align="center" border="0" cellPadding="0" cellSpacing="0" role="presentation" width="100%">
         <tbody>
           <tr>
@@ -12,6 +12,7 @@
                 <tr style="width:100%">
                   <td>
                     <h1 style="color:#484848;font-size:26px;line-height:1.3;font-weight:700">Your order was automatically canceled</h1>
+                    {{#eq "shipping" protected-data.deliveryMethod}}
                     <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">Your order for {{listing.title}} was automatically canceled as {{provider.display-name}} did not ship it within two weeks from the original purchase. You will be refunded fully.</p>
                     {{else}}
                       <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">Your order for {{listing.title}} was automatically canceled as {{provider.display-name}} did not deliver it within two weeks from the original purchase. You will be refunded fully.</p>

--- a/ext/transaction-processes/default-purchase/templates/purchase-shipping-time-expired-provider/purchase-shipping-time-expired-provider-html.html
+++ b/ext/transaction-processes/default-purchase/templates/purchase-shipping-time-expired-provider/purchase-shipping-time-expired-provider-html.html
@@ -3,7 +3,7 @@
 
   <head>
     <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
-  </head>{{#with transaction}}{{#eq "shipping" protected-data.deliveryMethod}}
+  </head>{{#with transaction}}
       <table style="background-color:#FFF;margin:0 auto;padding:24px 12px 0;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif" align="center" border="0" cellPadding="0" cellSpacing="0" role="presentation" width="100%">
         <tbody>
           <tr>
@@ -12,6 +12,7 @@
                 <tr style="width:100%">
                   <td>
                     <h1 style="color:#484848;font-size:26px;line-height:1.3;font-weight:700">An order for {{listing.title}} was automatically canceled</h1>
+                    {{#eq "shipping" protected-data.deliveryMethod}}
                     <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">You failed to mark an order for {{listing.title}} from {{customer.display-name}} as shipped within two weeks from the original purchase. Therefore, the order was automatically canceled.</p>
                     {{else}}
                       <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">You failed to mark an order for {{listing.title}} from {{customer.display-name}} as delivered within two weeks from the original purchase. Therefore, the order was automatically canceled.</p>


### PR DESCRIPTION
Move conditions for delivery method to parallel the else block in purchase email templates, so that the table layout works with all delivery method options.