### PR TITLE
WiP: Add more http methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [add] util/api.js: Added rudimentary support for other HTTP Methods. There's a new 'request'
+  function, which is easier to extend. [#229](https://github.com/sharetribe/web-template/pull/229)
+
 ## [v3.1.0] 2023-09-21
 
 - [fix] Add 2 missing error translations to en.json file.

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -48,7 +48,7 @@ const methods = {
   DELETE: 'DELETE',
 };
 
-const request = (path, method, body) => {
+const request = (path, method, body = {}) => {
   const url = `${apiBaseUrl()}${path}`;
   const options = {
     method,

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -40,10 +40,18 @@ const deserialize = str => {
   return transit.read(str, { typeHandlers });
 };
 
-const post = (path, body) => {
+const methods = {
+  POST: 'POST',
+  GET: 'GET',
+  PUT: 'PUT',
+  PATCH: 'PATCH',
+  DELETE: 'DELETE',
+};
+
+const request = (path, method, body) => {
   const url = `${apiBaseUrl()}${path}`;
   const options = {
-    method: 'POST',
+    method,
     credentials: 'include',
     headers: {
       'Content-Type': 'application/transit+json',
@@ -76,7 +84,7 @@ const post = (path, body) => {
 // See `server/api/transaction-line-items.js` to see what data should
 // be sent in the body.
 export const transactionLineItems = body => {
-  return post('/api/transaction-line-items', body);
+  return request('/api/transaction-line-items', methods.POST, body);
 };
 
 // Initiate a privileged transaction.
@@ -88,7 +96,7 @@ export const transactionLineItems = body => {
 // See `server/api/initiate-privileged.js` to see what data should be
 // sent in the body.
 export const initiatePrivileged = body => {
-  return post('/api/initiate-privileged', body);
+  return request('/api/initiate-privileged', methods.POST, body);
 };
 
 // Transition a transaction with a privileged transition.
@@ -100,7 +108,7 @@ export const initiatePrivileged = body => {
 // See `server/api/transition-privileged.js` to see what data should
 // be sent in the body.
 export const transitionPrivileged = body => {
-  return post('/api/transition-privileged', body);
+  return request('/api/transition-privileged', methods.POST, body);
 };
 
 // Create user with identity provider (e.g. Facebook or Google)
@@ -113,5 +121,5 @@ export const transitionPrivileged = body => {
 // See `server/api/auth/createUserWithIdp.js` to see what data should
 // be sent in the body.
 export const createUserWithIdp = body => {
-  return post('/api/auth/create-user-with-idp', body);
+  return request('/api/auth/create-user-with-idp', methods.POST, body);
 };


### PR DESCRIPTION
This modifies the functionality that was suggested in an incoming PR: https://github.com/sharetribe/web-template/pull/226

This keeps the **post** function, but moves most of its code to a new function called **request**. This way existing post calls won't break or cause problems when taking updates from upstream.