### PR TITLE
Fix: continuation of "add missing subunit divisors"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] Prev PR (#241) changed the structure of config.stripe unintentionally.
+  [#242](https://github.com/sharetribe/web-template/pull/242)
 - [fix] Ensure that stripe currencies have valid subunit divisors and add subunit divisors for BGN,
   CZK, PLN, RON. [#241](https://github.com/sharetribe/web-template/pull/241)
 - [change] configHelpers.js: remove trailing slash from marketplaceRootURL

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -65,7 +65,7 @@ const mergeCurrency = (hostedCurrency, defaultCurrency) => {
 const validateStripeCurrency = stripe => {
   const supportedCountries = stripe.supportedCountries || [];
   const supportedCurrencies = Object.keys(subUnitDivisors);
-  return supportedCountries.filter(country => {
+  const validSupportedCountries = supportedCountries.filter(country => {
     const isSupported = supportedCurrencies.includes(country.currency);
 
     if (!isSupported) {
@@ -77,6 +77,7 @@ const validateStripeCurrency = stripe => {
 
     return isSupported;
   });
+  return { ...stripe, supportedCountries: validSupportedCountries };
 };
 
 const mergeLocalizations = (hostedLocalization, defaultLocalization) => {


### PR DESCRIPTION
Prev PR (#241) changed the structure of config.stripe unintentionally.