### PR TITLE
Fix: Add namespace to listing field inputs to avoid conflicts in input names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] EditListingDetailsPanel: namespace listing field inputs to avoid conflicts in input names.
+  [#216](https://github.com/sharetribe/web-template/pull/216)
 - [add] Add French translations as a reference (fr.json)
   [#219](https://github.com/sharetribe/web-template/pull/219)
 - [add] Add a create-listing link to blank slates of SearchPage and ManageListingsPage.

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsForm.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsForm.js
@@ -116,6 +116,7 @@ const AddListingFields = props => {
   const { listingType, listingFieldsConfig, intl } = props;
   const fields = listingFieldsConfig.reduce((pickedFields, fieldConfig) => {
     const { key, includeForListingTypes, schemaType, scope } = fieldConfig || {};
+    const namespacedKey = scope === 'public' ? `pub_${key}` : `priv_${key}`;
 
     const isKnownSchemaType = EXTENDED_DATA_SCHEMA_TYPES.includes(schemaType);
     const isTargetProcessAlias =
@@ -126,8 +127,8 @@ const AddListingFields = props => {
       ? [
           ...pickedFields,
           <CustomExtendedDataField
-            key={key}
-            name={key}
+            key={namespacedKey}
+            name={namespacedKey}
             fieldConfig={fieldConfig}
             defaultRequiredMessage={intl.formatMessage({
               id: 'EditListingDetailsForm.defaultRequiredMessage',


### PR DESCRIPTION
Add namespace prefix to form inputs that represent listing fields to avoid conflicts in input names. (e.g. "pub_" or "priv_")

This fixes the error that happens if a listing field is named "description" - as the EditListingDetailsForm already contains an input named description.

Note: Currently, this only happens if someone adds a listing field with a name _title_, or _description_.