### PR TITLE
Handle missing hosted conf to show maintenance mode page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] Handle missing hosted configurations to show Maintenance Mode page
+  [#223](https://github.com/sharetribe/web-template/pull/223)
 - [add] Add German translation as a reference (de.json) and update other lang files.
   [#222](https://github.com/sharetribe/web-template/pull/222)
 - [change] Update browserlist DB (i.e. caniuse-lite entry in yarn.lock file)

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -513,63 +513,67 @@ export const displayPrice = listingTypeConfig => {
 ///////////////////////////////////////
 
 const restructureListingTypes = hostedListingTypes => {
-  return hostedListingTypes?.map(listingType => {
-    const { id, label, transactionProcess, unitType, ...rest } = listingType;
-    return transactionProcess
-      ? {
-          listingType: id,
-          label,
-          transactionType: {
-            process: transactionProcess.name,
-            alias: transactionProcess.alias,
-            unitType,
-          },
-          ...rest,
-        }
-      : null;
-  }) || [];
+  return (
+    hostedListingTypes?.map(listingType => {
+      const { id, label, transactionProcess, unitType, ...rest } = listingType;
+      return transactionProcess
+        ? {
+            listingType: id,
+            label,
+            transactionType: {
+              process: transactionProcess.name,
+              alias: transactionProcess.alias,
+              unitType,
+            },
+            ...rest,
+          }
+        : null;
+    }) || []
+  );
 };
 
 const restructureListingFields = hostedListingFields => {
-  return hostedListingFields?.map(listingField => {
-    const {
-      key,
-      scope,
-      schemaType,
-      enumOptions,
-      label,
-      filterConfig = {},
-      showConfig = {},
-      saveConfig = {},
-      ...rest
-    } = listingField;
-    const defaultLabel = label || key;
-    const enumOptionsMaybe = ['enum', 'multi-enum'].includes(schemaType) ? { enumOptions } : {};
-    const { required: isRequired, ...restSaveConfig } = saveConfig;
+  return (
+    hostedListingFields?.map(listingField => {
+      const {
+        key,
+        scope,
+        schemaType,
+        enumOptions,
+        label,
+        filterConfig = {},
+        showConfig = {},
+        saveConfig = {},
+        ...rest
+      } = listingField;
+      const defaultLabel = label || key;
+      const enumOptionsMaybe = ['enum', 'multi-enum'].includes(schemaType) ? { enumOptions } : {};
+      const { required: isRequired, ...restSaveConfig } = saveConfig;
 
-    return key
-      ? {
-          key,
-          scope,
-          schemaType,
-          ...enumOptionsMaybe,
-          filterConfig: {
-            ...filterConfig,
-            label: filterConfig.label || defaultLabel,
-          },
-          showConfig: {
-            ...showConfig,
-            label: showConfig.label || defaultLabel,
-          },
-          saveConfig: {
-            ...restSaveConfig,
-            isRequired,
-            label: saveConfig.label || defaultLabel,
-          },
-          ...rest,
-        }
-      : null;
-  }) || [];
+      return key
+        ? {
+            key,
+            scope,
+            schemaType,
+            ...enumOptionsMaybe,
+            filterConfig: {
+              ...filterConfig,
+              label: filterConfig.label || defaultLabel,
+            },
+            showConfig: {
+              ...showConfig,
+              label: showConfig.label || defaultLabel,
+            },
+            saveConfig: {
+              ...restSaveConfig,
+              isRequired,
+              label: saveConfig.label || defaultLabel,
+            },
+            ...rest,
+          }
+        : null;
+    }) || []
+  );
 };
 
 ///////////////////////////

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -513,7 +513,7 @@ export const displayPrice = listingTypeConfig => {
 ///////////////////////////////////////
 
 const restructureListingTypes = hostedListingTypes => {
-  return hostedListingTypes.map(listingType => {
+  return hostedListingTypes?.map(listingType => {
     const { id, label, transactionProcess, unitType, ...rest } = listingType;
     return transactionProcess
       ? {
@@ -527,11 +527,11 @@ const restructureListingTypes = hostedListingTypes => {
           ...rest,
         }
       : null;
-  });
+  }) || [];
 };
 
 const restructureListingFields = hostedListingFields => {
-  return hostedListingFields.map(listingField => {
+  return hostedListingFields?.map(listingField => {
     const {
       key,
       scope,
@@ -569,7 +569,7 @@ const restructureListingFields = hostedListingFields => {
           ...rest,
         }
       : null;
-  });
+  }) || [];
 };
 
 ///////////////////////////


### PR DESCRIPTION
This change fixes the current situation where, in case of missing hosted configurations, Maintenance Mode page doesn't get shown because these two functions throw an error.