### PR TITLE
Relax section id block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [change] PageBuilder: make sectionId and blockId optional.
+  [#254](https://github.com/sharetribe/web-template/pull/254)
 - [fix] PaginationLinks: fix pagination limit handling.
   [#253](https://github.com/sharetribe/web-template/pull/253)
 - [add] Add more config assets: analytics, googleSearchConsole, maps, localization.

--- a/src/containers/PageBuilder/BlockBuilder/BlockBuilder.js
+++ b/src/containers/PageBuilder/BlockBuilder/BlockBuilder.js
@@ -21,7 +21,7 @@ const defaultBlockComponents = {
 ////////////////////
 
 const BlockBuilder = props => {
-  const { blocks, options, ...otherProps } = props;
+  const { blocks, sectionId, options, ...otherProps } = props;
 
   // Extract block & field component mappings from props
   // If external mapping has been included for fields
@@ -40,14 +40,24 @@ const BlockBuilder = props => {
 
   return (
     <>
-      {blocks.map(block => {
+      {blocks.map((block, index) => {
         const config = components[block.blockType];
         const Block = config?.component;
+        const blockId = block.blockId || `${sectionId}-block-${index + 1}`;
+
         if (Block) {
-          return <Block key={block.blockId} {...block} {...blockOptionsMaybe} {...otherProps} />;
+          return (
+            <Block
+              key={`${blockId}_i${index}`}
+              {...block}
+              blockId={blockId}
+              {...blockOptionsMaybe}
+              {...otherProps}
+            />
+          );
         } else {
           // If the block type is unknown, the app can't know what to render
-          console.warn(`Unknown block type (${block.blockType}) detected.`);
+          console.warn(`Unknown block type (${block.blockType}) detected inside (${sectionId}).`);
           return null;
         }
       })}
@@ -56,7 +66,8 @@ const BlockBuilder = props => {
 };
 
 const propTypeBlock = shape({
-  blockId: string.isRequired,
+  blockId: string,
+  blockName: string,
   blockType: oneOf(['defaultBlock', 'footerBlock', 'socialMediaLink']).isRequired,
   // Plus all kind of unknown fields.
   // BlockBuilder doesn't really need to care about those

--- a/src/containers/PageBuilder/PageBuilder.js
+++ b/src/containers/PageBuilder/PageBuilder.js
@@ -123,7 +123,9 @@ const PageBuilder = props => {
                   <SectionBuilder sections={sections} options={options} />
                 )}
               </Main>
-              <FooterContainer />
+              <Footer>
+                <FooterContainer />
+              </Footer>
             </>
           );
         }}

--- a/src/containers/PageBuilder/SectionBuilder/SectionArticle/SectionArticle.js
+++ b/src/containers/PageBuilder/SectionBuilder/SectionArticle/SectionArticle.js
@@ -56,6 +56,7 @@ const SectionArticle = props => {
         >
           <BlockBuilder
             blocks={blocks}
+            sectionId={sectionId}
             ctaButtonClass={defaultClasses.ctaButton}
             options={options}
           />

--- a/src/containers/PageBuilder/SectionBuilder/SectionBuilder.js
+++ b/src/containers/PageBuilder/SectionBuilder/SectionBuilder.js
@@ -61,6 +61,23 @@ const SectionBuilder = props => {
     return config?.component;
   };
 
+  // Generate unique ids for sections if operator has managed to create duplicates
+  // E.g. "foobar", "foobar1", and "foobar2"
+  const sectionIds = [];
+  const getUniqueSectionId = (sectionId, index) => {
+    const candidate = sectionId || `section-${index + 1}`;
+    if (sectionIds.includes(candidate)) {
+      let sequentialCandidate = `${candidate}1`;
+      for (let i = 2; sectionIds.includes(sequentialCandidate); i++) {
+        sequentialCandidate = `${candidate}${i}`;
+      }
+      return getUniqueSectionId(sequentialCandidate, index);
+    } else {
+      sectionIds.push(candidate);
+      return candidate;
+    }
+  };
+
   return (
     <>
       {sections.map((section, index) => {
@@ -71,21 +88,25 @@ const SectionBuilder = props => {
           section?.appearance?.fieldType === 'customAppearance' &&
           section?.appearance?.textColor === 'white';
         const classes = classNames({ [css.darkTheme]: isDarkTheme });
+        const sectionId = getUniqueSectionId(section.sectionId, index);
 
         if (Section) {
           return (
             <Section
-              key={`${section.sectionId}_${index}`}
+              key={`${sectionId}_i${index}`}
               className={classes}
               defaultClasses={DEFAULT_CLASSES}
               isInsideContainer={isInsideContainer}
               options={otherOption}
               {...section}
+              sectionId={sectionId}
             />
           );
         } else {
           // If the section type is unknown, the app can't know what to render
-          console.warn(`Unknown section type (${section.sectionType}) detected.`);
+          console.warn(
+            `Unknown section type (${section.sectionType}) detected using sectionName (${section.sectionName}).`
+          );
           return null;
         }
       })}
@@ -94,7 +115,8 @@ const SectionBuilder = props => {
 };
 
 const propTypeSection = shape({
-  sectionId: string.isRequired,
+  sectionId: string,
+  sectionName: string,
   sectionType: oneOf(['article', 'carousel', 'columns', 'features', 'hero']).isRequired,
   // Plus all kind of unknown fields.
   // BlockBuilder doesn't really need to care about those

--- a/src/containers/PageBuilder/SectionBuilder/SectionCarousel/SectionCarousel.js
+++ b/src/containers/PageBuilder/SectionBuilder/SectionCarousel/SectionCarousel.js
@@ -137,6 +137,7 @@ const SectionCarousel = props => {
               rootClassName={css.block}
               ctaButtonClass={defaultClasses.ctaButton}
               blocks={blocks}
+              sectionId={sectionId}
               responsiveImageSizes={getResponsiveImageSizes(numColumns)}
               options={options}
             />

--- a/src/containers/PageBuilder/SectionBuilder/SectionColumns/SectionColumns.js
+++ b/src/containers/PageBuilder/SectionBuilder/SectionColumns/SectionColumns.js
@@ -74,6 +74,7 @@ const SectionColumns = props => {
           <BlockBuilder
             ctaButtonClass={defaultClasses.ctaButton}
             blocks={blocks}
+            sectionId={sectionId}
             responsiveImageSizes={getResponsiveImageSizes(numColumns)}
             options={options}
           />

--- a/src/containers/PageBuilder/SectionBuilder/SectionFeatures/SectionFeatures.js
+++ b/src/containers/PageBuilder/SectionBuilder/SectionFeatures/SectionFeatures.js
@@ -62,6 +62,7 @@ const SectionFeatures = props => {
             rootClassName={css.block}
             ctaButtonClass={defaultClasses.ctaButton}
             blocks={blocks}
+            sectionId={sectionId}
             responsiveImageSizes="(max-width: 767px) 100vw, 568px"
             options={options}
           />

--- a/src/containers/PageBuilder/SectionBuilder/SectionFooter/SectionFooter.js
+++ b/src/containers/PageBuilder/SectionBuilder/SectionFooter/SectionFooter.js
@@ -87,13 +87,13 @@ const SectionFooter = props => {
             </div>
             {showSocialMediaLinks ? (
               <div className={css.icons}>
-                <BlockBuilder blocks={linksWithBlockId} options={options} />
+                <BlockBuilder blocks={linksWithBlockId} sectionId={sectionId} options={options} />
               </div>
             ) : null}
             <Field data={copyright} className={css.copyright} />
           </div>
           <div className={classNames(css.grid, getGridCss(numberOfColumns))}>
-            <BlockBuilder blocks={blocks} options={options} />
+            <BlockBuilder blocks={blocks} sectionId={sectionId} options={options} />
           </div>
         </div>
       </div>


### PR DESCRIPTION
PageBuilder: make sectionId and blockId optional.
This also generates unique ids for sections if a content writer has managed to create duplicates
E.g. "foobar", "foobar1", and "foobar2"

In addition, move FooterContainer inside footer area created by LayoutComposer