### PR TITLE
Change phone number formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [change] FieldPhoneNumberInput: change formatter from fi locale to only format E.164. This does
+  not change input strings that don't start with a '+'.
+  [#233](https://github.com/sharetribe/web-template/pull/233)
+
 ## [v3.1.1] 2023-09-22
 
 - [fix] Single listing type caused problem on the EditListingWizard.

--- a/src/components/FieldPhoneNumberInput/FieldPhoneNumberInput.js
+++ b/src/components/FieldPhoneNumberInput/FieldPhoneNumberInput.js
@@ -7,7 +7,9 @@
 import React from 'react';
 
 import { FieldTextInput } from '../../components';
-import { format, parse } from './fiFormatter';
+// This formatter formats phone numbers that start with leading '+' sign,
+// but for other inputs it just strips space characters off.
+import { format, parse } from './e164Formatter';
 
 const FieldPhoneNumberInput = props => {
   const inputProps = {

--- a/src/components/FieldPhoneNumberInput/e164Formatter.js
+++ b/src/components/FieldPhoneNumberInput/e164Formatter.js
@@ -1,0 +1,65 @@
+// Add format and parse functions. This file follows E.164 format for international numbers
+// if the input starts with '+'.
+// Note: this does not format phone numbers that don't start with '+'
+//
+// If you want to have a localized phone number formatting, you could create own format and parse functions.
+// Check this Final Form example: https://codesandbox.io/s/10rzowm323
+
+/**
+ * Check if string starts with '+' character.
+ * @param {String} str
+ * @returns true if string starts with '+' character.
+ */
+const hasLeadingPlus = str => str.match(/^\+/g);
+
+/**
+ * Pick only digits from a string
+ * @param {String} str
+ * @returns string that contains only numbers
+ */
+const pickOnlyDigits = str => str.replace(/[^\d]/g, '');
+
+/**
+ * This picks only correct characters for e.164 formatted phone numbers if the phoneNumber starts with a '+' character.
+ * Otherwise, the phone number is left as it is.
+ *
+ * @param {String} phoneNumber
+ * @returns formatted E.164 phone number or a string that has not been formatted at all.
+ */
+const pickValidCharsForE164 = phoneNumber => {
+  const number = phoneNumber || '';
+  const startsWithPlus = !!hasLeadingPlus(number);
+  const digitsOnly = pickOnlyDigits(number);
+  // Digits must start with 1-9 and there can't be more than 15 digits altogether in E.164
+  const noLeadingZeroDigits =
+    digitsOnly.length > 0 && digitsOnly.charAt(0) === '0' ? digitsOnly.slice(1) : digitsOnly;
+
+  return startsWithPlus && noLeadingZeroDigits.length > 15
+    ? `+${noLeadingZeroDigits.slice(0, 15)}`
+    : startsWithPlus
+    ? `+${noLeadingZeroDigits}`
+    : number;
+};
+
+/**
+ * Format a phone number according to E.164 format.
+ * This formats the value that form has. This is executed first if there are initial values given to the form.
+ *
+ * Matches with the following format:
+ * +123 55 1234567, which is formatted as +123551234567
+ */
+export const format = value => {
+  if (!value) {
+    return '';
+  }
+
+  return pickValidCharsForE164(value);
+};
+
+/**
+ * Parser that handles the input string so that the plain number can be saved.
+ * This is executed, when user manually types or copy-pastes a phone number to the input field.
+ */
+export const parse = value => {
+  return pickValidCharsForE164(value);
+};

--- a/src/components/FieldPhoneNumberInput/fiFormatter.js
+++ b/src/components/FieldPhoneNumberInput/fiFormatter.js
@@ -1,3 +1,5 @@
+// NOTE: Template does not use this anymore. We might remove the file at some point in the future.
+
 /**
  * Slice a local number that is in the form
  * of 555 01234567


### PR DESCRIPTION
**FieldPhoneNumberInput**:

- Removes fiFormatter.js from active use
- Adds _e164Formatter.js_
  - This only formats a phone number if it starts with '+' character
  - For international phone numbers (following E.164 format)