### PR TITLE
Fix: macOS Sonoma seems to have issues with time zone handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] mac OS Sonoma seems to have issues with time zone handling.
+  [#235](https://github.com/sharetribe/web-template/pull/235)
 - [add] Update translation assets for French, Spanish, and Germany.
   [#236](https://github.com/sharetribe/web-template/pull/236)
 - [change] remove caret from react-image-gallery dependency.

--- a/src/components/OrderPanel/BookingTimeForm/FieldDateAndTimeInput.js
+++ b/src/components/OrderPanel/BookingTimeForm/FieldDateAndTimeInput.js
@@ -458,7 +458,13 @@ class FieldDateAndTimeInput extends Component {
       : () => false;
 
     const nextBoundary = findNextBoundary(TODAY, 'hour', timeZone);
-    const placeholderTime = formatDateIntoPartials(nextBoundary, intl, { timeZone })?.time;
+    let placeholderTime = '08:00';
+    try {
+      placeholderTime = formatDateIntoPartials(nextBoundary, intl, { timeZone })?.time;
+    } catch (error) {
+      // No need to handle error
+    }
+
     const startOfToday = getStartOf(TODAY, 'day', timeZone);
     const bookingEndTimeAvailable = bookingStartDate && (bookingStartTime || startTime);
     return (

--- a/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/EditListingAvailabilityExceptionForm/ExceptionDateTimeRange.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/EditListingAvailabilityExceptionForm/ExceptionDateTimeRange.js
@@ -353,7 +353,13 @@ const ExceptionDateTimeRange = props => {
   const endDateDisabled = !exceptionStartDate || !exceptionStartTime;
   const endTimeDisabled = !exceptionStartDate || !exceptionStartTime || !exceptionEndDate;
   const nextBoundary = findNextBoundary(TODAY, 'hour', timeZone);
-  const placeholderTime = formatDateIntoPartials(nextBoundary, intl, { timeZone })?.time;
+  let placeholderTime = '08:00';
+  try {
+    placeholderTime = formatDateIntoPartials(nextBoundary, intl, { timeZone })?.time;
+  } catch (error) {
+    // No need to handle error
+  }
+
   const startOfToday = getStartOf(TODAY, 'day', timeZone);
 
   return (

--- a/src/util/dates.js
+++ b/src/util/dates.js
@@ -20,6 +20,17 @@ export const isTimeZoneSupported = () => {
   if (typeof dtf === 'undefined' || typeof dtf.resolvedOptions === 'undefined') {
     return false;
   }
+
+  // TODO: Chrome and Firefox seem to have issues on macOS Sonoma, when populating timeZone on Intl API
+  // https://bugs.chromium.org/p/chromium/issues/detail?id=1487920
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1856428
+  // Note: we might remove this, when the bugs have been resolved on those browsers
+  if (!dtf.resolvedOptions().timeZone && isValidTimeZone('Europe/Helsinki')) {
+    console.error(`Time zone was undefined (new Intl.DateTimeFormat().resolvedOptions().timeZone).
+    This might cause problems for date and duration calculation on this browser.`);
+    return true;
+  }
+
   return !!dtf.resolvedOptions().timeZone;
 };
 


### PR DESCRIPTION
Chrome and Firefox seem to have issues on macOS Sonoma (v14), when populating timeZone on Intl API
- https://bugs.chromium.org/p/chromium/issues/detail?id=1487920
- https://bugzilla.mozilla.org/show_bug.cgi?id=1856428

The bigger problem remaining is the question of whether the Date object is created correctly if the time zone is wrong or undefined.
