### PR TITLE
Add warning about react app variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [add] Show warning if environment variable key that starts with REACT_APP contains word "SECRET".
+  [#224](https://github.com/sharetribe/web-template/pull/224)
 - [change] SearchPage.duck.js: use minStock and stockMode for listing.queries if dates filter is not
   in use. [#217](https://github.com/sharetribe/web-template/pull/217)
 - [fix] Handle missing hosted configurations to show Maintenance Mode page

--- a/src/app.js
+++ b/src/app.js
@@ -170,9 +170,60 @@ const MaintenanceModeError = props => {
   );
 };
 
+// This displays a warning if environment variable key contains a string "SECRET"
+const EnvironmentVariableWarning = props => {
+  const suspiciousEnvKey = props.suspiciousEnvKey;
+  // https://github.com/sharetribe/flex-integration-api-examples#warning-usage-with-your-web-app--website
+  const containsINTEG = str => str.toUpperCase().includes('INTEG');
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '100vh',
+      }}
+    >
+      <div style={{ width: '600px' }}>
+        <p>
+          Are you sure you want to reveal to the public web an environment variable called:{' '}
+          <b>{suspiciousEnvKey}</b>
+        </p>
+        <p>
+          All the environment variables that start with <i>REACT_APP_</i> prefix will be part of the
+          published React app that's running on a browser. Those variables are, therefore, visible
+          to anyone on the web. Secrets should only be used on a secure environment like the server.
+        </p>
+        {containsINTEG(suspiciousEnvKey) ? (
+          <p>
+            {'Note: '}
+            <span style={{ color: 'red' }}>
+              Do not use Integration API directly from the web app.
+            </span>
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+};
+
 export const ClientApp = props => {
   const { store, hostedTranslations = {}, hostedConfig = {} } = props;
   const appConfig = mergeConfig(hostedConfig, defaultConfig);
+
+  // Show warning on the localhost:3000, if the environment variable key contains "SECRET"
+  if (appSettings.dev) {
+    const envVars = process.env || {};
+    const envVarKeys = Object.keys(envVars);
+    const containsSECRET = str => str.toUpperCase().includes('SECRET');
+    const suspiciousSECRETKey = envVarKeys.find(
+      key => key.startsWith('REACT_APP_') && containsSECRET(key)
+    );
+
+    if (suspiciousSECRETKey) {
+      return <EnvironmentVariableWarning suspiciousEnvKey={suspiciousSECRETKey} />;
+    }
+  }
 
   // Show MaintenanceMode if the mandatory configurations are not available
   if (!appConfig.hasMandatoryConfigurations) {


### PR DESCRIPTION
On localhost:3000 (aka `yarn run dev`), we show a warning if bundled environment variables contain "secret"
![Screenshot 2023-09-19 at 18 13 05](https://github.com/sharetribe/web-template/assets/717315/3670bac8-6f49-4cb4-8722-726886f95e02)

Note: We don't want to print this message or log those variables on production - as that would just give tips for malicious users.