### PR TITLE
Fix keywords filter key clash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [fix] they keys of built-in filters could have clashed with listing field keys.
+  [#260](https://github.com/sharetribe/web-template/pull/260)
 - [fix] Use the correct translation asset in email templates.
   [#259](https://github.com/sharetribe/web-template/pull/259)
 - [fix] When stockType is oneItem: don't show shipping fee for additional items.

--- a/src/config/configSearch.js
+++ b/src/config/configSearch.js
@@ -39,10 +39,9 @@ export const priceFilter = {
   step: 5,
 };
 // // This is not in use by default.
-// // Needs more thinking how it should work together with main search.
 // export const keywordsFilter = {
 //   key: 'keywords',
-//   schemaType: 'text',
+//   schemaType: 'keywords',
 // }
 
 export const sortConfig = {

--- a/src/containers/SearchPage/FilterComponent.js
+++ b/src/containers/SearchPage/FilterComponent.js
@@ -39,7 +39,7 @@ const FilterComponent = props => {
   const name = key.replace(/\s+/g, '-').toLowerCase();
 
   // Default filters: price, keywords, dates
-  switch (key) {
+  switch (schemaType) {
     case 'price': {
       const { min, max, step } = config;
       return (

--- a/src/containers/SearchPage/SearchPageWithGrid.js
+++ b/src/containers/SearchPage/SearchPageWithGrid.js
@@ -308,7 +308,7 @@ export class SearchPageComponent extends Component {
               {availableFilters.map(config => {
                 return (
                   <FilterComponent
-                    key={`SearchFiltersMobile.${config.key}`}
+                    key={`SearchFiltersMobile.${config.scope || 'built-in'}.${config.key}`}
                     idPrefix="SearchFiltersMobile"
                     className={css.filter}
                     config={config}
@@ -351,7 +351,7 @@ export class SearchPageComponent extends Component {
                 {availableFilters.map(config => {
                   return (
                     <FilterComponent
-                      key={`SearchFiltersMobile.${config.key}`}
+                      key={`SearchFiltersMobile.${config.scope || 'built-in'}.${config.key}`}
                       idPrefix="SearchFiltersMobile"
                       config={config}
                       marketplaceCurrency={marketplaceCurrency}

--- a/src/containers/SearchPage/SearchPageWithMap.js
+++ b/src/containers/SearchPage/SearchPageWithMap.js
@@ -420,7 +420,7 @@ export class SearchPageComponent extends Component {
               {availableFilters.map(config => {
                 return (
                   <FilterComponent
-                    key={`SearchFiltersMobile.${config.key}`}
+                    key={`SearchFiltersMobile.${config.scope || 'built-in'}.${config.key}`}
                     idPrefix="SearchFiltersMobile"
                     config={config}
                     marketplaceCurrency={marketplaceCurrency}
@@ -448,7 +448,7 @@ export class SearchPageComponent extends Component {
                 {availablePrimaryFilters.map(config => {
                   return (
                     <FilterComponent
-                      key={`SearchFiltersPrimary.${config.key}`}
+                      key={`SearchFiltersPrimary.${config.scope || 'built-in'}.${config.key}`}
                       idPrefix="SearchFiltersPrimary"
                       config={config}
                       marketplaceCurrency={marketplaceCurrency}
@@ -476,7 +476,7 @@ export class SearchPageComponent extends Component {
                   {customSecondaryFilters.map(config => {
                     return (
                       <FilterComponent
-                        key={`SearchFiltersSecondary.${config.key}`}
+                        key={`SearchFiltersSecondary.${config.scope || 'built-in'}.${config.key}`}
                         idPrefix="SearchFiltersSecondary"
                         config={config}
                         marketplaceCurrency={marketplaceCurrency}

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -723,6 +723,16 @@ const validPriceConfig = config => {
   return isMaxBigger ? { key: 'price', schemaType: 'price', label, min, max, step } : null;
 };
 
+const validKeywordsConfig = config => {
+  const { enabled = true } = config;
+
+  if (!enabled) {
+    return null;
+  }
+
+  return { key: 'keywords', schemaType: 'keywords' };
+};
+
 const validDefaultFilters = defaultFilters => {
   return defaultFilters
     .map(data => {
@@ -731,6 +741,8 @@ const validDefaultFilters = defaultFilters => {
         ? validDatesConfig(data)
         : schemaType === 'price'
         ? validPriceConfig(data)
+        : schemaType === 'keywords'
+        ? validKeywordsConfig(data)
         : data;
     })
     .filter(Boolean);
@@ -769,7 +781,7 @@ const mergeSearchConfig = (hostedSearchConfig, defaultSearchConfig) => {
 
   const keywordsFilterMaybe =
     keywordsFilter?.enabled === true
-      ? [{ key: 'keywords', schemaType: 'text' }]
+      ? [{ key: 'keywords', schemaType: 'keywords' }]
       : defaultSearchConfig.keywordsFilter
       ? [defaultSearchConfig.keywordsFilter]
       : [];


### PR DESCRIPTION
It's possible that the listing field with the "keywords" key clashes with the actual keywords filter. This changes the setup to always rely on schemaType. (The other option would have been to refactor everything to rely on a scoped key, but that would have meant more changes.)