### PR TITLE
Fix error handling for webmanifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] webmanifest error should use log and return 500 if rendering is not possible.
+  [#238](https://github.com/sharetribe/web-template/pull/238)
+
 ## [v3.2.0] 2023-10-04
 
 - [fix] mac OS Sonoma seems to have issues with time zone handling.

--- a/server/resources/webmanifest.js
+++ b/server/resources/webmanifest.js
@@ -1,6 +1,10 @@
+const log = require('../log');
 const sdkUtils = require('../api-util/sdk');
 
 const rootUrl = process.env.REACT_APP_MARKETPLACE_ROOT_URL;
+
+// NOTE: This assumes that branding asset is created.
+//       If it's not, then the webmanifest returns dummy data.
 
 // Generate icons with correct syntax for web app manifest
 const generateIcons = variants => {
@@ -70,6 +74,24 @@ module.exports = (req, res) => {
       res.send(json);
     })
     .catch(e => {
-      handleError(res, e);
+      // Log error
+      log.error(e, 'webmanifest-render-failed');
+
+      // Return some generic data as app manifest
+      const defaultJsonData = {
+        name: 'Marketplace',
+        short_name: 'Marketplace',
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#ffffff',
+        icons: [],
+      };
+
+      // Format as JSON string (with indentation of 2 spaces)
+      const json = JSON.stringify(defaultJsonData, null, 2);
+
+      // Set the content type for web app manifest
+      res.setHeader('Content-Type', 'application/manifest+json');
+      res.send(json);
     });
 };


### PR DESCRIPTION
If webmanifest can't get data for the successful rendering, return some dummy data.