### PR TITLE
New release: v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,16 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+## [v3.1.1] 2023-09-22
+
 - [fix] Single listing type caused problem on the EditListingWizard.
   [#231](https://github.com/sharetribe/web-template/pull/231)
 - [fix] ManageListingCard: fix wrong (non-existent) classname.
   [#230](https://github.com/sharetribe/web-template/pull/230)
 - [add] util/api.js: Added rudimentary support for other HTTP Methods. There's a new 'request'
   function, which is easier to extend. [#229](https://github.com/sharetribe/web-template/pull/229)
+
+[v3.1.1]: https://github.com/sharetribe/web-template/compare/v3.1.0...v3.1.1
 
 ## [v3.1.0] 2023-09-21
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## [v3.1.1] 2023-09-22

There was a bug when only one listing type is used

- [fix] Single listing type caused a problem on the EditListingWizard.
  [#231](https://github.com/sharetribe/web-template/pull/231)
- [fix] ManageListingCard: fix wrong (non-existent) classname.
  [#230](https://github.com/sharetribe/web-template/pull/230)
- [add] util/api.js: Added rudimentary support for other HTTP Methods. There's a new 'request'
  function, which is easier to extend. [#229](https://github.com/sharetribe/web-template/pull/229)

[v3.1.1]: https://github.com/sharetribe/web-template/compare/v3.1.0...v3.1.1