### PR TITLE
Future assets

### DIFF
--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
@@ -46,7 +46,7 @@ const getTouchCoordinates = nativeEvent => {
 
 // Get correct geocoding variant: geocoderGoogleMaps or geocoderMapbox
 const getGeocoderVariant = mapProvider => {
-  const isGoogleMapsInUse = mapProvider === 'GOOGLE_MAPS';
+  const isGoogleMapsInUse = mapProvider === 'googleMaps';
   return isGoogleMapsInUse ? geocoderGoogleMaps : geocoderMapbox;
 };
 
@@ -550,7 +550,7 @@ class LocationAutocompleteInputImplementation extends Component {
             rootClassName={predictionsClass}
             predictions={predictions}
             currentLocationId={geocoderVariant.CURRENT_LOCATION_ID}
-            isGoogleMapsInUse={config.maps.mapProvider === 'GOOGLE_MAPS'}
+            isGoogleMapsInUse={config.maps.mapProvider === 'googleMaps'}
             geocoder={this.getGeocoder()}
             highlightedIndex={this.state.highlightedIndex}
             onSelectStart={this.handlePredictionsSelectStart}

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -23,7 +23,7 @@ export const Map = props => {
     useStaticMap,
   } = props;
   const mapsConfiguration = mapsConfig || config.maps;
-  const isGoogleMapsInUse = mapsConfiguration.mapProvider === 'GOOGLE_MAPS';
+  const isGoogleMapsInUse = mapsConfiguration.mapProvider === 'googleMaps';
   const StaticMap = isGoogleMapsInUse ? googleMapsMap.StaticMap : mapboxMap.StaticMap;
   const DynamicMap = isGoogleMapsInUse ? googleMapsMap.DynamicMap : mapboxMap.DynamicMap;
   const isMapsLibLoaded = isGoogleMapsInUse

--- a/src/config/configDefault.js
+++ b/src/config/configDefault.js
@@ -79,6 +79,9 @@ const defaultConfig = {
     search: '/listings/listing-search.json',
     transactionSize: '/transactions/minimum-transaction-size.json',
     // NOTE: we don't fetch commissions configuration here but on the server-side
+
+    // TODO: map provider configuration and analytics service should come from assets too.
+    // maps: 'integrations/map.json',
   },
 
   // Optional

--- a/src/config/configDefault.js
+++ b/src/config/configDefault.js
@@ -80,8 +80,10 @@ const defaultConfig = {
     transactionSize: '/transactions/minimum-transaction-size.json',
     // NOTE: we don't fetch commissions configuration here but on the server-side
 
-    // TODO: map provider configuration and analytics service should come from assets too.
-    // maps: 'integrations/map.json',
+    // TODO: Map provider configuration and analytics service should come from assets too.
+    //       It might take some time before these are actually available through hosted assets.
+    // maps: '/integrations/map.json',
+    // analytics: '/integrations/analytics.json',
   },
 
   // Optional
@@ -96,7 +98,9 @@ const defaultConfig = {
   // Optional
   // Note that Google Analytics might need advanced opt-out option / cookie consent
   // depending on jurisdiction (e.g. EU countries), since it relies on cookies.
-  googleAnalyticsId: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
+  analytics: {
+    googleAnalyticsId: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
+  },
 
   // Optional
   // Address information is used in SEO schema for Organization (http://schema.org/PostalAddress)

--- a/src/config/configMaps.js
+++ b/src/config/configMaps.js
@@ -7,10 +7,10 @@ import defaultLocationSearches from './configDefaultLocationSearches';
 export const mapboxAccessToken = process.env.REACT_APP_MAPBOX_ACCESS_TOKEN;
 export const googleMapsAPIKey = process.env.REACT_APP_GOOGLE_MAPS_API_KEY;
 
-// Choose map provider: 'MAPBOX', 'GOOGLE_MAPS'
+// Choose map provider: 'mapbox', 'googleMaps'
 // Note: you need to have REACT_APP_MAPBOX_ACCESS_TOKEN or REACT_APP_GOOGLE_MAPS_API_KEY
 //       set depending on which one you use in this config.
-export const mapProvider = 'MAPBOX';
+export const mapProvider = 'mapbox';
 
 // The location search input can be configured to show default
 // searches when the user focuses on the input and hasn't yet typed

--- a/src/containers/SearchPage/SearchMap/SearchMap.js
+++ b/src/containers/SearchPage/SearchMap/SearchMap.js
@@ -19,7 +19,7 @@ import css from './SearchMap.module.css';
 const REUSABLE_MAP_HIDDEN_HANDLE = 'reusableMapHidden';
 
 const getSearchMapVariant = mapProvider => {
-  const isGoogleMapsInUse = mapProvider === 'GOOGLE_MAPS';
+  const isGoogleMapsInUse = mapProvider === 'googleMaps';
   return isGoogleMapsInUse ? searchMapGoogleMaps : searchMapMapbox;
 };
 const getSearchMapVariantHandles = mapProvider => {

--- a/src/index.js
+++ b/src/index.js
@@ -98,7 +98,7 @@ const render = (store, shouldHydrate) => {
     });
 };
 
-const setupAnalyticsHandlers = () => {
+const setupAnalyticsHandlers = googleAnalyticsId => {
   let handlers = [];
 
   // Log analytics page views and events in dev mode
@@ -107,8 +107,8 @@ const setupAnalyticsHandlers = () => {
   }
 
   // Add Google Analytics 4 (GA4) handler if tracker ID is found
-  if (process.env.REACT_APP_GOOGLE_ANALYTICS_ID) {
-    if (process.env.REACT_APP_GOOGLE_ANALYTICS_ID.indexOf('G-') !== 0) {
+  if (googleAnalyticsId) {
+    if (googleAnalyticsId.indexOf('G-') !== 0) {
       console.warn(
         'Google Analytics 4 (GA4) should have measurement id that starts with "G-" prefix'
       );
@@ -141,7 +141,11 @@ if (typeof window !== 'undefined') {
     ...baseUrl,
     ...assetCdnBaseUrl,
   });
-  const analyticsHandlers = setupAnalyticsHandlers();
+
+  // Note: on localhost:3000, you need to use environment variable.
+  const googleAnalyticsIdFromSSR = initialState?.hostedAssets?.googleAnalyticsId;
+  const googleAnalyticsId = googleAnalyticsIdFromSSR || process.env.REACT_APP_GOOGLE_ANALYTICS_ID;
+  const analyticsHandlers = setupAnalyticsHandlers(googleAnalyticsId);
   const store = configureStore(initialState, sdk, analyticsHandlers);
 
   require('./util/polyfills');

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -533,6 +533,19 @@ const getListingMinimumPrice = transactionSize => {
 };
 
 ////////////////////////////////////
+// Validate and merge map configs //
+////////////////////////////////////
+const mergeMapConfig = (hostedMapConfig, defaultMapConfig) => {
+  const { mapProvider, mapboxAccessToken, googleMapsAPIKey, ...restOfDefault } = defaultMapConfig;
+  return {
+    ...restOfDefault,
+    mapProvider: hostedMapConfig?.provider || mapProvider,
+    mapboxAccessToken: hostedMapConfig?.mapboxAccessToken || mapboxAccessToken,
+    googleMapsAPIKey: hostedMapConfig?.googleMapsApiKey || googleMapsAPIKey,
+  };
+};
+
+////////////////////////////////////
 // Validate and merge all configs //
 ////////////////////////////////////
 const restructureListingTypes = hostedListingTypes => {
@@ -651,6 +664,9 @@ export const mergeConfig = (configAsset = {}, defaultConfigs = {}) => {
 
     // Hosted search configuration does not yet contain sortConfig
     search: validSearchConfig(searchConfig),
+
+    // Map provider info might come from hosted assets. Other map configs come from defaultConfigs.
+    maps: mergeMapConfig(configAsset.maps, defaultConfigs.maps),
 
     // Include hosted footer config, if it exists
     // Note: if footer asset is not set, Footer is not rendered.

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -27,6 +27,17 @@ const validLabel = label => {
   return [isValid, labelMaybe];
 };
 
+/////////////////////
+// Merge analytics //
+/////////////////////
+
+const mergeAnalyticsConfig = (hostedAnalyticsConfig, defaultAnalyticsConfig) => {
+  const { enabled, measurementId } = hostedAnalyticsConfig?.googleAnalytics || {};
+  const googleAnalyticsId =
+    enabled && measurementId ? measurementId : defaultAnalyticsConfig.googleAnalyticsId;
+  return { googleAnalyticsId };
+};
+
 ////////////////////
 // Merge branding //
 ////////////////////
@@ -649,6 +660,9 @@ export const mergeConfig = (configAsset = {}, defaultConfigs = {}) => {
 
     // Overwrite default configs if hosted config is available
     listingMinimumPriceSubUnits,
+
+    // Analytics might come from hosted assets at some point.
+    analytics: mergeAnalyticsConfig(configAsset.analytics, defaultConfigs.analytics),
 
     // Branding configuration comes entirely from hosted assets,
     // but defaults to values set in defaultConfigs.branding for

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -514,9 +514,18 @@ const validSortConfig = config => {
   return { active, queryParamName, relevanceKey, relevanceFilter, conflictingFilters, options };
 };
 
-const validSearchConfig = config => {
+const mergeSearchConfig = (hostedSearchConfig, defaultSearchConfig) => {
+  // The sortConfig is not yet configurable through Console / hosted assets,
+  // but other default search configs come from hosted assets
+  const searchConfig = hostedSearchConfig?.mainSearch
+    ? {
+        sortConfig: defaultSearchConfig.sortConfig,
+        ...hostedSearchConfig,
+      }
+    : defaultSearchConfig;
+
   const { mainSearch, dateRangeFilter, priceFilter, keywordsFilter, sortConfig, ...rest } =
-    config || {};
+    searchConfig || {};
   const searchType = ['location', 'keywords'].includes(mainSearch?.searchType)
     ? mainSearch?.searchType
     : 'keywords';
@@ -640,15 +649,6 @@ export const mergeConfig = (configAsset = {}, defaultConfigs = {}) => {
         }
       : null;
 
-  // The sortConfig is not yet configurable through Console / hosted assets,
-  // but other default search configs come from hosted assets
-  const searchConfig = configAsset.search?.mainSearch
-    ? {
-        sortConfig: defaultConfigs.search.sortConfig,
-        ...configAsset.search,
-      }
-    : defaultConfigs.search;
-
   // defaultConfigs.listingMinimumPriceSubUnits is the backup for listing's minimum price
   const listingMinimumPriceSubUnits =
     getListingMinimumPrice(configAsset.transactionSize) ||
@@ -677,7 +677,7 @@ export const mergeConfig = (configAsset = {}, defaultConfigs = {}) => {
     listing: validListingConfig(hostedListingConfig || defaultConfigs.listing),
 
     // Hosted search configuration does not yet contain sortConfig
-    search: validSearchConfig(searchConfig),
+    search: mergeSearchConfig(configAsset.search, defaultConfigs.search),
 
     // Map provider info might come from hosted assets. Other map configs come from defaultConfigs.
     maps: mergeMapConfig(configAsset.maps, defaultConfigs.maps),

--- a/src/util/includeScripts.js
+++ b/src/util/includeScripts.js
@@ -19,8 +19,8 @@ export const IncludeScripts = props => {
   const { marketplaceRootURL: rootURL, maps, googleAnalyticsId } = props?.config || {};
 
   const { mapProvider, googleMapsAPIKey, mapboxAccessToken } = maps || {};
-  const isGoogleMapsInUse = mapProvider === 'GOOGLE_MAPS';
-  const isMapboxInUse = mapProvider === 'MAPBOX';
+  const isGoogleMapsInUse = mapProvider === 'googleMaps';
+  const isMapboxInUse = mapProvider === 'mapbox';
 
   // Add Google Analytics script if correct id exists (it should start with 'G-' prefix)
   // See: https://developers.google.com/analytics/devguides/collection/gtagjs

--- a/src/util/includeScripts.js
+++ b/src/util/includeScripts.js
@@ -16,7 +16,8 @@ const GOOGLE_MAPS_SCRIPT_ID = 'GoogleMapsApi';
  *         should be whitelisted in the policy. Check: server/csp.js
  */
 export const IncludeScripts = props => {
-  const { marketplaceRootURL: rootURL, maps, googleAnalyticsId } = props?.config || {};
+  const { marketplaceRootURL: rootURL, maps, analytics } = props?.config || {};
+  const googleAnalyticsId = analytics.googleAnalyticsId;
 
   const { mapProvider, googleMapsAPIKey, mapboxAccessToken } = maps || {};
   const isGoogleMapsInUse = mapProvider === 'googleMaps';


### PR DESCRIPTION
Prepare for future assets (map provider and GA4)
Note: it might take a long time before we actually introduce these assets.

Some renaming happened: 
- mapProvider: 'MAPBOX' & 'GOOGLE_MAPS' => 'mapbox' & 'googleMaps'
- configDefault.js: `googleAnalyticsId` => `analytics.googleAnalyticsId`

Also configHelpers.js was refactored (including some rare bugs fixes)