### PR TITLE
Fix keywords filter drop from map search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] SearchPageWithMap: include extra query parameters for onMapMoveEnd callback as they might
+  contain 'keywords'. [#178](https://github.com/sharetribe/web-template/pull/178)
 - [fix] SectionCarousel was overflown, when scrollbars were enforced.
   [#177](https://github.com/sharetribe/web-template/pull/177)
 - [add] Import moment locales dynamically as a fallback.

--- a/src/containers/SearchPage/SearchPageWithMap.js
+++ b/src/containers/SearchPage/SearchPageWithMap.js
@@ -110,13 +110,14 @@ export class SearchPageComponent extends Component {
       });
 
       const originMaybe = isOriginInUse(this.props.config) ? { origin: viewportCenter } : {};
+      const dropNonFilterParams = false;
 
       const searchParams = {
         address,
         ...originMaybe,
         bounds: viewportBounds,
         mapSearch: true,
-        ...validFilterParams(rest, listingFieldsConfig, defaultFiltersConfig),
+        ...validFilterParams(rest, listingFieldsConfig, defaultFiltersConfig, dropNonFilterParams),
       };
 
       history.push(createResourceLocatorString('SearchPage', routes, {}, searchParams));

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -633,6 +633,7 @@ const mergeSearchConfig = (hostedSearchConfig, defaultSearchConfig) => {
   const searchConfig = hostedSearchConfig?.mainSearch
     ? {
         sortConfig: defaultSearchConfig.sortConfig,
+        keywordsFilter: defaultSearchConfig.keywordsFilter,
         ...hostedSearchConfig,
       }
     : defaultSearchConfig;


### PR DESCRIPTION
SearchPageWithMap: do not drop extra params when doing a search by moving the search map.