### PR TITLE
Fix: crash on checkout page (after inquiry)

### DIFF
--- a/src/containers/CheckoutPage/CheckoutPage.js
+++ b/src/containers/CheckoutPage/CheckoutPage.js
@@ -762,9 +762,7 @@ export class CheckoutPageComponent extends Component {
       return <NamedRedirect name="ListingPage" params={params} />;
     }
 
-    // Show breakdown only when (speculated?) transaction is loaded
-    // (i.e. it has an id and lineItems)
-    const tx = existingTransaction.id ? existingTransaction : speculatedTransaction;
+    const tx = speculatedTransaction.id ? speculatedTransaction : existingTransaction;
     const timeZone = listing?.attributes?.availabilityPlan?.timezone;
     const transactionProcessAlias = currentListing.attributes.publicData?.transactionProcessAlias;
     const unitType = currentListing.attributes.publicData?.unitType;
@@ -773,6 +771,9 @@ export class CheckoutPageComponent extends Component {
     const txBookingMaybe = tx.booking?.id
       ? { booking: ensureBooking(tx.booking), dateType, timeZone }
       : {};
+
+    // Show breakdown only when (speculated) transaction is loaded
+    // (i.e. it has an id and lineItems)
     const breakdown =
       tx.id && tx.attributes.lineItems?.length > 0 ? (
         <OrderBreakdown
@@ -784,6 +785,9 @@ export class CheckoutPageComponent extends Component {
           marketplaceName={config.marketplaceName}
         />
       ) : null;
+    const totalPrice = tx.id && tx.attributes.lineItems?.length > 0
+      ? getFormattedTotalPrice(tx, intl)
+      : null
 
     const process = latestProcessName ? getProcess(latestProcessName) : null;
     const transitions = process.transitions;
@@ -929,7 +933,7 @@ export class CheckoutPageComponent extends Component {
                   askShippingDetails={askShippingDetails}
                   showPickUplocation={orderData?.deliveryMethod === 'pickup'}
                   listingLocation={currentListing?.attributes?.publicData?.location}
-                  totalPrice={tx.id ? getFormattedTotalPrice(tx, intl) : null}
+                  totalPrice={totalPrice}
                   locale={config.localization.locale}
                   stripePublishableKey={config.stripe.publishableKey}
                   marketplaceName={config.marketplaceName}


### PR DESCRIPTION
When rendering `CheckoutPage`, the variable `tx`, (that is used to calculate breakdown and pay in) is preferred to be based on `existingTransaction`, rather than `speculatedTransaction`.

As a result, when trying to checkout after inquiry (as a customer, (1) visit listing page, (2) send message to provider and (3) request booking from order page) `CheckoutPage` crashes on render with the following output in console:

![Capture](https://github.com/sharetribe/web-template/assets/1393825/8e267927-f7b2-4bfd-a341-afdc6fb2c641)

This is because `existingTransaction` does not yet have all data expected by `getFormattedTotalPrice`.

This PR makes pay in/breakdown calculation prefer speculated transaction, plus some minor cosmetic refactor to make related code clearer.