### PR TITLE
Support code-splitted locale imports for moment.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [add] Import moment locales dynamically as a fallback.
+  [#171](https://github.com/sharetribe/web-template/pull/171)
 - [fix] This adds a few fixes to reported bugs
 
   - BookingTimeForm: do not allow line-item fetch with negative time range.

--- a/src/app.js
+++ b/src/app.js
@@ -69,11 +69,12 @@ import defaultMessages from './translations/defaultMicrocopy.json';
 //   1. hosted translation.json
 //   2. <lang>.json
 //   3. defaultMicrocopy.json
-// But you could just translate the defaultMicrocopy.json file and keep it updated. That way you
-// can avoid including <lang>.json into build files.
 //
 // I.e. remove "const messagesInLocale" and add import for the correct locale:
 // import messagesInLocale from './translations/fr.json';
+//
+// However, the recommendation is that you translate the defaultMicrocopy.json file and keep it updated.
+// That way you can avoid importing <lang>.json into build files, which is better for performance.
 const messagesInLocale = {};
 
 // If translation key is missing from `messagesInLocale` (e.g. fr.json),


### PR DESCRIPTION
Make it a bit less error-prone to change the locale.

By default that has a few steps:

1. **change locale in configDefault.js** file
```
  localization: {
    locale: 'fr-FR', // en -> fr-FR
    // etc.
  }
```

2. **Import locale for moment library** in _src/app.js_
3. **Change microcopy**  in the _Console_

3.5 Custom apps could also change defaultMicrocopy.json translations. That way accidentally deleted keys in dynamic hosted microcopy (in Console) won't cause the default English translations to be rendered in your custom client app.

---

This code makes the second step optional. 
However, for performance reasons, custom app developers should make a change like the one below in _src/app.js_:

```
import 'moment/locale/fr';
const hardCodedLocale = process.env.NODE_ENV === 'test' ? 'en' : 'fr';
```
