### PR TITLE
Support multiple listing types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [change] SearchPage.duck.js: use minStock and stockMode for listing.queries if dates filter is not
+  in use. [#217](https://github.com/sharetribe/web-template/pull/217)
 - [fix] Handle missing hosted configurations to show Maintenance Mode page
   [#223](https://github.com/sharetribe/web-template/pull/223)
 - [add] Add German translation as a reference (de.json) and update other lang files.

--- a/src/containers/EditListingPage/EditListingPage.test.js
+++ b/src/containers/EditListingPage/EditListingPage.test.js
@@ -1628,22 +1628,19 @@ describe('EditListingPageComponent', () => {
     const tabLabelDetails = 'EditListingWizard.tabLabelDetails';
     expect(screen.getByText(tabLabelDetails)).toBeInTheDocument();
 
-    const tabLabelLocation = 'EditListingWizard.tabLabelLocation';
-    expect(screen.getByText(tabLabelLocation)).toBeInTheDocument();
-
-    const tabLabelPricing = 'EditListingWizard.tabLabelPricing';
-    expect(screen.getByText(tabLabelPricing)).toBeInTheDocument();
-
+    // Check that default photos panel is not shown initially (it's added after listing type is selected)
     const tabLabelPhotos = 'EditListingWizard.tabLabelPhotos';
-    expect(screen.getByText(tabLabelPhotos)).toBeInTheDocument();
+    expect(screen.queryByText(tabLabelPhotos)).not.toBeInTheDocument();
 
     userEvent.selectOptions(
       screen.getByLabelText('EditListingDetailsForm.listingTypeLabel'),
       'product-selling'
     );
 
-    // Tabs removed
+    // Tabs not in use
+    const tabLabelLocation = 'EditListingWizard.tabLabelLocation';
     expect(screen.queryByText(tabLabelLocation)).not.toBeInTheDocument();
+    const tabLabelPricing = 'EditListingWizard.tabLabelPricing';
     expect(screen.queryByText(tabLabelPricing)).not.toBeInTheDocument();
     const tabLabelAvailability = 'EditListingWizard.tabLabelAvailability';
     expect(screen.queryByText(tabLabelAvailability)).not.toBeInTheDocument();

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsForm.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsForm.js
@@ -183,6 +183,10 @@ const EditListingDetailsFormComponent = props => (
       );
       const maxLength60Message = maxLength(maxLengthMessage, TITLE_MAX_LENGTH);
 
+      // Show title and description only after listing type is selected
+      const showTitle = listingType;
+      const showDescription = listingType;
+
       const classes = classNames(css.root, className);
       const submitReady = (updated && pristine) || ready;
       const submitInProgress = updateInProgress;
@@ -192,34 +196,6 @@ const EditListingDetailsFormComponent = props => (
         <Form className={classes} onSubmit={handleSubmit}>
           <ErrorMessage fetchErrors={fetchErrors} />
 
-          <FieldTextInput
-            id={`${formId}title`}
-            name="title"
-            className={css.title}
-            type="text"
-            label={intl.formatMessage({ id: 'EditListingDetailsForm.title' })}
-            placeholder={intl.formatMessage({ id: 'EditListingDetailsForm.titlePlaceholder' })}
-            maxLength={TITLE_MAX_LENGTH}
-            validate={composeValidators(required(titleRequiredMessage), maxLength60Message)}
-            autoFocus={autoFocus}
-          />
-
-          <FieldTextInput
-            id={`${formId}description`}
-            name="description"
-            className={css.description}
-            type="textarea"
-            label={intl.formatMessage({ id: 'EditListingDetailsForm.description' })}
-            placeholder={intl.formatMessage({
-              id: 'EditListingDetailsForm.descriptionPlaceholder',
-            })}
-            validate={required(
-              intl.formatMessage({
-                id: 'EditListingDetailsForm.descriptionRequired',
-              })
-            )}
-          />
-
           <FieldSelectListingType
             name="listingType"
             listingTypes={selectableListingTypes}
@@ -228,6 +204,38 @@ const EditListingDetailsFormComponent = props => (
             formApi={formApi}
             intl={intl}
           />
+
+          {showTitle ? (
+            <FieldTextInput
+              id={`${formId}title`}
+              name="title"
+              className={css.title}
+              type="text"
+              label={intl.formatMessage({ id: 'EditListingDetailsForm.title' })}
+              placeholder={intl.formatMessage({ id: 'EditListingDetailsForm.titlePlaceholder' })}
+              maxLength={TITLE_MAX_LENGTH}
+              validate={composeValidators(required(titleRequiredMessage), maxLength60Message)}
+              autoFocus={autoFocus}
+            />
+          ) : null}
+
+          {showDescription ? (
+            <FieldTextInput
+              id={`${formId}description`}
+              name="description"
+              className={css.description}
+              type="textarea"
+              label={intl.formatMessage({ id: 'EditListingDetailsForm.description' })}
+              placeholder={intl.formatMessage({
+                id: 'EditListingDetailsForm.descriptionPlaceholder',
+              })}
+              validate={required(
+                intl.formatMessage({
+                  id: 'EditListingDetailsForm.descriptionRequired',
+                })
+              )}
+            />
+          ) : null}
 
           <AddListingFields
             listingType={listingType}

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsPanel.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsPanel.js
@@ -24,11 +24,11 @@ import css from './EditListingDetailsPanel.module.css';
  * if multiple listing types are available.
  *
  * @param {Array} listingTypes
- * @param {Object} existingListingInfo
+ * @param {Object} existingListingTypeInfo
  * @returns an object containing mainly information that can be stored to publicData.
  */
-const getTransactionInfo = (listingTypes, existingListingInfo = {}, inlcudeLabel = false) => {
-  const { listingType, transactionProcessAlias, unitType } = existingListingInfo;
+const getTransactionInfo = (listingTypes, existingListingTypeInfo = {}, inlcudeLabel = false) => {
+  const { listingType, transactionProcessAlias, unitType } = existingListingTypeInfo;
 
   if (listingType && transactionProcessAlias && unitType) {
     return { listingType, transactionProcessAlias, unitType };
@@ -55,15 +55,15 @@ const getTransactionInfo = (listingTypes, existingListingInfo = {}, inlcudeLabel
  * if process has been changed for existing listing.)
  *
  * @param {Object} publicData JSON-like data stored to listing entity.
- * @returns object literal with to keys: { hasExistingListingType, existingListingType }
+ * @returns object literal with to keys: { hasExistingListingType, existingListingTypeInfo }
  */
 const hasSetListingType = publicData => {
   const { listingType, transactionProcessAlias, unitType } = publicData;
-  const existingListingType = { listingType, transactionProcessAlias, unitType };
+  const existingListingTypeInfo = { listingType, transactionProcessAlias, unitType };
 
   return {
     hasExistingListingType: !!listingType && !!transactionProcessAlias && !!unitType,
-    existingListingType,
+    existingListingTypeInfo,
   };
 };
 
@@ -177,12 +177,12 @@ const setNoAvailabilityForUnbookableListings = processAlias => {
  * config.listing.listingFields.
  *
  * @param {object} props
- * @param {object} existingListingType info saved to listing's publicData
+ * @param {object} existingListingTypeInfo info saved to listing's publicData
  * @param {object} listingTypes app's configured types (presets for listings)
  * @param {object} listingFieldsConfig those extended data fields that are part of configurations
  * @returns initialValues object for the form
  */
-const getInitialValues = (props, existingListingType, listingTypes, listingFieldsConfig) => {
+const getInitialValues = (props, existingListingTypeInfo, listingTypes, listingFieldsConfig) => {
   const { description, title, publicData, privateData } = props?.listing?.attributes || {};
   const { listingType } = publicData;
 
@@ -191,7 +191,7 @@ const getInitialValues = (props, existingListingType, listingTypes, listingField
     title,
     description,
     // Transaction type info: listingType, transactionProcessAlias, unitType
-    ...getTransactionInfo(listingTypes, existingListingType),
+    ...getTransactionInfo(listingTypes, existingListingTypeInfo),
     ...initialValuesForListingFields(publicData, 'public', listingType, listingFieldsConfig),
     ...initialValuesForListingFields(privateData, 'private', listingType, listingFieldsConfig),
   };
@@ -218,18 +218,18 @@ const EditListingDetailsPanel = props => {
   const listingTypes = config.listing.listingTypes;
   const listingFieldsConfig = config.listing.listingFields;
 
-  const { hasExistingListingType, existingListingType } = hasSetListingType(publicData);
+  const { hasExistingListingType, existingListingTypeInfo } = hasSetListingType(publicData);
   const hasValidExistingListingType =
     hasExistingListingType &&
     !!listingTypes.find(conf => {
-      const listinTypesMatch = conf.listingType === existingListingType.listingType;
-      const unitTypesMatch = conf.transactionType?.unitType === existingListingType.unitType;
+      const listinTypesMatch = conf.listingType === existingListingTypeInfo.listingType;
+      const unitTypesMatch = conf.transactionType?.unitType === existingListingTypeInfo.unitType;
       return listinTypesMatch && unitTypesMatch;
     });
 
   const initialValues = getInitialValues(
     props,
-    existingListingType,
+    existingListingTypeInfo,
     listingTypes,
     listingFieldsConfig
   );

--- a/src/containers/EditListingPage/EditListingWizard/EditListingWizard.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingWizard.js
@@ -296,9 +296,9 @@ const getListingTypeConfig = (listing, selectedListingType, config) => {
   const hasOnlyOneListingType = validListingTypes?.length === 1;
 
   const listingTypeConfig = existingListingType
-    ? validListingTypes.find(config => config.listingType === existingListingType)
+    ? validListingTypes.find(conf => conf.listingType === existingListingType)
     : selectedListingType
-    ? validListingTypes.find(config => config.listingType === selectedListingType.listingType)
+    ? validListingTypes.find(conf => conf.listingType === selectedListingType.listingType)
     : hasOnlyOneListingType
     ? validListingTypes[0]
     : null;
@@ -425,9 +425,11 @@ class EditListingWizard extends Component {
       ? validListingTypes[0].transactionType.process
       : INQUIRY_PROCESS_NAME;
 
+    const hasListingTypeSelected = existingListingType || this.state.selectedListingType;
+
     // For oudated draft listing, we don't show other tabs but the "details"
     const tabs =
-      invalidExistingListingType && isNewListingFlow
+      isNewListingFlow && (invalidExistingListingType || !hasListingTypeSelected)
         ? TABS_DETAILS_ONLY
         : isBookingProcess(processName)
         ? TABS_BOOKING

--- a/src/util/search.js
+++ b/src/util/search.js
@@ -85,9 +85,11 @@ export const isOriginInUse = config =>
  */
 export const isStockInUse = config => {
   const listingTypes = config.listing.listingTypes;
-  const hasItems = !!listingTypes.find(conf => conf.transactionType.unitType === 'item');
+  const stockProcesses = ['default-purchase'];
+  const hasStockProcessesInUse = !!listingTypes.find(conf =>
+    stockProcesses.includes(conf.transactionType.process)
+  );
 
-  // TODO: if there are multiple processes with both products and bookings,
-  // sdk.listings.query needs more thinking on SearchPage. (bookings have stock=0)
-  return hasItems && listingTypes.length === 1;
+  // Note: these are active processes!
+  return hasStockProcessesInUse;
 };


### PR DESCRIPTION
Main changes:
- SearchPage: use minStock and stockMode for listing.queries if the "dates" filter is **not** in use.
- EditListingWizard: The _listing type selector_ is shown on the top of the _EditListingDetailsForm_ and only the "details" panel is visible until the listing type is selected.