### PR TITLE
new release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+## [v3.2.0] 2023-10-04
+
 - [fix] mac OS Sonoma seems to have issues with time zone handling.
   [#235](https://github.com/sharetribe/web-template/pull/235)
 - [add] Update translation assets for French, Spanish, and Germany.
@@ -29,6 +31,8 @@ way to update this template, but currently, we follow a pattern:
 - [change] FieldPhoneNumberInput: change formatter from fi locale to only format E.164. This does
   not change input strings that don't start with a '+'.
   [#233](https://github.com/sharetribe/web-template/pull/233)
+
+  [v3.2.0]: https://github.com/sharetribe/web-template/compare/v3.1.1...v3.2.0
 
 ## [v3.1.1] 2023-09-22
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## [v3.2.0] 2023-10-04

- [fix] mac OS Sonoma seems to have issues with time zone handling.
  [#235](https://github.com/sharetribe/web-template/pull/235)
- [add] Update translation assets for French, Spanish, and Germany.
  [#236](https://github.com/sharetribe/web-template/pull/236)
- [change] remove caret from react-image-gallery dependency.
  [#234](https://github.com/sharetribe/web-template/pull/234)
- [add] Plausible analytics integration. This can be used through environment variable:
  REACT_APP_PLAUSIBLE_DOMAINS [#228](https://github.com/sharetribe/web-template/pull/228)
- [add] Prepare for appIcon property to come from branding asset. This generates site.webmanifest
  file and apple-touch-icon link. [#215](https://github.com/sharetribe/web-template/pull/215)
- [add] Prepare for configurable Logo variants. Console will support height variants of 24, 36, and
  48 pixels. [#214](https://github.com/sharetribe/web-template/pull/214)
- [change] FieldPhoneNumberInput: change formatter from fi locale to only format E.164. This does
  not change input strings that don't start with a '+'.
  [#233](https://github.com/sharetribe/web-template/pull/233)

  [v3.2.0]: https://github.com/sharetribe/web-template/compare/v3.1.1...v3.2.0
