### PR TITLE
Fix wrong pending state name at checkout page

### DIFF
--- a/src/containers/CheckoutPage/CheckoutPageTransactionHelpers.js
+++ b/src/containers/CheckoutPage/CheckoutPageTransactionHelpers.js
@@ -133,7 +133,7 @@ export const hasDefaultPaymentMethod = (stripeCustomerFetched, currentUser) =>
   );
 
 /**
- * Check if payment is expired (PAYMENT_EXPIRED state) or if payment has passed 15 minute treshold from PAYMENT_PENDING
+ * Check if payment is expired (PAYMENT_EXPIRED state) or if payment has passed 15 minute treshold from PENDING_PAYMENT
  *
  * @param {Object} existingTransaction
  * @param {Object} process
@@ -143,7 +143,7 @@ export const hasPaymentExpired = (existingTransaction, process) => {
   const state = process.getState(existingTransaction);
   return state === process.states.PAYMENT_EXPIRED
     ? true
-    : state === process.states.PAYMENT_PENDING
+    : state === process.states.PENDING_PAYMENT
     ? minutesBetween(existingTransaction.attributes.lastTransitionedAt, new Date()) >= 15
     : false;
 };

--- a/src/containers/CheckoutPage/CheckoutPageWithPayment.js
+++ b/src/containers/CheckoutPage/CheckoutPageWithPayment.js
@@ -280,7 +280,7 @@ const onStripeInitialized = (stripe, process, props) => {
     stripe &&
     !paymentIntent &&
     tx?.id &&
-    process?.getState(tx) === process?.states.PAYMENT_PENDING &&
+    process?.getState(tx) === process?.states.PENDING_PAYMENT &&
     !hasPaymentExpired(tx, process);
 
   if (shouldFetchPaymentIntent) {


### PR DESCRIPTION
`PAYMENT_PENDING` is a no-existing state so `shouldFetchPaymentIntent` is always `false` and `onRetrievePaymentIntent` is never called.