### PR TITLE
Fix missing css import on CheckoutPage/ErrorMessages.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+## [v3.0.1] 2023-09-06
+
+- [fix] CheckoutPage/ErrorMessages: add missing css import.
+  [#211](https://github.com/sharetribe/web-template/pull/211)
+
 ## [v3.0.0] 2023-09-04
 
 This is a major version release. Mainly due to a new process and big changes to the CheckoutPage.

--- a/src/containers/CheckoutPage/ErrorMessages.js
+++ b/src/containers/CheckoutPage/ErrorMessages.js
@@ -12,6 +12,8 @@ import {
   transactionInitiateOrderStripeErrors,
 } from '../../util/errors';
 
+import css from './CheckoutPage.module.css';
+
 // Collect error message checks to a single function.
 export const getErrorMessages = (
   listingNotFound,


### PR DESCRIPTION
CheckoutPage/ErrorMessages: add missing css import.