### PR TITLE
Fix iphone safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] ListingImageGallery: Mobile Safari was not showing thumbnail stripe correctly, if the
+  content overflew. [#158](https://github.com/sharetribe/web-template/pull/158)
 - [change] Update README.md [#157](https://github.com/sharetribe/web-template/pull/157)
 
 ## [v1.0.0] 2023-04-25

--- a/src/containers/ListingPage/ListingImageGallery/ListingImageGallery.module.css
+++ b/src/containers/ListingPage/ListingImageGallery/ListingImageGallery.module.css
@@ -1,20 +1,24 @@
 @import '../../../styles/customMediaQueries.css';
 
 :global(.image-gallery-thumbnails-container) {
+  text-align: left !important;
+}
+:global(.image-gallery-thumbnails) {
+  padding-top: 24px;
+  padding-bottom: 0;
+
   /*
    By default, the gallery controls the scroll position of the thumbnails when
    browsing the images. We change this logic to a freely scrollable container
    that the user controls. This overflow works together with the
    `disableThumbnailScroll` option in the component JS.
    */
-  overflow: auto;
-  text-align: left !important;
-}
-:global(.image-gallery-thumbnails) {
-  padding-top: 24px;
-  padding-bottom: 0;
   width: 100vw;
+  overflow: auto;
 
+  @media (--viewportMedium) {
+    width: calc(100vw - 48px);
+  }
   @media (--viewportLarge) {
     width: unset;
   }


### PR DESCRIPTION
ListingPageCarousel>ListingImageGallery: mobile Safari wasn't showing all the thumbnails if the thumbnails overflow (overflow:auto).