### PR TITLE
Fix page builder section carousel with scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] SectionCarousel was overflown, when scrollbars were enforced.
+  [#177](https://github.com/sharetribe/web-template/pull/177)
 - [add] Import moment locales dynamically as a fallback.
   [#171](https://github.com/sharetribe/web-template/pull/171)
 - [fix] This adds a few fixes to reported bugs

--- a/src/containers/PageBuilder/SectionBuilder/SectionCarousel/SectionCarousel.js
+++ b/src/containers/PageBuilder/SectionBuilder/SectionCarousel/SectionCarousel.js
@@ -54,7 +54,11 @@ const SectionCarousel = props => {
       if (hasBlocks) {
         const windowWidth = window.innerWidth;
         const elem = window.document.getElementById(sliderContainerId);
-        const carouselWidth = elem.clientWidth > windowWidth ? windowWidth : elem.clientWidth;
+        const scrollbarWidth = window.innerWidth - document.body.clientWidth;
+        const elementWidth =
+          elem.clientWidth >= windowWidth - scrollbarWidth ? windowWidth : elem.clientWidth;
+        const carouselWidth = elementWidth - scrollbarWidth;
+
         elem.style.setProperty('--carouselWidth', `${carouselWidth}px`);
       }
     };


### PR DESCRIPTION
Fix: when scrollbar was enforced, there was issue with carousel being too wide