### PR TITLE
Fix delivery method should contain string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,18 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] When delivery method is not set, it's still better to maintain the value as string, because
+  it's used as an argument in translations.
+  [#316](https://github.com/sharetribe/web-template/pull/316)
+
 ## [v4.0.0] 2024-02-07
 
-Breaking change: if you have customized your transaction process, you need to update the email templates. The new customer commission (#293) adds changes to emails that contain a receipt aka order breakdown information. In addition, also PR 310 touches the email templates.
+Breaking change: if you have customized your transaction process, you need to update the email
+templates. The new customer commission (#293) adds changes to emails that contain a receipt aka
+order breakdown information. In addition, also PR 310 touches the email templates.
 
 This also prepares the codebase for future configuration possibilities:
+
 - Postponing the requirement for a provider to give payout details (but it is still needed)
 - Makes certain listing features optional (location, delivery method)
 - Adds infinity stock (It is just emulated through a big number 10^15)

--- a/src/components/OrderPanel/ProductOrderForm/ProductOrderForm.js
+++ b/src/components/OrderPanel/ProductOrderForm/ProductOrderForm.js
@@ -98,7 +98,14 @@ const DeliveryMethodMaybe = props => {
         type="hidden"
       />
     </div>
-  ) : null;
+  ) : (
+    <FieldTextInput
+      id={`${formId}.deliveryMethod`}
+      className={css.deliveryField}
+      name="deliveryMethod"
+      type="hidden"
+    />
+  );
 };
 
 const renderForm = formRenderProps => {
@@ -315,14 +322,16 @@ const ProductOrderForm = props => {
   const hasOneItemLeft = currentStock && currentStock === 1;
   const hasOneItemMode = !allowOrdersOfMultipleItems && currentStock > 0;
   const quantityMaybe = hasOneItemLeft || hasOneItemMode ? { quantity: '1' } : {};
-  const singleDeliveryMethodAvailableMaybe =
+  const deliveryMethodMaybe =
     shippingEnabled && !pickupEnabled
       ? { deliveryMethod: 'shipping' }
       : !shippingEnabled && pickupEnabled
       ? { deliveryMethod: 'pickup' }
+      : !shippingEnabled && !pickupEnabled
+      ? { deliveryMethod: 'none' }
       : {};
   const hasMultipleDeliveryMethods = pickupEnabled && shippingEnabled;
-  const initialValues = { ...quantityMaybe, ...singleDeliveryMethodAvailableMaybe };
+  const initialValues = { ...quantityMaybe, ...deliveryMethodMaybe };
 
   return (
     <FinalForm


### PR DESCRIPTION
Save the deliveryMethod as 'none' to protected data when it's not defined.
(It's still better to maintain the value as string, because it's used as an argument for translations.)
