### PR TITLE
Remove hyphens auto from heading???

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [change] PageBuilder - Headings: hyphens:auto CSS rule is too eager to hyphanate and it doesn't
+  try to fit long words into an empty next line before splitting.
+  [#270](https://github.com/sharetribe/web-template/pull/270)
 - [add] Update translation assets for French.
   [#269](https://github.com/sharetribe/web-template/pull/269)
 - [add] Limit listing fields to specific listing types through Console.

--- a/src/containers/PageBuilder/Primitives/Heading/Heading.module.css
+++ b/src/containers/PageBuilder/Primitives/Heading/Heading.module.css
@@ -17,7 +17,6 @@
   word-break: break-all;
   /* use break-word if available */
   word-break: break-word;
-  hyphens: auto;
 }
 
 /* Specific styles */


### PR DESCRIPTION
The word break is needed, because otherwise, long words break the layout.

The effect of a plain `word-break` rule is that long words are only broken when they don’t fit the column on their own line. I.e. if the current partially filled line doesn’t have space for the word, the word is dropped to the next line — and if the word doesn’t fit there (even after having the whole line for itself), then the word is broken from the character that would otherwise start pushing the container to be wider than the layout has given to it.

The `hyphens: auto;` doesn’t try to fit the long word to an (empty) next line. Instead, it just takes the currently available space after the previous word and fills it with a couple of syllables. Hence, the **_hyphens_** CSS rule is too eager to hyphenate - as it prefers to fill lines instead of keeping words whole as much as possible.

![css-is-awesome](https://github.com/sharetribe/web-template/assets/717315/f6d02d0c-5066-4278-99fa-75ee34577fde)

> Note: in the codebase, we also have `text-wrap: balance;` for the _H1_, but that enhancement is only supported by Chromium browsers at the moment.
