### PR TITLE
Code-split FieldDateInput, FieldDateRangeInput, FieldDateRangeController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2023-XX-XX
 
+- [change] Code-split FieldDateInput, FieldDateRangeInput, FieldDateRangeController. The consequence
+  is that react-dates library is code-splitted too.
+  [#290](https://github.com/sharetribe/web-template/pull/290)
 - [change] Move IconCard under SaveCardDetails (might be code-splitted later).
   [#283](https://github.com/sharetribe/web-template/pull/283)
 - [change] Code-split Topbar component and move it under TopbarContainer.

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,7 @@
  * Read more:
  * https://medium.com/visual-development/how-to-fix-nasty-circular-dependency-issues-once-and-for-all-in-javascript-typescript-a04c987cf0de
  */
+import loadable from '@loadable/component';
 
 // Icons
 export { default as IconAdd } from './IconAdd/IconAdd';
@@ -86,9 +87,6 @@ export { default as ModalInMobile } from './ModalInMobile/ModalInMobile';
 // Fields (for Final Form)
 export { default as FieldCheckbox } from './FieldCheckbox/FieldCheckbox';
 export { default as FieldCurrencyInput } from './FieldCurrencyInput/FieldCurrencyInput';
-export { default as FieldDateInput } from './FieldDateInput/FieldDateInput';
-export { default as FieldDateRangeController } from './FieldDateRangeController/FieldDateRangeController';
-export { default as FieldDateRangeInput } from './FieldDateRangeInput/FieldDateRangeInput';
 export { default as FieldRadioButton } from './FieldRadioButton/FieldRadioButton';
 export { default as FieldReviewRating } from './FieldReviewRating/FieldReviewRating';
 export { default as FieldSelect } from './FieldSelect/FieldSelect';
@@ -100,6 +98,11 @@ export { default as FieldPhoneNumberInput } from './FieldPhoneNumberInput/FieldP
 export { default as LocationAutocompleteInput, FieldLocationAutocompleteInput } from './LocationAutocompleteInput/LocationAutocompleteInput';
 // Fields and inputs using old naming pattern
 export { default as StripeBankAccountTokenInputField } from './StripeBankAccountTokenInputField/StripeBankAccountTokenInputField';
+// Fields wrapping react-dates
+// NOTE: these are code-splitted since the library is heavy and needed only on couple of pages
+export const FieldDateInput = loadable(() => import(/* webpackChunkName: "FieldDateInput" */ './FieldDateInput/FieldDateInput'));
+export const FieldDateRangeController = loadable(() => import(/* webpackChunkName: "FieldDateRangeController" */ './FieldDateRangeController/FieldDateRangeController'));
+export const FieldDateRangeInput = loadable(() => import(/* webpackChunkName: "FieldDateRangeInput" */ './FieldDateRangeInput/FieldDateRangeInput'));
 
 // Tab navigation
 export { default as TabNav } from './TabNav/TabNav';


### PR DESCRIPTION
This also creates a separate chunk out of the react-dates library. 
(This change reduces -54.97 kB from the main code-chunk.)

```
Note: when a component is code-splitted, its loading order is not fixed anymore.
Therefore, one needs to check that the CSS rules, passed from the parent,
are not clashing with the rules from the component itself.
Use rootClassName to omit the component's own rules completely.
```
https://www.sharetribe.com/docs/template/how-to-customize-template-styles/#parent-vs-child