### PR TITLE
Add google site verification config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [add] Add support for site verification for Google Search Console.
+  [#183](https://github.com/sharetribe/web-template/pull/183)
 - [change] Prepare that keywords filter config might come from listing-search asset.
-  [#181](https://github.com/sharetribe/web-template/pull/181)
+  [#182](https://github.com/sharetribe/web-template/pull/182)
 - [fix] localization asset: Add localization asset (it won't be available yet).
   [#180](https://github.com/sharetribe/web-template/pull/180)
 - [fix] EditListingDeliveryPanel:

--- a/src/config/configDefault.js
+++ b/src/config/configDefault.js
@@ -85,6 +85,7 @@ const defaultConfig = {
     //       It might take some time before these are actually available through hosted assets.
     // maps: '/integrations/map.json',
     // analytics: '/integrations/analytics.json',
+    // googleSearchConsole: '/integrations/google-search-console.json',
     // localization: '/general/localization.json',
   },
 
@@ -102,6 +103,13 @@ const defaultConfig = {
   // depending on jurisdiction (e.g. EU countries), since it relies on cookies.
   analytics: {
     googleAnalyticsId: process.env.REACT_APP_GOOGLE_ANALYTICS_ID,
+  },
+
+  // Optional
+  // This creates meta tag for Google Search Console verification
+  // I.e. <meta name=“google-site-verification” content=“GOOGLE_SITE_VERIFICATION_TOKEN”/>
+  googleSearchConsole: {
+    googleSiteVerification: null, // Add google-site-verification token as a string
   },
 
   // Optional

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -765,6 +765,10 @@ export const mergeConfig = (configAsset = {}, defaultConfigs = {}) => {
     // Map provider info might come from hosted assets. Other map configs come from defaultConfigs.
     maps: mergeMapConfig(configAsset.maps, defaultConfigs.maps),
 
+    // Google Site Verification can be given through configs.
+    // Renders a meta tag: <meta name="google-site-verification" content="[token-here]>" />
+    googleSearchConsole: configAsset.googleSearchConsole || defaultConfigs.googleSearchConsole,
+
     // Include hosted footer config, if it exists
     // Note: if footer asset is not set, Footer is not rendered.
     footer: configAsset.footer,

--- a/src/util/seo.js
+++ b/src/util/seo.js
@@ -141,12 +141,23 @@ export const twitterMetaProps = data => {
  * Creates data for Open Graph and Twitter meta tags.
  */
 export const metaTagProps = (tagData, config) => {
-  const { marketplaceRootURL, facebookAppId, marketplaceName, siteTwitterHandle } = config;
+  const {
+    marketplaceRootURL,
+    facebookAppId,
+    marketplaceName,
+    siteTwitterHandle,
+    googleSearchConsole,
+  } = config;
 
   const author = tagData.author || marketplaceName;
+  const googleSiteVerification = googleSearchConsole?.googleSiteVerification;
+  const googleSiteVerificationMaybe = googleSiteVerification
+    ? [{ name: 'google-site-verification', content: googleSiteVerification }]
+    : [];
   const defaultMeta = [
     { name: 'description', content: tagData.description },
     { name: 'author', content: author },
+    ...googleSiteVerificationMaybe,
   ];
 
   const openGraphMeta = openGraphMetaProps({


### PR DESCRIPTION
This creates a meta tag for Google Search Console verification
I.e. `<meta name=“google-site-verification” content=“GOOGLE_SITE_VERIFICATION_TOKEN”/>`