### PR TITLE
configHelpers.js: remove trailing slash from marketplaceRootURL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
-- [fix] webmanifest error should use log and return 500 if rendering is not possible.
+- [change] configHelpers.js: remove trailing slash from marketplaceRootURL
+  [#239](https://github.com/sharetribe/web-template/pull/239)
+- [fix] webmanifest error should use log and not return 500 if rendering dynamic data fails.
   [#238](https://github.com/sharetribe/web-template/pull/238)
 
 ## [v3.2.0] 2023-10-04

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -803,6 +803,11 @@ const hasMandatoryConfigs = hostedConfig => {
 };
 
 export const mergeConfig = (configAsset = {}, defaultConfigs = {}) => {
+  // Remove trailing slash from marketplaceRootURL if any
+  const marketplaceRootURL = defaultConfigs.marketplaceRootURL;
+  const cleanedRootURL =
+    typeof marketplaceRootURL === 'string' ? marketplaceRootURL.replace(/\/$/, '') : '';
+
   // defaultConfigs.listingMinimumPriceSubUnits is the backup for listing's minimum price
   const listingMinimumPriceSubUnits =
     getListingMinimumPrice(configAsset.transactionSize) ||
@@ -811,6 +816,8 @@ export const mergeConfig = (configAsset = {}, defaultConfigs = {}) => {
   return {
     // Use default configs as a starting point for app config.
     ...defaultConfigs,
+
+    marketplaceRootURL: cleanedRootURL,
 
     // Overwrite default configs if hosted config is available
     listingMinimumPriceSubUnits,


### PR DESCRIPTION
It seems too common to accidentally add trailing slash to REACT_APP_MARKETPLACE_ROOT_URL env var.
Since we now have a point (configHelpers.js), where configs can be cleaned, it's good to remove possible trailing slash there.