### PR TITLE
Show booking time based on line item type in booking templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] Email templates: Show booking time based on line item type in booking templates
+  [#145](https://github.com/sharetribe/web-template/pull/145)
 - [change] Listing field of type enum should be explicitly handled as strings.
   [#146](https://github.com/sharetribe/web-template/pull/146)
 - [fix] ListingImageGallery was not setting image dimensions aka sizes.

--- a/ext/transaction-processes/default-booking/templates/booking-declined-request/booking-declined-request-html.html
+++ b/ext/transaction-processes/default-booking/templates/booking-declined-request/booking-declined-request-html.html
@@ -2,7 +2,11 @@
 <html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
-  </head>{{~#*inline "format-date"~}}{{#with transaction.listing.availability-plan}}{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}{{#with transaction}}
+  </head>
+{{~#*inline "format-date"~}}{{#with transaction.listing.availability-plan}}{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}
+{{~#*inline "format-date-day"~}}{{#with transaction.listing.availability-plan}}{{date date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}
+{{~#*inline "format-date-day-before"~}}{{#with transaction.listing.availability-plan}}{{date-day-before date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}
+{{#with transaction}}
   <table style="background-color:#FFF;margin:0 auto;padding:24px 12px 0;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif" align="center" border="0" cellPadding="0" cellSpacing="0" role="presentation" width="100%">
     <tbody>
       <tr>
@@ -11,7 +15,15 @@
             <tr style="width:100%">
               <td>
                 <h1 style="color:#484848;font-size:26px;line-height:1.3;font-weight:700">Your booking request was declined</h1>
-                <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">Unfortunately {{ provider.display-name }} decided to decline your booking request for {{ listing.title }} from {{> format-date date=booking.start}} to {{> format-date date=booking.end}}. You have not been billed.</p>
+                <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">Unfortunately {{ provider.display-name }} decided to decline your booking request for {{ listing.title }} from 
+                  {{#each tx-line-items}}{{#eq "line-item/hour" code}}
+                    {{> format-date date=booking.start}} to {{> format-date date=booking.end}}
+                    {{/ eq}}{{#eq "line-item/day" code}}
+                    {{> format-date-day date=booking.start}} to {{> format-date-day-before date=booking.end}}
+                    {{/ eq}}{{#eq "line-item/night" code}}
+                    {{> format-date-day date=booking.start}} to {{> format-date-day date=booking.end}}
+                  {{/ eq}}{{/each}}
+                  . You have not been billed.</p>
                 <table style="padding:16px 0 0" align="center" border="0" cellPadding="0" cellSpacing="0" role="presentation" width="100%">
                   <tbody>
                     <tr>

--- a/ext/transaction-processes/default-booking/templates/booking-expired-request/booking-expired-request-html.html
+++ b/ext/transaction-processes/default-booking/templates/booking-expired-request/booking-expired-request-html.html
@@ -2,7 +2,11 @@
 <html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
-  </head>{{~#*inline "format-date"~}}{{#with transaction.listing.availability-plan}}{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}{{#with transaction}}
+  </head>
+  {{~#*inline "format-date"~}}{{#with transaction.listing.availability-plan}}{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}
+  {{~#*inline "format-date-day"~}}{{#with transaction.listing.availability-plan}}{{date date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}
+  {{~#*inline "format-date-day-before"~}}{{#with transaction.listing.availability-plan}}{{date-day-before date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}
+  {{#with transaction}}
   <table style="background-color:#FFF;margin:0 auto;padding:24px 12px 0;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif" align="center" border="0" cellPadding="0" cellSpacing="0" role="presentation" width="100%">
     <tbody>
       <tr>
@@ -11,7 +15,15 @@
             <tr style="width:100%">
               <td>
                 <h1 style="color:#484848;font-size:26px;line-height:1.3;font-weight:700">Your booking request expired</h1>
-                <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">{{ provider.display-name }} didn't respond to your booking request for {{ listing.title }} from {{> format-date date=booking.start}} to {{> format-date date=booking.end}} on time,so your request expired. Your card has not been charged.</p>
+                <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">{{ provider.display-name }} didn't respond to your booking request for {{ listing.title }} from 
+                  {{#each tx-line-items}}{{#eq "line-item/hour" code}}
+                    {{> format-date date=booking.start}} to {{> format-date date=booking.end}}
+                    {{/ eq}}{{#eq "line-item/day" code}}
+                    {{> format-date-day date=booking.start}} to {{> format-date-day-before date=booking.end}}
+                    {{/ eq}}{{#eq "line-item/night" code}}
+                    {{> format-date-day date=booking.start}} to {{> format-date-day date=booking.end}}
+                  {{/ eq}}{{/each}}
+                   on time,so your request expired. Your card has not been charged.</p>
                 <table style="padding:16px 0 0" align="center" border="0" cellPadding="0" cellSpacing="0" role="presentation" width="100%">
                   <tbody>
                     <tr>

--- a/ext/transaction-processes/default-booking/templates/booking-operator-accepted-request/booking-operator-accepted-request-html.html
+++ b/ext/transaction-processes/default-booking/templates/booking-operator-accepted-request/booking-operator-accepted-request-html.html
@@ -2,7 +2,11 @@
 <html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
-  </head>{{~#*inline "format-date"~}}{{#with transaction.listing.availability-plan}}{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}{{#with transaction}}
+  </head>
+  {{~#*inline "format-date"~}}{{#with transaction.listing.availability-plan}}{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}
+  {{~#*inline "format-date-day"~}}{{#with transaction.listing.availability-plan}}{{date date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}
+  {{~#*inline "format-date-day-before"~}}{{#with transaction.listing.availability-plan}}{{date-day-before date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}
+  {{#with transaction}}
   <table style="background-color:#FFF;margin:0 auto;padding:24px 12px 0;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif" align="center" border="0" cellPadding="0" cellSpacing="0" role="presentation" width="100%">
     <tbody>
       <tr>
@@ -11,7 +15,15 @@
             <tr style="width:100%">
               <td>
                 <h1 style="color:#484848;font-size:26px;line-height:1.3;font-weight:700">A booking for one of your listings was accepted on your behalf</h1>
-                <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">{{marketplace.name}} administrator accepted a booking by {{ customer.display-name }} for {{ listing.title }} from {{> format-date date=booking.start}} to {{> format-date date=booking.end}} on your behalf.</p>
+                <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">{{marketplace.name}} administrator accepted a booking by {{ customer.display-name }} for {{ listing.title }} from 
+                  {{#each tx-line-items}}{{#eq "line-item/hour" code}}
+                    {{> format-date date=booking.start}} to {{> format-date date=booking.end}}
+                    {{/ eq}}{{#eq "line-item/day" code}}
+                    {{> format-date-day date=booking.start}} to {{> format-date-day-before date=booking.end}}
+                    {{/ eq}}{{#eq "line-item/night" code}}
+                    {{> format-date-day date=booking.start}} to {{> format-date-day date=booking.end}}
+                  {{/ eq}}{{/each}}
+                   on your behalf.</p>
                 <table style="padding:16px 0 0" align="center" border="0" cellPadding="0" cellSpacing="0" role="presentation" width="100%">
                   <tbody>
                     <tr>

--- a/ext/transaction-processes/default-booking/templates/booking-operator-declined-request/booking-operator-declined-request-html.html
+++ b/ext/transaction-processes/default-booking/templates/booking-operator-declined-request/booking-operator-declined-request-html.html
@@ -2,7 +2,11 @@
 <html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html charset=UTF-8" />
-  </head>{{~#*inline "format-date"~}}{{#with transaction.listing.availability-plan}}{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}{{#with transaction}}
+  </head>
+  {{~#*inline "format-date"~}}{{#with transaction.listing.availability-plan}}{{date date format="h:mm a" tz=timezone}} on {{date date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}
+  {{~#*inline "format-date-day"~}}{{#with transaction.listing.availability-plan}}{{date date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}
+  {{~#*inline "format-date-day-before"~}}{{#with transaction.listing.availability-plan}}{{date-day-before date format="MMM d, YYYY" tz=timezone}}{{/with}}{{~/inline~}}
+  {{#with transaction}}
   <table style="background-color:#FFF;margin:0 auto;padding:24px 12px 0;font-family:-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif" align="center" border="0" cellPadding="0" cellSpacing="0" role="presentation" width="100%">
     <tbody>
       <tr>
@@ -11,7 +15,14 @@
             <tr style="width:100%">
               <td>
                 <h1 style="color:#484848;font-size:26px;line-height:1.3;font-weight:700">A booking for one of your listings was declined on your behalf</h1>
-                <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">{{marketplace.name}} administrator declined a booking by {{ customer.display-name }} for {{ listing.title }} from {{> format-date date=booking.start}} to {{> format-date date=booking.end}} on your behalf.</p>
+                <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">{{marketplace.name}} administrator declined a booking by {{ customer.display-name }} for {{ listing.title }} from 
+                  {{#each tx-line-items}}{{#eq "line-item/hour" code}}
+                    {{> format-date date=booking.start}} to {{> format-date date=booking.end}}
+                    {{/ eq}}{{#eq "line-item/day" code}}
+                    {{> format-date-day date=booking.start}} to {{> format-date-day-before date=booking.end}}
+                    {{/ eq}}{{#eq "line-item/night" code}}
+                    {{> format-date-day date=booking.start}} to {{> format-date-day date=booking.end}}
+                  {{/ eq}}{{/each}}                   on your behalf.</p>
                 <table style="padding:16px 0 0" align="center" border="0" cellPadding="0" cellSpacing="0" role="presentation" width="100%">
                   <tbody>
                     <tr>


### PR DESCRIPTION
- **hour** shows date & time for the booking time range
- **day** shows a date range, where the last day is inclusive (while API uses exclusive end)
- **night** shows a date range with an exclusive end (which is natural for nights)