### PR TITLE
Generate webmanifest

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,13 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <!--!meta-->
 
-    <!-- Create icons using https://realfavicongenerator.net/ -->
-    <!-- Note: we don't use favicon.ico, favicon-32x32.png, favicon-16x16.png, or safari-pinned-tab.svg as "favicon" icon comes from hosted assets / Console -->
-    <link rel="apple-touch-icon" sizes="180x180" href="/static/icons/apple-touch-icon.png">
-    <link rel="manifest" href="/static/icons/site.webmanifest">
-    <meta name="msapplication-TileColor" content="#da532c">
-    <meta name="theme-color" content="#ffffff">
-    <meta name="msapplication-config" content="/static/icons/browserconfig.xml">
+    <!-- Favicons and app icons -->
+    <!-- If you want more control, you can create icons using https://realfavicongenerator.net/ and remove generated webmanifest from the server and Page -->
+    <!-- Note: we generate web app manifest from design/branding.json, and it is set in src/components/Page/Page component -->
+    <!-- Note: we don't use favicon.ico by default. However, favicon-48x48.png, favicon-32x32.png, favicon-16x16.png and apple-touch-icon come from hosted assets / Console -->
     <!-- End Favicons -->
 
     <!--!link-->

--- a/server/api-util/sdk.js
+++ b/server/api-util/sdk.js
@@ -168,3 +168,21 @@ exports.fetchCommission = sdk => {
       return response;
     });
 };
+
+// Fetch branding asset with 'latest' alias.
+// This is needed for generating webmanifest on server-side.
+exports.fetchBranding = sdk => {
+  return sdk.assetsByAlias({ paths: ['design/branding.json'], alias: 'latest' }).then(response => {
+    // Let's throw an error if we can't fetch branding for some reason
+    const brandingAsset = response?.data?.data?.[0];
+    if (!brandingAsset) {
+      const message = 'Branding configuration was not available.';
+      const error = new Error(message);
+      error.status = 400;
+      error.statusText = message;
+      error.data = {};
+      throw error;
+    }
+    return response;
+  });
+};

--- a/server/apiServer.js
+++ b/server/apiServer.js
@@ -10,6 +10,7 @@ const bodyParser = require('body-parser');
 const cors = require('cors');
 const apiRouter = require('./apiRouter');
 const wellKnownRouter = require('./wellKnownRouter');
+const webmanifestResourceRoute = require('./resources/webmanifest');
 
 const radix = 10;
 const PORT = parseInt(process.env.REACT_APP_DEV_API_SERVER_PORT, radix);
@@ -26,6 +27,12 @@ app.use(
 app.use(cookieParser());
 app.use('/.well-known', wellKnownRouter);
 app.use('/api', apiRouter);
+
+// Generate web app manifest
+// When developing with "yarn run dev",
+// you can reach the manifest from http://localhost:3500/site.webmanifest
+// The corresponding <link> element is set in src/components/Page/Page.js
+app.get('/site.webmanifest', webmanifestResourceRoute);
 
 app.listen(PORT, () => {
   console.log(`API server listening on ${PORT}`);

--- a/server/index.js
+++ b/server/index.js
@@ -33,6 +33,7 @@ const passport = require('passport');
 const auth = require('./auth');
 const apiRouter = require('./apiRouter');
 const wellKnownRouter = require('./wellKnownRouter');
+const webmanifestResourceRoute = require('./resources/webmanifest');
 const { getExtractors } = require('./importer');
 const renderer = require('./renderer');
 const dataLoader = require('./dataLoader');
@@ -139,6 +140,12 @@ app.use(cookieParser());
 // We need to handle these endpoints separately so that they are accessible by Flex
 // even if you have enabled basic authentication e.g. in staging environment.
 app.use('/.well-known', wellKnownRouter);
+
+// Generate web app manifest
+// When developing with "yarn run dev",
+// you can reach the manifest from http://localhost:3500/site.webmanifest
+// The corresponding <link> element is set in src/components/Page/Page.js
+app.get('/site.webmanifest', webmanifestResourceRoute);
 
 // Use basic authentication when not in dev mode. This is
 // intentionally after the static middleware and /.well-known

--- a/server/resources/webmanifest.js
+++ b/server/resources/webmanifest.js
@@ -1,0 +1,75 @@
+const sdkUtils = require('../api-util/sdk');
+
+const rootUrl = process.env.REACT_APP_MARKETPLACE_ROOT_URL;
+
+// Generate icons with correct syntax for web app manifest
+const generateIcons = variants => {
+  const variantArray = Object.values(variants);
+  return variantArray.map(variant => {
+    const { url, width, height } = variant;
+    return {
+      src: url,
+      // This should be square - as it is set to square in assetc schema
+      sizes: `${width}x${height}`,
+      // The image type is hard-coded - even though, Imgix default setup might return something else.
+      type: 'image/png',
+    };
+  });
+};
+
+// Middleware to generate web app manifest for /site.webmanifest call
+// https://developer.mozilla.org/en-US/docs/Web/Manifest
+module.exports = (req, res) => {
+  const sdk = sdkUtils.getSdk(req, res);
+
+  // Note: marketplace.show endpoint is only called to fetch the name of the marketplace.
+  // In your custom app, you might just hard-code this and remove the extra XHR call.
+  const marketplacePromise = () => sdk.marketplace.show({ 'fields.marketplace': ['name'] });
+
+  Promise.all([marketplacePromise(), sdkUtils.fetchBranding(sdk)])
+    .then(response => {
+      const [marketplaceResponse, brandingResponse] = response;
+
+      // Get name
+      const marketplace = marketplaceResponse.data.data;
+      const marketplaceName = marketplace?.attributes?.name;
+
+      // Collect data and included from the branding asset
+      const brandingAssets = brandingResponse.data.data;
+      const data = brandingAssets?.[0]?.attributes?.data;
+      const included = brandingResponse.data?.included || {};
+
+      // Marketplace color is used as theme_color
+      const marketplaceColor = data?.marketplaceColors?.mainColor;
+      const startURL = rootUrl ? `${rootUrl.replace(/\/$/, '')}/` : '/';
+
+      // App icons
+      // Note: icons can be checked from design/branding.json asset (appIcon property),
+      // but in your custom app, you might just hard-code this and remove the extra XHR call.
+      const appIconId = data?.appIcon?._ref?.id;
+      const appIcon = included.find(entity => entity.id === appIconId);
+      const appIconVariants = appIcon?.attributes?.variants || {};
+      const icons = generateIcons(appIconVariants);
+
+      // Response as JSON data
+      const jsonData = {
+        name: marketplaceName, // This could be hard-coded, since it changes rarely
+        short_name: marketplaceName, // This could be hard-coded, since it changes rarely
+        start_url: startURL,
+        display: 'standalone',
+        theme_color: marketplaceColor, // This could be hard-coded, since it changes rarely
+        background_color: '#ffffff',
+        icons,
+      };
+
+      // Format as JSON string (with indentation of 2 spaces)
+      const json = JSON.stringify(jsonData, null, 2);
+
+      // Set the content type for web app manifest
+      res.setHeader('Content-Type', 'application/manifest+json');
+      res.send(json);
+    })
+    .catch(e => {
+      handleError(res, e);
+    });
+};

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -6,7 +6,7 @@ import appSettings from '../config/settings';
 import { types as sdkTypes, transit } from './sdkLoader';
 import Decimal from 'decimal.js';
 
-export const apiBaseUrl = () => {
+export const apiBaseUrl = marketplaceRootURL => {
   const port = process.env.REACT_APP_DEV_API_SERVER_PORT;
   const useDevApiServer = process.env.NODE_ENV === 'development' && !!port;
 
@@ -15,8 +15,8 @@ export const apiBaseUrl = () => {
     return `http://localhost:${port}`;
   }
 
-  // Otherwise, use the same domain and port as the frontend
-  return `${window.location.origin}`;
+  // Otherwise, use the given marketplaceRootURL parameter or the same domain and port as the frontend
+  return marketplaceRootURL ? marketplaceRootURL.replace(/\/$/, '') : `${window.location.origin}`;
 };
 
 // Application type handlers for JS SDK.

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -139,12 +139,12 @@ const getVariantURL = (socialSharingImage, variantName) => {
 
 const mergeBranding = (brandingConfig, defaultBranding) => {
   const {
-    favicon,
     marketplaceColors,
     logo,
     logoSettings,
     loginBackgroundImage,
     socialSharingImage,
+    ...rest
   } = brandingConfig || {};
 
   const marketplaceColor = marketplaceColors?.mainColor || defaultBranding.marketplaceColor;
@@ -170,7 +170,7 @@ const mergeBranding = (brandingConfig, defaultBranding) => {
     brandImage: loginBackgroundImage,
     facebookImage,
     twitterImage,
-    favicon,
+    ...rest,
   };
 };
 


### PR DESCRIPTION
Previously we have instructed customizers to generate app icons including favicon using realfavicongenerator.net.

This PR is built so that it assumes branding.json to contain a **appIcon** property. We use that property to generate **_site.webmanifest_** resource, which is linked through `<link rel="manifest" href={webmanifestURL(marketplaceRootURL)} />`, which is set in Page component.

This also includes apple-touch-icon through data from appIcon and refactors favicon variant code a bit on Page.js.

> Note 1: This setup works in most cases, but if you want to show apple-touch-icon when adding a bookmark on iOS, you need to have a file called apple-touch-icon.png on the root of the domain. (For some reason, the linked apple-touch-icon image is only used when saving the app to the Home screen...)

> Note 2: This setup doesn't change the favicon.ico setup - we are not going to add that to the default as PNG icons work well. However, some browsers might try to fetch favicon.ico from the domain root automatically, which leads to 404.

You might still consider generating icons through realfavicongenerator.net instead - it has more features available.
If you do that, then you need to:
- Add your generated icons to _**./public/static/icons/**_ directory
- Add the `<meta>` & `<link>` elements to index.html (or Page.js)
- Remove `app.get('/site.webmanifest', webmanifestResourceRoute);` from server/index.js & server/apiServer.js
- Remove/change _webmanifestURL_ setup on Page.js
  - and check how _appleTouchIcon_ should work in your case
