### PR TITLE
Include more assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [add] Add more config assets: analytics, googleSearchConsole, maps, localization.
+  [#252](https://github.com/sharetribe/web-template/pull/252)
 - [add] SectionHero component added to the PageBuilder.
   [#244](https://github.com/sharetribe/web-template/pull/244)
 - [fix] Map integration is mandatory, but let's not allow error loops if not available.

--- a/src/config/configDefault.js
+++ b/src/config/configDefault.js
@@ -72,8 +72,9 @@ const defaultConfig = {
   },
 
   // CDN assets for the app. Configurable through Flex Console.
-  // Currently, only translation.json is available.
-  // Note: the path must match the path defined in Asset Delivery API
+  // Note 1: The path must match the path defined in Asset Delivery API
+  // Note 2: If you customize the app and rely on custom code instead of a config assets,
+  //         you should remove the unnecessary config asset from this list.
   appCdnAssets: {
     translations: '/content/translations.json',
     footer: '/content/footer.json',
@@ -83,14 +84,14 @@ const defaultConfig = {
     listingFields: '/listings/listing-fields.json',
     search: '/listings/listing-search.json',
     transactionSize: '/transactions/minimum-transaction-size.json',
+    analytics: '/integrations/analytics.json',
+    googleSearchConsole: '/integrations/google-search-console.json',
+    // These assets are not yet editable through Console.
+    // However, Sharetribe onboarding might generate them.
+    // You could still rely on environment variables and comment these out.
+    maps: '/integrations/map.json',
+    localization: '/general/localization.json',
     // NOTE: we don't fetch commission configuration here but on the server-side
-
-    // TODO: Map provider configuration and analytics service should come from the assets too.
-    //       It might take some time before these are actually available through hosted assets.
-    // maps: '/integrations/map.json',
-    // analytics: '/integrations/analytics.json',
-    // googleSearchConsole: '/integrations/google-search-console.json',
-    // localization: '/general/localization.json',
   },
 
   // Optional


### PR DESCRIPTION
This includes these config assets:
  - analytics: '/integrations/analytics.json',
  - googleSearchConsole: '/integrations/google-search-console.json',
  - maps: '/integrations/map.json',
  - localization: '/general/localization.json',

Note that these are not yet available through Console and if you have these set from environment variables (and you are fine with that setup), could still rely on environment variables and comment these out.

In addition, we use configDefault as a backup for this information if the hosted asset is empty.  (Check configHelpers.js) 
**_This might change in the future as a fallback value doesn't really work with everything._** 
You should plan at least how you want to handle currency (especially, when it becomes editable through Console).