### PR TITLE
Topbar: add CustomLinksMenu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [add] new component CustomLinksMenu added to the Topbar. It shows custom links if there's enough
+  space available, or adds a new menu component that includes those links in a dropdown list.
+  [#320](https://github.com/sharetribe/web-template/pull/320)
 - [add] Mention Sharetribe Experts in the README.md
   [#332](https://github.com/sharetribe/web-template/pull/332)
 - [fix] AuthenticationPage: fix mobile layout issue when content was too long
@@ -34,7 +37,7 @@ way to update this template, but currently, we follow a pattern:
   the currentUser's role (customer vs provider).
   [#321](https://github.com/sharetribe/web-template/pull/321)
 - [fix] A listing using the inquiry transaction process should not show the payout details warning
-  to the user.
+  to the user. [#319](https://github.com/sharetribe/web-template/pull/319)
 - [add] Update translations for de.json, es.json, and fr.json.
   [#317](https://github.com/sharetribe/web-template/pull/317)
 - [fix] When delivery method is not set, it's still better to maintain the value as string, because

--- a/src/components/ExternalLink/ExternalLink.js
+++ b/src/components/ExternalLink/ExternalLink.js
@@ -1,23 +1,26 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import { node, string } from 'prop-types';
 
 // External link that opens in a new tab/window, ensuring that the
 // opened page doesn't have access to the current page.
 //
 // See: https://mathiasbynens.github.io/rel-noopener/
 const ExternalLink = props => {
-  const { children, ...rest } = props;
+  const { children, target, ...rest } = props;
+  const targetProp = target || '_blank';
+  const anchorProps =
+    targetProp === '_blank'
+      ? { target: '_blank', rel: 'noopener noreferrer' }
+      : { target: targetProp };
   return (
-    <a {...rest} target="_blank" rel="noopener noreferrer">
+    <a {...rest} {...anchorProps}>
       {children}
     </a>
   );
 };
 
-ExternalLink.defaultProps = { children: null };
+ExternalLink.defaultProps = { children: null, target: '_blank' };
 
-const { node } = PropTypes;
-
-ExternalLink.propTypes = { children: node };
+ExternalLink.propTypes = { children: node, target: string };
 
 export default ExternalLink;

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
@@ -544,6 +544,7 @@ class LocationAutocompleteInputImplementation extends Component {
               inputRef(node);
             }
           }}
+          title={search}
           data-testid="location-search"
         />
         {renderPredictions ? (

--- a/src/components/Logo/LinkedLogo.js
+++ b/src/components/Logo/LinkedLogo.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import { oneOf, string } from 'prop-types';
+import { oneOf, shape, string } from 'prop-types';
 import classNames from 'classnames';
 
-import { NamedLink, Logo } from '../../components';
+import { ExternalLink, Logo, NamedLink } from '../../components';
 
 import css from './LinkedLogo.module.css';
 
@@ -13,11 +13,22 @@ const LinkedLogo = props => {
     logoClassName,
     logoImageClassName,
     layout,
+    linkToExternalSite,
     alt,
     ...rest
   } = props;
   const classes = classNames(rootClassName || css.root, className);
-  return (
+  // Note: href might come as an empty string (falsy), in which case we default to 'LandingPage'.
+  return linkToExternalSite?.href ? (
+    <ExternalLink className={classes} href={linkToExternalSite.href} target="_self" {...rest}>
+      <Logo
+        layout={layout}
+        className={logoClassName}
+        logoImageClassName={logoImageClassName}
+        alt={alt}
+      />
+    </ExternalLink>
+  ) : (
     <NamedLink className={classes} name="LandingPage" {...rest}>
       <Logo
         layout={layout}
@@ -35,6 +46,7 @@ LinkedLogo.defaultProps = {
   logoClassName: null,
   logoImageClassName: null,
   layout: 'desktop',
+  linkToExternalSite: null,
 };
 
 LinkedLogo.propTypes = {
@@ -43,6 +55,9 @@ LinkedLogo.propTypes = {
   logoClassName: string,
   logoImageClassName: string,
   layout: oneOf(['desktop', 'mobile']),
+  linkToExternalSite: shape({
+    href: string.isRequired,
+  }),
 };
 
 export default LinkedLogo;

--- a/src/components/Logo/Logo.js
+++ b/src/components/Logo/Logo.js
@@ -60,13 +60,15 @@ export const LogoComponent = props => {
     const variantNames = getVariantNames(variants);
     const { width } = getVariantData(variants);
     return (
-      <div className={logoClasses}>
+      <div className={logoClasses} style={{ width: `${width}px` }}>
         <ResponsiveImage
           rootClassName={logoImageClasses}
           alt={marketplaceName}
           image={logoImageDesktop}
           variants={variantNames}
           sizes={`${width}px`}
+          width={width}
+          height={logoSettings?.height}
         />
       </div>
     );
@@ -89,6 +91,7 @@ export const LogoComponent = props => {
           image={logoImageMobile}
           variants={variantNames}
           sizes={sizes}
+          width={width}
         />
       </div>
     );

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -184,16 +184,16 @@ class Menu extends Component {
   }
 
   render() {
-    const { className, rootClassName } = this.props;
+    const { id, className, rootClassName } = this.props;
     const rootClass = rootClassName || css.root;
     const classes = classNames(rootClass, className);
     const menuChildren = this.state.ready ? this.prepareChildren() : null;
 
     return (
       <div
+        id={id}
         className={classes}
         onBlur={this.onBlur}
-        tabIndex={0}
         onKeyDown={this.onKeyDown}
         ref={c => {
           this.menu = c;

--- a/src/components/Menu/__snapshots__/Menu.test.js.snap
+++ b/src/components/Menu/__snapshots__/Menu.test.js.snap
@@ -4,7 +4,6 @@ exports[`Menu matches snapshot 1`] = `
 <DocumentFragment>
   <div
     class="root"
-    tabindex="0"
   >
     <button
       class="root"

--- a/src/config/configDefault.js
+++ b/src/config/configDefault.js
@@ -83,6 +83,7 @@ const defaultConfig = {
   appCdnAssets: {
     translations: '/content/translations.json',
     footer: '/content/footer.json',
+    topbar: '/content/top-bar.json',
     branding: '/design/branding.json',
     layout: '/design/layout.json',
     listingTypes: '/listings/listing-types.json',

--- a/src/containers/CheckoutPage/CheckoutPage.js
+++ b/src/containers/CheckoutPage/CheckoutPage.js
@@ -153,7 +153,7 @@ const EnhancedCheckoutPage = props => {
     />
   ) : (
     <Page title={title} scrollingDisabled={scrollingDisabled}>
-      <CustomTopbar intl={intl} />
+      <CustomTopbar intl={intl} linkToExternalSite={config?.topbar?.logoLink} />
     </Page>
   );
 };

--- a/src/containers/CheckoutPage/CheckoutPageWithInquiryProcess.js
+++ b/src/containers/CheckoutPage/CheckoutPageWithInquiryProcess.js
@@ -148,7 +148,7 @@ export const CheckoutPageWithInquiryProcess = props => {
 
   return (
     <Page title={title} scrollingDisabled={scrollingDisabled}>
-      <CustomTopbar intl={intl} />
+      <CustomTopbar intl={intl} linkToExternalSite={config?.topbar?.logoLink} />
       <div className={css.contentContainer}>
         <MobileListingImage
           listingTitle={listingTitle}

--- a/src/containers/CheckoutPage/CheckoutPageWithPayment.js
+++ b/src/containers/CheckoutPage/CheckoutPageWithPayment.js
@@ -419,7 +419,7 @@ export const CheckoutPageWithPayment = props => {
 
   return (
     <Page title={title} scrollingDisabled={scrollingDisabled}>
-      <CustomTopbar intl={intl} />
+      <CustomTopbar intl={intl} linkToExternalSite={config?.topbar?.logoLink} />
       <div className={css.contentContainer}>
         <MobileListingImage
           listingTitle={listingTitle}

--- a/src/containers/CheckoutPage/CustomTopbar.js
+++ b/src/containers/CheckoutPage/CustomTopbar.js
@@ -28,7 +28,7 @@ const CustomTopbar = props => {
     };
   });
 
-  const { className, rootClassName, intl } = props;
+  const { className, rootClassName, intl, linkToExternalSite } = props;
   const classes = classNames(rootClassName || css.topbar, className);
 
   return (
@@ -36,6 +36,7 @@ const CustomTopbar = props => {
       <LinkedLogo
         layout={isMobile ? 'mobile' : 'desktop'}
         alt={intl.formatMessage({ id: 'CheckoutPage.goToLandingPage' })}
+        linkToExternalSite={linkToExternalSite}
       />
     </div>
   );

--- a/src/containers/ContactDetailsPage/ContactDetailsPage.js
+++ b/src/containers/ContactDetailsPage/ContactDetailsPage.js
@@ -74,7 +74,6 @@ export const ContactDetailsPageComponent = props => {
         topbar={
           <>
             <TopbarContainer
-              currentPage="ContactDetailsPage"
               desktopClassName={css.desktopTopbar}
               mobileClassName={css.mobileTopbar}
             />

--- a/src/containers/FooterContainer/FooterContainer.js
+++ b/src/containers/FooterContainer/FooterContainer.js
@@ -10,7 +10,7 @@ const SectionBuilder = loadable(
 );
 
 const FooterComponent = () => {
-  const { footer = {} } = useConfiguration();
+  const { footer = {}, topbar } = useConfiguration();
 
   // If footer asset is not set, let's not render Footer at all.
   if (Object.keys(footer).length === 0) {
@@ -24,6 +24,7 @@ const FooterComponent = () => {
     ...footer,
     sectionId: 'footer',
     sectionType: 'footer',
+    linkLogoToExternalSite: topbar?.logoLink,
   };
 
   return <SectionBuilder sections={[footerSection]} />;

--- a/src/containers/InboxPage/InboxPage.js
+++ b/src/containers/InboxPage/InboxPage.js
@@ -297,7 +297,6 @@ export const InboxPageComponent = props => {
           <TopbarContainer
             mobileRootClassName={css.mobileTopbar}
             desktopClassName={css.desktopTopbar}
-            currentPage="InboxPage"
           />
         }
         sideNav={

--- a/src/containers/ManageListingsPage/ManageListingCard/__snapshots__/ManageListingCard.test.js.snap
+++ b/src/containers/ManageListingsPage/ManageListingCard/__snapshots__/ManageListingCard.test.js.snap
@@ -89,7 +89,6 @@ exports[`ManageListingCard matches snapshot (purchase) 1`] = `
       >
         <div
           class="root menu cardIsOpen"
-          tabindex="0"
         >
           <button
             class="root menuLabel"

--- a/src/containers/ManageListingsPage/ManageListingsPage.js
+++ b/src/containers/ManageListingsPage/ManageListingsPage.js
@@ -128,7 +128,7 @@ export class ManageListingsPageComponent extends Component {
         <LayoutSingleColumn
           topbar={
             <>
-              <TopbarContainer currentPage="ManageListingsPage" />
+              <TopbarContainer />
               <UserNav currentPage="ManageListingsPage" />
             </>
           }

--- a/src/containers/PageBuilder/PageBuilder.js
+++ b/src/containers/PageBuilder/PageBuilder.js
@@ -88,6 +88,7 @@ const PageBuilder = props => {
     fallbackPage,
     schemaType,
     options,
+    currentPage,
     ...pageProps
   } = props;
 
@@ -114,7 +115,7 @@ const PageBuilder = props => {
           return (
             <>
               <Topbar as="header" className={css.topbar}>
-                <TopbarContainer />
+                <TopbarContainer currentPage={currentPage} />
               </Topbar>
               <Main as="main" className={css.main}>
                 {sections.length === 0 && inProgress ? (

--- a/src/containers/PageBuilder/SectionBuilder/SectionFooter/SectionFooter.js
+++ b/src/containers/PageBuilder/SectionBuilder/SectionFooter/SectionFooter.js
@@ -43,6 +43,7 @@ const SectionFooter = props => {
     copyright,
     blocks,
     options,
+    linkLogoToExternalSite,
   } = props;
 
   // If external mapping has been included for fields
@@ -76,6 +77,7 @@ const SectionFooter = props => {
               rootClassName={css.logoLink}
               logoClassName={css.logoWrapper}
               logoImageClassName={css.logoImage}
+              linkToExternalSite={linkLogoToExternalSite}
             />
           </div>
           <div className={css.sloganMobile}>

--- a/src/containers/PageBuilder/SectionBuilder/SectionFooter/SectionFooter.js
+++ b/src/containers/PageBuilder/SectionBuilder/SectionFooter/SectionFooter.js
@@ -17,6 +17,7 @@ const GRID_CONFIG = [
   { contentCss: css.contentCol3, gridCss: css.gridCol3 },
   { contentCss: css.contentCol4, gridCss: css.gridCol4 },
 ];
+const MAX_MOBILE_SCREEN_WIDTH = 1024;
 
 const getIndex = numberOfColumns => numberOfColumns - 1;
 
@@ -58,6 +59,11 @@ const SectionFooter = props => {
   });
 
   const showSocialMediaLinks = socialMediaLinks?.length > 0;
+  const hasMatchMedia = typeof window !== 'undefined' && window?.matchMedia;
+  const isMobileLayout = hasMatchMedia
+    ? window.matchMedia(`(max-width: ${MAX_MOBILE_SCREEN_WIDTH}px)`)?.matches
+    : true;
+  const logoLayout = isMobileLayout ? 'mobile' : 'desktop';
 
   // use block builder instead of mapping blocks manually
 
@@ -78,6 +84,7 @@ const SectionFooter = props => {
               logoClassName={css.logoWrapper}
               logoImageClassName={css.logoImage}
               linkToExternalSite={linkLogoToExternalSite}
+              layout={logoLayout}
             />
           </div>
           <div className={css.sloganMobile}>

--- a/src/containers/PasswordChangePage/PasswordChangePage.js
+++ b/src/containers/PasswordChangePage/PasswordChangePage.js
@@ -56,7 +56,6 @@ export const PasswordChangePageComponent = props => {
         topbar={
           <>
             <TopbarContainer
-              currentPage="PasswordChangePage"
               desktopClassName={css.desktopTopbar}
               mobileClassName={css.mobileTopbar}
             />

--- a/src/containers/PaymentMethodsPage/PaymentMethodsPage.js
+++ b/src/containers/PaymentMethodsPage/PaymentMethodsPage.js
@@ -146,7 +146,6 @@ const PaymentMethodsPageComponent = props => {
         topbar={
           <>
             <TopbarContainer
-              currentPage="PaymentMethodsPage"
               desktopClassName={css.desktopTopbar}
               mobileClassName={css.mobileTopbar}
             />

--- a/src/containers/ProfilePage/ProfilePage.js
+++ b/src/containers/ProfilePage/ProfilePage.js
@@ -225,7 +225,7 @@ const ProfilePageComponent = props => {
     >
       <LayoutSideNavigation
         sideNavClassName={css.aside}
-        topbar={<TopbarContainer currentPage="ProfilePage" />}
+        topbar={<TopbarContainer />}
         sideNav={
           <AsideContent user={user} isCurrentUser={isCurrentUser} displayName={displayName} />
         }

--- a/src/containers/ProfileSettingsPage/ProfileSettingsPage.js
+++ b/src/containers/ProfileSettingsPage/ProfileSettingsPage.js
@@ -91,7 +91,7 @@ export const ProfileSettingsPageComponent = props => {
       <LayoutSingleColumn
         topbar={
           <>
-            <TopbarContainer currentPage="ProfileSettingsPage" />
+            <TopbarContainer />
             <UserNav currentPage="ProfileSettingsPage" />
           </>
         }

--- a/src/containers/SearchPage/SearchPageWithGrid.js
+++ b/src/containers/SearchPage/SearchPageWithGrid.js
@@ -297,11 +297,7 @@ export class SearchPageComponent extends Component {
         title={title}
         schema={schema}
       >
-        <TopbarContainer
-          rootClassName={topbarClasses}
-          currentPage="SearchPage"
-          currentSearchParams={urlQueryParams}
-        />
+        <TopbarContainer rootClassName={topbarClasses} currentSearchParams={urlQueryParams} />
         <div className={css.layoutWrapperContainer}>
           <aside className={css.layoutWrapperFilterColumn} data-testid="filterColumnAside">
             <div className={css.filterColumnContent}>

--- a/src/containers/SearchPage/SearchPageWithMap.js
+++ b/src/containers/SearchPage/SearchPageWithMap.js
@@ -392,11 +392,7 @@ export class SearchPageComponent extends Component {
         title={title}
         schema={schema}
       >
-        <TopbarContainer
-          rootClassName={topbarClasses}
-          currentPage="SearchPage"
-          currentSearchParams={urlQueryParams}
-        />
+        <TopbarContainer rootClassName={topbarClasses} currentSearchParams={urlQueryParams} />
         <div className={css.container}>
           <div className={css.searchResultContainer}>
             <SearchFiltersMobile

--- a/src/containers/StripePayoutPage/StripePayoutPage.js
+++ b/src/containers/StripePayoutPage/StripePayoutPage.js
@@ -150,7 +150,6 @@ export const StripePayoutPageComponent = props => {
         topbar={
           <>
             <TopbarContainer
-              currentPage="StripePayoutPage"
               desktopClassName={css.desktopTopbar}
               mobileClassName={css.mobileTopbar}
             />

--- a/src/containers/TopbarContainer/Topbar/Topbar.js
+++ b/src/containers/TopbarContainer/Topbar/Topbar.js
@@ -89,6 +89,22 @@ const getResolvedCustomLinks = (customLinks, routeConfiguration) => {
   });
 };
 
+const isCMSPage = found =>
+  found.route?.name === 'CMSPage' ? `CMSPage:${found.params?.pageId}` : null;
+const isInboxPage = found =>
+  found.route?.name === 'InboxPage' ? `InboxPage:${found.params?.tab}` : null;
+// Find the name of the current route/pathname.
+// It's used as handle for currentPage check.
+const getResolvedCurrentPage = (location, routeConfiguration) => {
+  const matchedRoutes = matchPathname(location.pathname, routeConfiguration);
+  if (matchedRoutes.length > 0) {
+    const found = matchedRoutes[0];
+    const cmsPageName = isCMSPage(found);
+    const inboxPageName = isInboxPage(found);
+    return cmsPageName ? cmsPageName : inboxPageName ? inboxPageName : `${found.route?.name}`;
+  }
+};
+
 const GenericError = props => {
   const { show } = props;
   const classes = classNames(css.genericError, {
@@ -213,6 +229,7 @@ class TopbarComponent extends Component {
     // Custom links are sorted so that group="primary" are always at the beginning of the list.
     const sortedCustomLinks = sortCustomLinks(config.topbar?.customLinks);
     const customLinks = getResolvedCustomLinks(sortedCustomLinks, routeConfiguration);
+    const resolvedCurrentPage = currentPage || getResolvedCurrentPage(location, routeConfiguration);
 
     const notificationDot = notificationCount > 0 ? <div className={css.notificationDot} /> : null;
 
@@ -230,7 +247,7 @@ class TopbarComponent extends Component {
         currentUser={currentUser}
         onLogout={this.handleLogout}
         notificationCount={notificationCount}
-        currentPage={currentPage}
+        currentPage={resolvedCurrentPage}
         customLinks={customLinks}
       />
     );
@@ -264,7 +281,7 @@ class TopbarComponent extends Component {
           authScopes={authScopes}
           currentUser={currentUser}
           onLogout={this.handleLogout}
-          currentPage={currentPage}
+          currentPage={resolvedCurrentPage}
         />
         <div className={classNames(mobileRootClassName || css.container, mobileClassName)}>
           <Button
@@ -293,7 +310,7 @@ class TopbarComponent extends Component {
             className={desktopClassName}
             currentUserHasListings={currentUserHasListings}
             currentUser={currentUser}
-            currentPage={currentPage}
+            currentPage={resolvedCurrentPage}
             initialSearchFormValues={initialSearchFormValues}
             intl={intl}
             isAuthenticated={isAuthenticated}

--- a/src/containers/TopbarContainer/Topbar/Topbar.js
+++ b/src/containers/TopbarContainer/Topbar/Topbar.js
@@ -9,7 +9,6 @@ import { useRouteConfiguration } from '../../../context/routeConfigurationContex
 
 import { FormattedMessage, intlShape, useIntl } from '../../../util/reactIntl';
 import { isMainSearchTypeKeywords, isOriginInUse } from '../../../util/search';
-import { withViewport } from '../../../util/uiHelpers';
 import { parse, stringify } from '../../../util/urlHelpers';
 import { createResourceLocatorString, pathByRouteName } from '../../../util/routes';
 import { propTypes } from '../../../util/types';
@@ -155,7 +154,6 @@ class TopbarComponent extends Component {
       currentUserHasOrders,
       currentPage,
       notificationCount,
-      viewport,
       intl,
       location,
       onManageDisableScrolling,
@@ -173,7 +171,10 @@ class TopbarComponent extends Component {
 
     const notificationDot = notificationCount > 0 ? <div className={css.notificationDot} /> : null;
 
-    const isMobileLayout = viewport.width < MAX_MOBILE_SCREEN_WIDTH;
+    const hasMatchMedia = typeof window !== 'undefined' && window?.matchMedia;
+    const isMobileLayout = hasMatchMedia
+      ? window.matchMedia(`(max-width: ${MAX_MOBILE_SCREEN_WIDTH}px)`)?.matches
+      : true;
     const isMobileMenuOpen = isMobileLayout && mobilemenu === 'open';
     const isMobileSearchOpen = isMobileLayout && mobilesearch === 'open';
 
@@ -348,12 +349,6 @@ TopbarComponent.propTypes = {
     search: string.isRequired,
   }).isRequired,
 
-  // from withViewport
-  viewport: shape({
-    width: number.isRequired,
-    height: number.isRequired,
-  }).isRequired,
-
   // from useIntl
   intl: intlShape.isRequired,
 
@@ -364,7 +359,7 @@ TopbarComponent.propTypes = {
   routeConfiguration: arrayOf(propTypes.route).isRequired,
 };
 
-const EnhancedTopbar = props => {
+const Topbar = props => {
   const config = useConfiguration();
   const routeConfiguration = useRouteConfiguration();
   const intl = useIntl();
@@ -377,8 +372,5 @@ const EnhancedTopbar = props => {
     />
   );
 };
-
-const Topbar = withViewport(EnhancedTopbar);
-Topbar.displayName = 'Topbar';
 
 export default Topbar;

--- a/src/containers/TopbarContainer/Topbar/Topbar.js
+++ b/src/containers/TopbarContainer/Topbar/Topbar.js
@@ -253,7 +253,7 @@ class TopbarComponent extends Component {
             notificationCount={notificationCount}
             onLogout={this.handleLogout}
             onSearchSubmit={this.handleSubmit}
-            appConfig={config}
+            config={config}
           />
         </div>
         <Modal

--- a/src/containers/TopbarContainer/Topbar/Topbar.js
+++ b/src/containers/TopbarContainer/Topbar/Topbar.js
@@ -228,7 +228,11 @@ class TopbarComponent extends Component {
             <MenuIcon className={css.menuIcon} />
             {notificationDot}
           </Button>
-          <LinkedLogo layout={'mobile'} alt={intl.formatMessage({ id: 'Topbar.logoIcon' })} />
+          <LinkedLogo
+            layout={'mobile'}
+            alt={intl.formatMessage({ id: 'Topbar.logoIcon' })}
+            linkToExternalSite={config?.topbar?.logoLink}
+          />
           <Button
             rootClassName={css.searchMenu}
             onClick={this.handleMobileSearchOpen}

--- a/src/containers/TopbarContainer/Topbar/Topbar.module.css
+++ b/src/containers/TopbarContainer/Topbar/Topbar.module.css
@@ -170,8 +170,8 @@
   @media (--viewportMedium) {
     flex-basis: 576px;
     flex-grow: 1;
-    min-height: 100vh;
-    height: 100%;
+    min-height: max(100%, 100vh);
+    height: auto;
     padding: 24px;
     background-color: var(--colorWhite);
     border-bottom: none;

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
@@ -88,10 +88,17 @@ const calculateContainerWidth = (containerRefTarget, parentWidth) => {
  * renders primary links directly there if there's enough space - and secondary links are shown inside a "More" menu.
  * If the space is limited, primary links as well as secondary links are shown inside the "More" menu.
  *
+ * Note: this component is inherently a bit fragile as it needs to deal with DOM directly. If you customize TopbarDesktop,
+ * test the responsiveness thoroughly.
+ *
  * props:
+ * - customLinks: array of link configurations.
  * - hasClientSideContentReady: indicates if TopbarDesktop is ready to render
+ * - currentPage: string that indicates if this is "LandingPage" or "SearchPage", etc.
+ * - intl: React Intl instance
+ *
  * @param {*} props contains currentPage, customLinks, intl, and hasClientSideContentReady
- * @returns
+ * @returns component to be placed inside TopbarDesktop
  */
 const CustomLinksMenu = ({ currentPage, customLinks = [], hasClientSideContentReady, intl }) => {
   const containerRef = useRef(null);

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
@@ -93,7 +93,7 @@ const calculateContainerWidth = (containerRefTarget, parentWidth) => {
  * @param {*} props contains currentPage, customLinks, intl, and hasClientSideContentReady
  * @returns
  */
-const CustomLinksMenu = ({ currentPage, customLinks = [], intl, hasClientSideContentReady }) => {
+const CustomLinksMenu = ({ currentPage, customLinks = [], hasClientSideContentReady, intl }) => {
   const containerRef = useRef(null);
   const observer = useRef(null);
   const [mounted, setMounted] = useState(false);
@@ -163,7 +163,7 @@ const CustomLinksMenu = ({ currentPage, customLinks = [], intl, hasClientSideCon
 
   // If there are no custom links, just render createListing link.
   if (customLinks?.length === 0) {
-    return <CreateListingMenuLink customLinksMenuClass={css.customLinksMenu} />;
+    return <CreateListingMenuLink customLinksMenuClass={css.createListingLinkOnly} />;
   }
 
   const styleMaybe = mounted ? { style: { width: `${containerWidth}px` } } : {};

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
@@ -1,0 +1,192 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import PriorityLinks, { CreateListingMenuLink } from './PriorityLinks';
+import LinksMenu from './LinksMenu';
+
+import css from './CustomLinksMenu.module.css';
+
+const draftId = '00000000-0000-0000-0000-000000000000';
+const createListingLinkConfig = intl => ({
+  group: 'primary',
+  text: intl.formatMessage({ id: 'TopbarDesktop.createListing' }),
+  type: 'internal',
+  route: {
+    name: 'EditListingPage',
+    params: { slug: 'draft', id: draftId, type: 'new', tab: 'details' },
+  },
+  highlight: true,
+});
+
+/**
+ * Group links to 2 groups:
+ * - priorityLinks (Those primary links that fit into current width of the TopbarDesktop.)
+ * - menuLinks (The rest of the links that are shown inside dropdown menu.)
+ *
+ * @param {*} links array of link configs in an order where primary group is shown first
+ * @param {*} containerWidth width reserved for the CustomLinksMenu component
+ * @param {*} menuMoreWidth width that the "More" label takes
+ * @returns Object containing arrays: { priorityLinks, menuLinks }
+ */
+const groupMeasuredLinks = (links, containerWidth, menuMoreWidth) => {
+  const isMeasured = !!links?.[0]?.width && menuMoreWidth > 0;
+  const hasNoPrimaryLinks = !links.find(l => l.group === 'primary');
+  // - We can't calculate groups, if the width of the rendered links are not measured
+  // - We don't need to calculate groups, if links don't contain any 'primary' links
+  if (!isMeasured || hasNoPrimaryLinks) {
+    return { priorityLinks: [], menuLinks: links };
+  }
+
+  const groupedLinks = links.reduce(
+    (pickedLinks, link, i) => {
+      const isPrimary = link.group === 'primary';
+      const isLast = i === links.length - 1;
+      // Has menuLinks at this point of the iteration (seconary links are at the end of the array)
+      const hasMenuLinks = pickedLinks.menuLinks?.length > 0;
+
+      const hasSpace =
+        isLast && !hasMenuLinks
+          ? link.cumulatedWidth <= containerWidth
+          : link.cumulatedWidth + menuMoreWidth <= containerWidth;
+
+      return isPrimary && hasSpace
+        ? {
+            priorityLinks: [...pickedLinks.priorityLinks, link],
+            menuLinks: pickedLinks.menuLinks,
+          }
+        : {
+            priorityLinks: pickedLinks.priorityLinks,
+            menuLinks: [...pickedLinks.menuLinks, link],
+          };
+    },
+    { priorityLinks: [], menuLinks: [] }
+  );
+  return groupedLinks;
+};
+
+const calculateContainerWidth = (containerRefTarget, parentWidth) => {
+  // Siblings include logo, search form, (inbox, profile menu || login signup)
+  const siblingArray = Array.from(containerRefTarget.parentNode.childNodes).filter(
+    n => n !== containerRefTarget
+  );
+  const siblingWidthsCombined = siblingArray.reduce((acc, node) => acc + node.offsetWidth, 0);
+
+  // .root class of the TopbarDesktop has 24px padding on the right
+  // Firefox doesn't support computedStyleMap()
+  const parentStyleMap = containerRefTarget.parentElement.computedStyleMap
+    ? containerRefTarget.parentElement.computedStyleMap()
+    : null;
+  const topbarPaddingRight = parentStyleMap?.get('padding-right')?.value;
+  const padding = topbarPaddingRight != null ? topbarPaddingRight : 24;
+
+  // We figure out available width from parent (TopbarDesktop/<nav>) and siblings
+  const availableContainerWidth = parentWidth - siblingWidthsCombined - padding;
+  return availableContainerWidth;
+};
+
+/**
+ * Create CustomLinksMenu component that takes all the extra space from the TopbarDesktop and
+ * renders primary links directly there if there's enough space - and secondary links are shown inside a "More" menu.
+ * If the space is limited, primary links as well as secondary links are shown inside the "More" menu.
+ *
+ * props:
+ * - hasClientSideContentReady: indicates if TopbarDesktop is ready to render
+ * @param {*} props contains currentPage, customLinks, intl, and hasClientSideContentReady
+ * @returns
+ */
+const CustomLinksMenu = ({ currentPage, customLinks = [], intl, hasClientSideContentReady }) => {
+  const containerRef = useRef(null);
+  const observer = useRef(null);
+  const [mounted, setMounted] = useState(false);
+  const [moreLabelWidth, setMoreLabelWidth] = useState(0);
+  const [links, setLinks] = useState([createListingLinkConfig(intl), ...customLinks]);
+  const [layoutData, setLayoutData] = useState({
+    priorityLinks: links,
+    menuLinks: links,
+    containerWidth: 0,
+  });
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    let animationFrameId = null;
+    if (hasClientSideContentReady && moreLabelWidth > 0) {
+      // ResizeObserver sets layout data: grouped priority links and links that go to menuLinks dropdown
+      observer.current = new ResizeObserver(entries => {
+        const containerRefParentWidth = containerRef.current?.parentNode?.offsetWidth;
+        const bodyOffsetWidth = document.body.offsetWidth;
+
+        for (const entry of entries) {
+          // Body's width has changed (aka viewport has changed)
+          const isBodyTheTarget = entry.target === document.body;
+          // If the width of the TopbarDesktop (aka <nav>) changes, this assumes that the document.body has the correct width.
+          const hasWidthOfTopbarDesktopChanged =
+            !isBodyTheTarget && containerRefParentWidth !== bodyOffsetWidth;
+
+          if (isBodyTheTarget || hasWidthOfTopbarDesktopChanged) {
+            const target = containerRef?.current;
+            const availableContainerWidth = calculateContainerWidth(target, bodyOffsetWidth);
+
+            // The groupedLinks variable contains { priorityLinks, menuLinks }
+            const groupedLinks = groupMeasuredLinks(links, availableContainerWidth, moreLabelWidth);
+            // The setLayoutData call affects the UI. This pushes the painting to the next frame.
+            animationFrameId = window.requestAnimationFrame(() => {
+              setLayoutData({ ...groupedLinks, containerWidth: availableContainerWidth });
+            });
+            // After setLayoutData is called, don't process other entries
+            break;
+          }
+        }
+      });
+
+      if (containerRef?.current) {
+        // We need to observe both document body and the component's own container
+        // When the window is squeezed, priority links prevent the container to shrink smaller.
+        // At that point, we need to calculate the width from the width of the body.
+        // It's also possible that some of the other elements get a repaint after window-level repaint (e.g. image loads)
+        // In those cases, we just need to
+        observer.current.observe(document.body);
+        observer.current.observe(containerRef.current);
+      }
+    }
+    return () => {
+      observer.current?.unobserve(document.body);
+      observer.current?.unobserve(containerRef.current);
+      if (animationFrameId) {
+        window.cancelAnimationFrame(animationFrameId);
+      }
+    };
+  }, [containerRef, hasClientSideContentReady, moreLabelWidth, links]);
+
+  const { priorityLinks, menuLinks, containerWidth } = layoutData;
+
+  // If there are no custom links, just render createListing link.
+  if (customLinks?.length === 0) {
+    return <CreateListingMenuLink customLinksMenuClass={css.customLinksMenu} />;
+  }
+
+  const styleMaybe = mounted ? { style: { width: `${containerWidth}px` } } : {};
+  const isMeasured = !!links?.[0]?.width;
+  const hasMenuLinks = menuLinks?.length > 0;
+  const hasPriorityLinks = isMeasured && priorityLinks.length > 0;
+
+  return (
+    <div className={css.customLinksMenu} ref={containerRef} {...styleMaybe}>
+      <PriorityLinks links={links} priorityLinks={priorityLinks} setLinks={setLinks} />
+      {hasMenuLinks ? (
+        <LinksMenu
+          id="linksMenu"
+          currentPage={currentPage}
+          links={menuLinks}
+          showMoreLabel={hasPriorityLinks}
+          moreLabelWidth={moreLabelWidth}
+          setMoreLabelWidth={setMoreLabelWidth}
+          intl={intl}
+        />
+      ) : null}
+    </div>
+  );
+};
+
+export default CustomLinksMenu;

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.module.css
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.module.css
@@ -1,0 +1,6 @@
+.customLinksMenu {
+  flex-grow: 1;
+  display: flex;
+  justify-content: right;
+  height: 100%;
+}

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.module.css
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.module.css
@@ -4,3 +4,8 @@
   justify-content: right;
   height: 100%;
 }
+.createListingLinkOnly {
+  display: flex;
+  justify-content: right;
+  height: 100%;
+}

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/LinksMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/LinksMenu.js
@@ -110,7 +110,7 @@ const MenuLabelContent = ({ showMoreLabel, isOpen, intl }) => (
     {showMoreLabel
       ? intl.formatMessage({ id: 'TopbarDesktop.LinksMenu.more' })
       : intl.formatMessage({ id: 'TopbarDesktop.LinksMenu.all' })}
-    <IconArrowHead direction={isOpen ? 'up' : 'down'} size="small" rootClassName={css.arrowIcon} />
+    <IconArrowHead direction="down" size="small" rootClassName={css.arrowIcon} />
   </span>
 );
 

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/LinksMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/LinksMenu.js
@@ -114,7 +114,7 @@ const MenuLabelContent = ({ showMoreLabel, isOpen, intl }) => (
 const LinksMenu = props => {
   const [isOpen, setIsOpen] = useState(false);
   const { id, currentPage, links, showMoreLabel, moreLabelWidth, setMoreLabelWidth, intl } = props;
-  const contentPlacementOffset = moreLabelWidth ? -1 * (moreLabelWidth / 2) : 48;
+  const contentPlacementOffset = moreLabelWidth ? -1 * (moreLabelWidth / 2) : 24;
   return (
     <>
       <Menu

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/LinksMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/LinksMenu.js
@@ -1,0 +1,149 @@
+import React, { useEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
+
+import {
+  ExternalLink,
+  IconArrowHead,
+  Menu,
+  MenuContent,
+  MenuItem,
+  MenuLabel,
+  NamedLink,
+} from '../../../../../components';
+
+import css from './LinksMenu.module.css';
+
+/**
+ * Link components to be shown inside the dropdown.
+ *
+ * @param {*} props contain keys: linkConfig, currentPage
+ * @returns NamedLink or ExternalLink
+ */
+const LinkComponent = ({ linkConfig, currentPage }) => {
+  const { text, type, href, route } = linkConfig;
+  const getCurrentPageClass = page => {
+    const hasPageName = name => currentPage?.indexOf(name) === 0;
+    const isCMSPage = pageId => hasPageName('CMSPage') && currentPage === `${page}:${pageId}`;
+    const isInboxPage = tab => hasPageName('InboxPage') && currentPage === `${page}:${tab}`;
+    const isCurrentPage = currentPage === page;
+    return isCMSPage(route?.params?.pageId) || isInboxPage(route?.params?.tab) || isCurrentPage
+      ? css.currentPage
+      : null;
+  };
+
+  // Note: if the config contains 'route' keyword,
+  // then in-app linking config has been resolved already.
+  if (type === 'internal' && route) {
+    // Internal link
+    const { name, params, to } = route || {};
+    const className = classNames(css.menuLink, getCurrentPageClass(name));
+    return (
+      <NamedLink name={name} params={params} to={to} className={className}>
+        <span className={css.menuItemBorder} />
+        {text}
+      </NamedLink>
+    );
+  }
+  return (
+    <ExternalLink href={href} className={css.menuLink}>
+      <span className={css.menuItemBorder} />
+      {text}
+    </ExternalLink>
+  );
+};
+
+/**
+ * When the links menu shows "More" label (instead of "Menu"), the label width needs to be measured.
+ *
+ * @param {*} props containing: width, setWidth, label
+ * @returns div with same styles as the real "More" label or null if width is known.
+ */
+const MeasureMoreMenu = props => {
+  const { width, setWidth, label } = props;
+  const moreMenuRef = useRef(null);
+  useEffect(() => {
+    if (moreMenuRef.current && !width) {
+      setWidth(moreMenuRef.current.offsetWidth);
+    }
+  }, [moreMenuRef, width]);
+
+  // Component is measured outside of the viewport
+  const styleWrapper = !!width
+    ? {}
+    : {
+        style: {
+          position: 'absolute',
+          top: '-2000px',
+          left: '-2000px',
+          width: 'auto', // The content defines width
+          height: 'var(--topbarHeightDesktop)',
+          display: 'flex',
+          flexDirection: 'row',
+        },
+      };
+
+  return !width ? (
+    <div id="measureMoreLabel" className={css.linkMenuLabel} ref={moreMenuRef} {...styleWrapper}>
+      {label}
+    </div>
+  ) : null;
+};
+
+/**
+ * Menu label has text (Menu vs More) and arrow up vs down
+ *
+ * @param {*} props contain keys: showMoreLabel, isOpen, intl
+ * @returns span containing menu label text and IconArrowHead
+ */
+const MenuLabelContent = ({ showMoreLabel, isOpen, intl }) => (
+  <span className={css.linkMenuLabelWrapper}>
+    {showMoreLabel
+      ? intl.formatMessage({ id: 'TopbarDesktop.LinksMenu.more' })
+      : intl.formatMessage({ id: 'TopbarDesktop.LinksMenu.all' })}
+    <IconArrowHead direction={isOpen ? 'up' : 'down'} size="small" rootClassName={css.arrowIcon} />
+  </span>
+);
+
+/**
+ * Menu that shows custom links with label showing either "Menu" or "More".
+ * The component also measures the width of the "More" label.
+ *
+ * @param {*} props contain: id, currentPage, links, showMoreLabel, moreLabelWidth, setMoreLabelWidth, intl
+ * @returns menu component
+ */
+const LinksMenu = props => {
+  const [isOpen, setIsOpen] = useState(false);
+  const { id, currentPage, links, showMoreLabel, moreLabelWidth, setMoreLabelWidth, intl } = props;
+  const contentPlacementOffset = moreLabelWidth ? -1 * (moreLabelWidth / 2) : 48;
+  return (
+    <>
+      <Menu
+        id={id}
+        contentPlacementOffset={contentPlacementOffset}
+        contentPosition="left"
+        isOpen={isOpen}
+        onToggleActive={setIsOpen}
+      >
+        <MenuLabel className={css.linkMenuLabel} isOpenClassName={css.linkMenuIsOpen}>
+          <MenuLabelContent showMoreLabel={showMoreLabel} isOpen={isOpen} intl={intl} />
+        </MenuLabel>
+        <MenuContent className={css.linkMenuContent}>
+          {links.map(linkConfig => {
+            return (
+              <MenuItem key={linkConfig.text}>
+                <LinkComponent linkConfig={linkConfig} currentPage={currentPage} />
+              </MenuItem>
+            );
+          })}
+        </MenuContent>
+      </Menu>
+      <MeasureMoreMenu
+        width={moreLabelWidth}
+        setWidth={setMoreLabelWidth}
+        label={<MenuLabelContent showMoreLabel={true} intl={intl} />}
+      />
+    </>
+  );
+};
+
+export default LinksMenu;

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/LinksMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/LinksMenu.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 
 import {
@@ -67,6 +68,7 @@ const MeasureMoreMenu = props => {
     }
   }, [moreMenuRef, width]);
 
+  const isServer = typeof window === 'undefined';
   // Component is measured outside of the viewport
   const styleWrapper = !!width
     ? {}
@@ -82,11 +84,19 @@ const MeasureMoreMenu = props => {
         },
       };
 
-  return !width ? (
-    <div id="measureMoreLabel" className={css.linkMenuLabel} ref={moreMenuRef} {...styleWrapper}>
-      {label}
-    </div>
-  ) : null;
+  return !width && !isServer
+    ? ReactDOM.createPortal(
+        <div
+          id="measureMoreLabel"
+          className={css.linkMenuLabel}
+          ref={moreMenuRef}
+          {...styleWrapper}
+        >
+          {label}
+        </div>,
+        document.body
+      )
+    : null;
 };
 
 /**

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/LinksMenu.module.css
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/LinksMenu.module.css
@@ -1,0 +1,110 @@
+@import '../../../../../styles/customMediaQueries.css';
+
+.currentPage {
+  color: var(--colorBlack);
+  position: relative;
+
+  & .menuItemBorder {
+    width: 6px;
+    background-color: var(--colorBlack);
+  }
+
+  &:hover {
+    & .menuItemBorder {
+      background-color: var(--colorBlack);
+    }
+  }
+}
+
+.linkMenuLabelWrapper {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: baseline;
+  margin: 28px 0;
+  text-decoration: inherit;
+}
+
+.linkMenuLabel {
+  flex-shrink: 0;
+
+  border-bottom: 0px solid;
+  transition: var(--transitionStyleButton);
+
+  font-weight: var(--fontWeightMedium);
+  font-size: 14px;
+  line-height: 18px;
+  letter-spacing: 0;
+  color: var(--colorGrey700);
+
+  display: inline;
+  height: 100%;
+  margin: 0;
+  padding: 0 12px 0 12px;
+
+  &:hover {
+    border-bottom: 4px solid var(--marketplaceColor);
+    border-radius: 0;
+    text-decoration: none;
+    color: var(--colorBlack);
+  }
+
+  &:active {
+    border-bottom: 0;
+  }
+}
+
+.linkMenuIsOpen {
+  &:hover {
+    border-bottom: 0;
+  }
+}
+
+.arrowIcon {
+  margin-left: 8px;
+}
+
+.linkMenuContent {
+  min-width: 276px;
+  padding: 20px 0;
+}
+
+/* left animated "border" like hover element */
+.menuItemBorder {
+  position: absolute;
+  top: 2px;
+  left: 0px;
+  height: calc(100% - 4px);
+  width: 0;
+  transition: width var(--transitionStyleButton);
+}
+
+.menuLink {
+  composes: textSmall from global;
+  position: relative;
+  display: block;
+
+  /* Dimensions */
+  width: 100%;
+  min-width: 276px;
+  margin: 0;
+  padding: 4px 24px;
+
+  /* Layout details */
+  color: var(--colorGrey700);
+  text-align: left;
+  transition: var(--transitionStyleButton);
+
+  &:hover {
+    color: var(--colorBlack);
+    text-decoration: none;
+
+    & .menuItemBorder {
+      width: 6px;
+      background-color: var(--marketplaceColor);
+    }
+  }
+
+  @media (--viewportMedium) {
+    margin: 0;
+  }
+}

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/PriorityLinks.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/PriorityLinks.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 
 import { FormattedMessage } from '../../../../../util/reactIntl';
@@ -81,6 +82,7 @@ const PriorityLinks = props => {
   }, [containerRef]);
 
   const { links, priorityLinks } = props;
+  const isServer = typeof window === 'undefined';
   const isMeasured = links?.[0]?.width && (priorityLinks.length === 0 || priorityLinks?.[0]?.width);
   const styleWrapper = !!isMeasured
     ? {}
@@ -97,12 +99,21 @@ const PriorityLinks = props => {
       };
   const linkConfigs = isMeasured ? priorityLinks : links;
 
-  return (
+  return isMeasured || isServer ? (
     <div className={css.priorityLinkWrapper} {...styleWrapper} ref={containerRef}>
       {linkConfigs.map(linkConfig => {
         return <PriorityLink key={linkConfig.text} linkConfig={linkConfig} />;
       })}
     </div>
+  ) : (
+    ReactDOM.createPortal(
+      <div className={css.priorityLinkWrapper} {...styleWrapper} ref={containerRef}>
+        {linkConfigs.map(linkConfig => {
+          return <PriorityLink key={linkConfig.text} linkConfig={linkConfig} />;
+        })}
+      </div>,
+      document.body
+    )
   );
 };
 

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/PriorityLinks.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/PriorityLinks.js
@@ -7,6 +7,12 @@ import { ExternalLink, NamedLink } from '../../../../../components';
 
 import css from './PriorityLinks.module.css';
 
+/**
+ * Create component that shows only a single "Post a new listing" link.
+ *
+ * @param {*} props contains customLinksMenuClass
+ * @returns div with only one link inside.
+ */
 export const CreateListingMenuLink = props => {
   return (
     <div className={props.customLinksMenuClass}>

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/PriorityLinks.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/PriorityLinks.js
@@ -1,0 +1,103 @@
+import React, { useEffect, useRef } from 'react';
+import classNames from 'classnames';
+
+import { FormattedMessage } from '../../../../../util/reactIntl';
+
+import { ExternalLink, NamedLink } from '../../../../../components';
+
+import css from './PriorityLinks.module.css';
+
+export const CreateListingMenuLink = props => {
+  return (
+    <div className={props.customLinksMenuClass}>
+      <NamedLink name="NewListingPage" className={classNames(css.priorityLink, css.highlight)}>
+        <span className={css.priorityLinkLabel}>
+          <FormattedMessage id="TopbarDesktop.createListing" />
+        </span>
+      </NamedLink>
+    </div>
+  );
+};
+
+/**
+ * Link component that can be used on TopbarDesktop.
+ *
+ * @param {*} props containing linkConfig including resolved 'route' params for NamedLink.
+ * @returns NamedLink or ExternalLink component based on config.
+ */
+const PriorityLink = ({ linkConfig }) => {
+  const { text, type, href, route, highlight } = linkConfig;
+  const classes = classNames(css.priorityLink, { [css.highlight]: highlight });
+
+  // Note: if the config contains 'route' keyword,
+  // then in-app linking config has been resolved already.
+  if (type === 'internal' && route) {
+    // Internal link
+    const { name, params, to } = route || {};
+    return (
+      <NamedLink name={name} params={params} to={to} className={classes}>
+        <span className={css.priorityLinkLabel}>{text}</span>
+      </NamedLink>
+    );
+  }
+  return (
+    <ExternalLink href={href} className={classes}>
+      <span className={css.priorityLinkLabel}>{text}</span>
+    </ExternalLink>
+  );
+};
+
+/**
+ * Create priority links, which are visible on the desktop layout on the Topbar.
+ * If space is limited, this doesn't include anything to the Topbar.
+ *
+ * @param {*} props contains links array and setLinks function
+ * @returns container div with priority links included.
+ */
+const PriorityLinks = props => {
+  const containerRef = useRef(null);
+
+  // With this useEffect, we measure the widths of each rendered priority link
+  // This is done once before the real rendering and it's done outside the viewport.
+  useEffect(() => {
+    const isMeasured = props.links?.[0]?.width;
+    if (containerRef.current && !isMeasured) {
+      const linksFromRenderedWrapper = [...containerRef.current.childNodes];
+      let cumulatedWidth = 0;
+      // Generate an array of link configs with width & cumulatedWidth included
+      const linksWithWidths = props.links.reduce((links, l, i) => {
+        const width = linksFromRenderedWrapper[i].offsetWidth;
+        cumulatedWidth = cumulatedWidth + width;
+        return [...links, { ...l, width, cumulatedWidth }];
+      }, []);
+      props.setLinks(linksWithWidths);
+    }
+  }, [containerRef]);
+
+  const { links, priorityLinks } = props;
+  const isMeasured = links?.[0]?.width && (priorityLinks.length === 0 || priorityLinks?.[0]?.width);
+  const styleWrapper = !!isMeasured
+    ? {}
+    : {
+        style: {
+          position: 'absolute',
+          top: '-2000px',
+          left: '-2000px',
+          width: '100%',
+          height: 'var(--topbarHeightDesktop)',
+          display: 'flex',
+          flexDirection: 'row',
+        },
+      };
+  const linkConfigs = isMeasured ? priorityLinks : links;
+
+  return (
+    <div className={css.priorityLinkWrapper} {...styleWrapper} ref={containerRef}>
+      {linkConfigs.map(linkConfig => {
+        return <PriorityLink key={linkConfig.text} linkConfig={linkConfig} />;
+      })}
+    </div>
+  );
+};
+
+export default PriorityLinks;

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/PriorityLinks.module.css
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/PriorityLinks.module.css
@@ -1,0 +1,52 @@
+@import '../../../../../styles/customMediaQueries.css';
+
+.priorityLinkWrapper {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: right;
+}
+
+.priorityLink {
+  border-bottom: 0px solid;
+  transition: var(--transitionStyleButton);
+
+  font-weight: var(--fontWeightMedium);
+  font-size: 14px;
+  line-height: 18px;
+  letter-spacing: 0;
+  color: var(--colorGrey700);
+
+  flex-shrink: 0;
+  height: 100%;
+  padding: 0 12px 0 12px;
+  margin: 0;
+
+  &:hover {
+    color: var(--colorBlack);
+    border-bottom: 4px solid var(--marketplaceColor);
+    border-radius: 0;
+    text-decoration: none;
+  }
+
+  @media (--viewportMedium) {
+    line-height: 16px;
+    margin: 0;
+  }
+}
+
+.highlight {
+  color: var(--marketplaceColor);
+  &:hover {
+    color: var(--marketplaceColorDark);
+  }
+}
+
+.priorityLinkLabel {
+  composes: textSmall from global;
+  display: inline-block;
+  margin: 28px 0;
+  text-decoration: inherit;
+  text-wrap: nowrap;
+}

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -20,46 +20,29 @@ import TopbarSearchForm from '../TopbarSearchForm/TopbarSearchForm';
 
 import css from './TopbarDesktop.module.css';
 
-const TopbarDesktop = props => {
-  const {
-    className,
-    appConfig,
-    currentUser,
-    currentPage,
-    rootClassName,
-    currentUserHasListings,
-    notificationCount,
-    intl,
-    isAuthenticated,
-    onLogout,
-    onSearchSubmit,
-    initialSearchFormValues,
-  } = props;
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const marketplaceName = appConfig.marketplaceName;
-  const authenticatedOnClientSide = mounted && isAuthenticated;
-  const isAuthenticatedOrJustHydrated = isAuthenticated || !mounted;
-
-  const classes = classNames(rootClassName || css.root, className);
-
-  const search = (
-    <TopbarSearchForm
-      className={css.searchLink}
-      desktopInputRoot={css.topbarSearchWithLeftPadding}
-      onSubmit={onSearchSubmit}
-      initialValues={initialSearchFormValues}
-      appConfig={appConfig}
-    />
+const SignupLink = () => {
+  return (
+    <NamedLink name="SignupPage" className={css.signupLink}>
+      <span className={css.signup}>
+        <FormattedMessage id="TopbarDesktop.signup" />
+      </span>
+    </NamedLink>
   );
+};
 
+const LoginLink = () => {
+  return (
+    <NamedLink name="LoginPage" className={css.loginLink}>
+      <span className={css.login}>
+        <FormattedMessage id="TopbarDesktop.login" />
+      </span>
+    </NamedLink>
+  );
+};
+
+const InboxLink = ({ notificationCount, currentUserHasListings }) => {
   const notificationDot = notificationCount > 0 ? <div className={css.notificationDot} /> : null;
-
-  const inboxLink = authenticatedOnClientSide ? (
+  return (
     <NamedLink
       className={css.inboxLink}
       name="InboxPage"
@@ -70,15 +53,17 @@ const TopbarDesktop = props => {
         {notificationDot}
       </span>
     </NamedLink>
-  ) : null;
+  );
+};
 
+const ProfileMenu = ({ currentPage, currentUser, onLogout }) => {
   const currentPageClass = page => {
     const isAccountSettingsPage =
       page === 'AccountSettingsPage' && ACCOUNT_SETTINGS_PAGES.includes(currentPage);
     return currentPage === page || isAccountSettingsPage ? css.currentPage : null;
   };
 
-  const profileMenu = authenticatedOnClientSide ? (
+  return (
     <Menu>
       <MenuLabel className={css.profileMenuLabel} isOpenClassName={css.profileMenuIsOpen}>
         <Avatar className={css.avatar} user={currentUser} disableProfileLink />
@@ -119,23 +104,49 @@ const TopbarDesktop = props => {
         </MenuItem>
       </MenuContent>
     </Menu>
+  );
+};
+
+const TopbarDesktop = props => {
+  const {
+    className,
+    appConfig,
+    currentUser,
+    currentPage,
+    rootClassName,
+    currentUserHasListings,
+    notificationCount,
+    intl,
+    isAuthenticated,
+    onLogout,
+    onSearchSubmit,
+    initialSearchFormValues,
+  } = props;
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const marketplaceName = appConfig.marketplaceName;
+  const authenticatedOnClientSide = mounted && isAuthenticated;
+  const isAuthenticatedOrJustHydrated = isAuthenticated || !mounted;
+
+  const classes = classNames(rootClassName || css.root, className);
+
+  const inboxLinkMaybe = authenticatedOnClientSide ? (
+    <InboxLink
+      notificationCount={notificationCount}
+      currentUserHasListings={currentUserHasListings}
+    />
   ) : null;
 
-  const signupLink = isAuthenticatedOrJustHydrated ? null : (
-    <NamedLink name="SignupPage" className={css.signupLink}>
-      <span className={css.signup}>
-        <FormattedMessage id="TopbarDesktop.signup" />
-      </span>
-    </NamedLink>
-  );
+  const profileMenuMaybe = authenticatedOnClientSide ? (
+    <ProfileMenu currentPage={currentPage} currentUser={currentUser} onLogout={onLogout} />
+  ) : null;
 
-  const loginLink = isAuthenticatedOrJustHydrated ? null : (
-    <NamedLink name="LoginPage" className={css.loginLink}>
-      <span className={css.login}>
-        <FormattedMessage id="TopbarDesktop.login" />
-      </span>
-    </NamedLink>
-  );
+  const signupLinkMaybe = isAuthenticatedOrJustHydrated ? null : <SignupLink />;
+  const loginLinkMaybe = isAuthenticatedOrJustHydrated ? null : <LoginLink />;
 
   return (
     <nav className={classes}>
@@ -145,16 +156,24 @@ const TopbarDesktop = props => {
         alt={intl.formatMessage({ id: 'TopbarDesktop.logo' }, { marketplaceName })}
         linkToExternalSite={appConfig?.topbar?.logoLink}
       />
-      {search}
+      <TopbarSearchForm
+        className={css.searchLink}
+        desktopInputRoot={css.topbarSearchWithLeftPadding}
+        onSubmit={onSearchSubmit}
+        initialValues={initialSearchFormValues}
+        appConfig={appConfig}
+      />
+
       <NamedLink className={css.createListingLink} name="NewListingPage">
         <span className={css.createListing}>
           <FormattedMessage id="TopbarDesktop.createListing" />
         </span>
       </NamedLink>
-      {inboxLink}
-      {profileMenu}
-      {signupLink}
-      {loginLink}
+
+      {inboxLinkMaybe}
+      {profileMenuMaybe}
+      {signupLinkMaybe}
+      {loginLinkMaybe}
     </nav>
   );
 };

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -134,6 +134,7 @@ const TopbarDesktop = props => {
   const authenticatedOnClientSide = mounted && isAuthenticated;
   const isAuthenticatedOrJustHydrated = isAuthenticated || !mounted;
 
+  const giveSpaceForSearch = customLinks == null || customLinks?.length === 0;
   const classes = classNames(rootClassName || css.root, className);
 
   const inboxLinkMaybe = authenticatedOnClientSide ? (
@@ -159,7 +160,7 @@ const TopbarDesktop = props => {
         linkToExternalSite={config?.topbar?.logoLink}
       />
       <TopbarSearchForm
-        className={css.searchLink}
+        className={classNames(css.searchLink, { [css.takeAvailableSpace]: giveSpaceForSearch })}
         desktopInputRoot={css.topbarSearchWithLeftPadding}
         onSubmit={onSearchSubmit}
         initialValues={initialSearchFormValues}

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -110,7 +110,7 @@ const ProfileMenu = ({ currentPage, currentUser, onLogout }) => {
 const TopbarDesktop = props => {
   const {
     className,
-    appConfig,
+    config,
     currentUser,
     currentPage,
     rootClassName,
@@ -128,7 +128,7 @@ const TopbarDesktop = props => {
     setMounted(true);
   }, []);
 
-  const marketplaceName = appConfig.marketplaceName;
+  const marketplaceName = config.marketplaceName;
   const authenticatedOnClientSide = mounted && isAuthenticated;
   const isAuthenticatedOrJustHydrated = isAuthenticated || !mounted;
 
@@ -154,14 +154,14 @@ const TopbarDesktop = props => {
         className={css.logoLink}
         layout="desktop"
         alt={intl.formatMessage({ id: 'TopbarDesktop.logo' }, { marketplaceName })}
-        linkToExternalSite={appConfig?.topbar?.logoLink}
+        linkToExternalSite={config?.topbar?.logoLink}
       />
       <TopbarSearchForm
         className={css.searchLink}
         desktopInputRoot={css.topbarSearchWithLeftPadding}
         onSubmit={onSearchSubmit}
         initialValues={initialSearchFormValues}
-        appConfig={appConfig}
+        appConfig={config}
       />
 
       <NamedLink className={css.createListingLink} name="NewListingPage">
@@ -185,7 +185,7 @@ TopbarDesktop.defaultProps = {
   currentPage: null,
   notificationCount: 0,
   initialSearchFormValues: {},
-  appConfig: null,
+  config: null,
 };
 
 TopbarDesktop.propTypes = {
@@ -200,7 +200,7 @@ TopbarDesktop.propTypes = {
   onSearchSubmit: func.isRequired,
   initialSearchFormValues: object,
   intl: intlShape.isRequired,
-  appConfig: object,
+  config: object,
 };
 
 export default TopbarDesktop;

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -17,13 +17,14 @@ import {
 } from '../../../../components';
 
 import TopbarSearchForm from '../TopbarSearchForm/TopbarSearchForm';
+import CustomLinksMenu from './CustomLinksMenu/CustomLinksMenu';
 
 import css from './TopbarDesktop.module.css';
 
 const SignupLink = () => {
   return (
-    <NamedLink name="SignupPage" className={css.signupLink}>
-      <span className={css.signup}>
+    <NamedLink name="SignupPage" className={css.topbarLink}>
+      <span className={css.topbarLinkLabel}>
         <FormattedMessage id="TopbarDesktop.signup" />
       </span>
     </NamedLink>
@@ -32,8 +33,8 @@ const SignupLink = () => {
 
 const LoginLink = () => {
   return (
-    <NamedLink name="LoginPage" className={css.loginLink}>
-      <span className={css.login}>
+    <NamedLink name="LoginPage" className={css.topbarLink}>
+      <span className={css.topbarLinkLabel}>
         <FormattedMessage id="TopbarDesktop.login" />
       </span>
     </NamedLink>
@@ -44,11 +45,11 @@ const InboxLink = ({ notificationCount, currentUserHasListings }) => {
   const notificationDot = notificationCount > 0 ? <div className={css.notificationDot} /> : null;
   return (
     <NamedLink
-      className={css.inboxLink}
+      className={css.topbarLink}
       name="InboxPage"
       params={{ tab: currentUserHasListings ? 'sales' : 'orders' }}
     >
-      <span className={css.inbox}>
+      <span className={css.topbarLinkLabel}>
         <FormattedMessage id="TopbarDesktop.inbox" />
         {notificationDot}
       </span>
@@ -71,7 +72,7 @@ const ProfileMenu = ({ currentPage, currentUser, onLogout }) => {
       <MenuContent className={css.profileMenuContent}>
         <MenuItem key="ManageListingsPage">
           <NamedLink
-            className={classNames(css.yourListingsLink, currentPageClass('ManageListingsPage'))}
+            className={classNames(css.menuLink, currentPageClass('ManageListingsPage'))}
             name="ManageListingsPage"
           >
             <span className={css.menuItemBorder} />
@@ -80,7 +81,7 @@ const ProfileMenu = ({ currentPage, currentUser, onLogout }) => {
         </MenuItem>
         <MenuItem key="ProfileSettingsPage">
           <NamedLink
-            className={classNames(css.profileSettingsLink, currentPageClass('ProfileSettingsPage'))}
+            className={classNames(css.menuLink, currentPageClass('ProfileSettingsPage'))}
             name="ProfileSettingsPage"
           >
             <span className={css.menuItemBorder} />
@@ -89,7 +90,7 @@ const ProfileMenu = ({ currentPage, currentUser, onLogout }) => {
         </MenuItem>
         <MenuItem key="AccountSettingsPage">
           <NamedLink
-            className={classNames(css.yourListingsLink, currentPageClass('AccountSettingsPage'))}
+            className={classNames(css.menuLink, currentPageClass('AccountSettingsPage'))}
             name="AccountSettingsPage"
           >
             <span className={css.menuItemBorder} />
@@ -111,6 +112,7 @@ const TopbarDesktop = props => {
   const {
     className,
     config,
+    customLinks,
     currentUser,
     currentPage,
     rootClassName,
@@ -164,11 +166,12 @@ const TopbarDesktop = props => {
         appConfig={config}
       />
 
-      <NamedLink className={css.createListingLink} name="NewListingPage">
-        <span className={css.createListing}>
-          <FormattedMessage id="TopbarDesktop.createListing" />
-        </span>
-      </NamedLink>
+      <CustomLinksMenu
+        currentPage={currentPage}
+        customLinks={customLinks}
+        intl={intl}
+        hasClientSideContentReady={authenticatedOnClientSide || !isAuthenticatedOrJustHydrated}
+      />
 
       {inboxLinkMaybe}
       {profileMenuMaybe}

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -143,6 +143,7 @@ const TopbarDesktop = props => {
         className={css.logoLink}
         layout="desktop"
         alt={intl.formatMessage({ id: 'TopbarDesktop.logo' }, { marketplaceName })}
+        linkToExternalSite={appConfig?.topbar?.logoLink}
       />
       {search}
       <NamedLink className={css.createListingLink} name="NewListingPage">

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.module.css
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.module.css
@@ -59,6 +59,10 @@
   }
 }
 
+.takeAvailableSpace {
+  flex-grow: 1;
+}
+
 .topbarSearchWithLeftPadding {
   padding-left: 24px;
   padding-right: 24px;

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.module.css
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.module.css
@@ -36,16 +36,11 @@
 
 /* Search */
 .searchLink {
-  flex-grow: 1;
+  min-width: 320px;
   height: 100%;
-  margin-right: 24px;
   border-left-style: solid;
   border-left-width: 1px;
   border-left-color: var(--colorGrey100);
-
-  @media (--viewportLarge) {
-    padding-left: 0;
-  }
 }
 
 .search {
@@ -66,6 +61,7 @@
 
 .topbarSearchWithLeftPadding {
   padding-left: 24px;
+  padding-right: 24px;
   height: var(--topbarHeightDesktop);
 
   @media (--viewportLarge) {
@@ -73,48 +69,10 @@
   }
 }
 
-/* Create listing (CTA for providers) */
-.createListingLink {
-  border-bottom: 0px solid;
-  transition: var(--transitionStyleButton);
-
-  font-weight: var(--fontWeightMedium);
-  font-size: 14px;
-  line-height: 18px;
-  letter-spacing: 0;
-  color: var(--marketplaceColor);
-
+/* These is used with Inbox, Sign up, and Log in */
+.topbarLink {
   flex-shrink: 0;
-  height: 100%;
-  padding: 0 12px 0 12px;
-  margin: 0;
 
-  &:hover {
-    color: var(--marketplaceColorDark);
-    border-bottom: 4px solid var(--marketplaceColor);
-    border-radius: 0;
-    text-decoration: none;
-  }
-
-  @media (--viewportMedium) {
-    line-height: 16px;
-    margin: 0;
-  }
-}
-
-.topbarDesktopLabel {
-  composes: textSmall from global;
-  display: inline-block;
-  margin: 28px 0;
-  text-decoration: inherit;
-}
-
-.createListing {
-  composes: topbarDesktopLabel;
-}
-
-/* Inbox */
-.inboxLink {
   border-bottom: 0px solid;
   transition: var(--transitionStyleButton);
 
@@ -141,8 +99,11 @@
   }
 }
 
-.inbox {
-  composes: topbarDesktopLabel;
+.topbarLinkLabel {
+  composes: textSmall from global;
+  display: inline-block;
+  margin: 28px 0;
+  text-decoration: inherit;
   position: relative;
 }
 
@@ -186,6 +147,12 @@
   border-bottom: 0px solid;
   transition: var(--transitionStyleButton);
 
+  font-weight: var(--fontWeightMedium);
+  font-size: 14px;
+  line-height: 18px;
+  letter-spacing: 0;
+  color: var(--colorGrey700);
+
   flex-shrink: 0;
   display: flex;
   align-items: center;
@@ -219,52 +186,6 @@
   padding-top: 20px;
 }
 
-/* Authentication */
-.signupLink {
-  border-bottom: 0px solid;
-  transition: var(--transitionStyleButton);
-
-  flex-shrink: 0;
-  height: 100%;
-  padding: 0 12px 0 12px;
-
-  color: var(--colorGrey700);
-
-  &:hover {
-    color: var(--colorBlack);
-    border-bottom: 4px solid var(--marketplaceColor);
-    border-radius: 0;
-    text-decoration: none;
-  }
-}
-
-.loginLink {
-  border-bottom: 0px solid;
-  transition: var(--transitionStyleButton);
-
-  flex-shrink: 0;
-  height: 100%;
-  padding: 0 12px 0 12px;
-
-  color: var(--colorGrey700);
-
-  &:hover {
-    color: var(--colorBlack);
-    border-bottom: 4px solid var(--marketplaceColor);
-    border-radius: 0;
-    text-decoration: none;
-  }
-}
-
-.signup,
-.login {
-  composes: textSmall from global;
-
-  display: inline-block;
-  margin: 28px 0;
-  text-decoration: inherit;
-}
-
 /* left animated "border" like hover element */
 .menuItemBorder {
   position: absolute;
@@ -275,14 +196,14 @@
   transition: width var(--transitionStyleButton);
 }
 
-.profileSettingsLink,
-.yourListingsLink {
+.menuLink {
   composes: textSmall from global;
   position: relative;
   display: block;
 
   /* Dimensions */
   width: 100%;
+  min-width: 276px;
   margin: 0;
   padding: 4px 24px;
 

--- a/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
@@ -13,12 +13,47 @@ import { ensureCurrentUser } from '../../../../util/data';
 
 import {
   AvatarLarge,
+  ExternalLink,
   InlineTextButton,
   NamedLink,
   NotificationBadge,
 } from '../../../../components';
 
 import css from './TopbarMobileMenu.module.css';
+
+const CustomLinkComponent = ({ linkConfig, currentPage }) => {
+  const { group, text, type, href, route } = linkConfig;
+  const getCurrentPageClass = page => {
+    const hasPageName = name => currentPage?.indexOf(name) === 0;
+    const isCMSPage = pageId => hasPageName('CMSPage') && currentPage === `${page}:${pageId}`;
+    const isInboxPage = tab => hasPageName('InboxPage') && currentPage === `${page}:${tab}`;
+    const isCurrentPage = currentPage === page;
+
+    return isCMSPage(route?.params?.pageId) || isInboxPage(route?.params?.tab) || isCurrentPage
+      ? css.currentPage
+      : null;
+  };
+
+  // Note: if the config contains 'route' keyword,
+  // then in-app linking config has been resolved already.
+  if (type === 'internal' && route) {
+    // Internal link
+    const { name, params, to } = route || {};
+    const className = classNames(css.navigationLink, getCurrentPageClass(name));
+    return (
+      <NamedLink name={name} params={params} to={to} className={className}>
+        <span className={css.menuItemBorder} />
+        {text}
+      </NamedLink>
+    );
+  }
+  return (
+    <ExternalLink href={href} className={css.navigationLink}>
+      <span className={css.menuItemBorder} />
+      {text}
+    </ExternalLink>
+  );
+};
 
 const TopbarMobileMenu = props => {
   const {
@@ -27,10 +62,21 @@ const TopbarMobileMenu = props => {
     currentUserHasListings,
     currentUser,
     notificationCount,
+    customLinks,
     onLogout,
   } = props;
 
   const user = ensureCurrentUser(currentUser);
+
+  const extraLinks = customLinks.map(linkConfig => {
+    return (
+      <CustomLinkComponent
+        key={linkConfig.text}
+        linkConfig={linkConfig}
+        currentPage={currentPage}
+      />
+    );
+  });
 
   if (!isAuthenticated) {
     const signup = (
@@ -59,6 +105,10 @@ const TopbarMobileMenu = props => {
               values={{ lineBreak: <br />, signupOrLogin }}
             />
           </div>
+
+          <div className={css.customLinksWrapper}>{extraLinks}</div>
+
+          <div className={css.spacer} />
         </div>
         <div className={css.footer}>
           <NamedLink className={css.createNewListingLink} name="NewListingPage">
@@ -78,8 +128,10 @@ const TopbarMobileMenu = props => {
   const currentPageClass = page => {
     const isAccountSettingsPage =
       page === 'AccountSettingsPage' && ACCOUNT_SETTINGS_PAGES.includes(currentPage);
-    return currentPage === page || isAccountSettingsPage ? css.currentPage : null;
+    const isInboxPage = currentPage?.indexOf('InboxPage') === 0 && page?.indexOf('InboxPage') === 0;
+    return currentPage === page || isAccountSettingsPage || isInboxPage ? css.currentPage : null;
   };
+  const inboxTab = currentUserHasListings ? 'sales' : 'orders';
 
   return (
     <div className={css.root}>
@@ -91,32 +143,36 @@ const TopbarMobileMenu = props => {
         <InlineTextButton rootClassName={css.logoutButton} onClick={onLogout}>
           <FormattedMessage id="TopbarMobileMenu.logoutLink" />
         </InlineTextButton>
-        <NamedLink
-          className={classNames(css.inbox, currentPageClass('InboxPage'))}
-          name="InboxPage"
-          params={{ tab: currentUserHasListings ? 'sales' : 'orders' }}
-        >
-          <FormattedMessage id="TopbarMobileMenu.inboxLink" />
-          {notificationCountBadge}
-        </NamedLink>
-        <NamedLink
-          className={classNames(css.navigationLink, currentPageClass('ManageListingsPage'))}
-          name="ManageListingsPage"
-        >
-          <FormattedMessage id="TopbarMobileMenu.yourListingsLink" />
-        </NamedLink>
-        <NamedLink
-          className={classNames(css.navigationLink, currentPageClass('ProfileSettingsPage'))}
-          name="ProfileSettingsPage"
-        >
-          <FormattedMessage id="TopbarMobileMenu.profileSettingsLink" />
-        </NamedLink>
-        <NamedLink
-          className={classNames(css.navigationLink, currentPageClass('AccountSettingsPage'))}
-          name="AccountSettingsPage"
-        >
-          <FormattedMessage id="TopbarMobileMenu.accountSettingsLink" />
-        </NamedLink>
+
+        <div className={css.accountLinksWrapper}>
+          <NamedLink
+            className={classNames(css.inbox, currentPageClass(`InboxPage:${inboxTab}`))}
+            name="InboxPage"
+            params={{ tab: inboxTab }}
+          >
+            <FormattedMessage id="TopbarMobileMenu.inboxLink" />
+            {notificationCountBadge}
+          </NamedLink>
+          <NamedLink
+            className={classNames(css.navigationLink, currentPageClass('ManageListingsPage'))}
+            name="ManageListingsPage"
+          >
+            <FormattedMessage id="TopbarMobileMenu.yourListingsLink" />
+          </NamedLink>
+          <NamedLink
+            className={classNames(css.navigationLink, currentPageClass('ProfileSettingsPage'))}
+            name="ProfileSettingsPage"
+          >
+            <FormattedMessage id="TopbarMobileMenu.profileSettingsLink" />
+          </NamedLink>
+          <NamedLink
+            className={classNames(css.navigationLink, currentPageClass('AccountSettingsPage'))}
+            name="AccountSettingsPage"
+          >
+            <FormattedMessage id="TopbarMobileMenu.accountSettingsLink" />
+          </NamedLink>
+        </div>
+        <div className={css.customLinksWrapper}>{extraLinks}</div>
         <div className={css.spacer} />
       </div>
       <div className={css.footer}>

--- a/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.module.css
+++ b/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.module.css
@@ -16,6 +16,16 @@
   align-items: flex-start;
 }
 
+.accountLinksWrapper,
+.customLinksWrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+.accountLinksWrapper {
+  margin-bottom: 36px;
+}
+
 .footer {
   position: fixed;
   bottom: 0;
@@ -143,7 +153,7 @@
   /* Font */
   composes: h1 from global;
 
-  margin-bottom: 24px;
+  margin-bottom: 48px;
   margin-top: var(--TopbarMobileMenu_topMargin);
 }
 .authenticationLinks {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -933,6 +933,8 @@
   "Topbar.menuIcon": "Open menu",
   "Topbar.mobileSearchHelp": "Find what you are looking for.",
   "Topbar.searchIcon": "Open search",
+  "TopbarDesktop.LinksMenu.all": "Menu",
+  "TopbarDesktop.LinksMenu.more": "More",
   "TopbarDesktop.accountSettingsLink": "Account settings",
   "TopbarDesktop.createListing": "Post a new listing",
   "TopbarDesktop.inbox": "Inbox",

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -944,6 +944,13 @@ export const mergeConfig = (configAsset = {}, defaultConfigs = {}) => {
       ? configAsset.googleSearchConsole
       : defaultConfigs.googleSearchConsole,
 
+    // The top-bar.json asset contains logo link and custom links
+    // - The logo link can be used to link logo to another domain
+    // - Custom links are links specified by marketplace operator (both internal and external)
+    //   - Topbar tries to fit primary links to the visible space,
+    //     but secondary links are always behind dropdown menu.
+    topbar: configAsset.topbar, // defaultConfigs.topbar,
+
     // Include hosted footer config, if it exists
     // Note: if footer asset is not set, Footer is not rendered.
     footer: configAsset.footer,


### PR DESCRIPTION
It will be possible to add _**custom links**_ through Console at some point in the future.
- Those links can be flagged as either _primary_ or _secondary_
  - Primary links will be shown directly in the TopbarDesktop, if there's space for them
    - If there's not enough space, a "More" menu is shown instead
    - If no primary links fit directly into the visible space, then "More" menu is just "Menu".
    - "Post a new listing" link is always shown as the first primary link, which is prioritized to the visible space
  - Secondary links will always be shown in a "More" menu (aka LinksMenu component)
- The _CustomLinksMenu_ component will calculate its width based on how much space there's available on the TopbarDesktop after the sibling components have taken their own space.
  - Uses ResizeObserver internally
  - Note: this setup is inherently a bit fragile as it needs to deal with DOM directly. If you customize Topbar, test the responsiveness thoroughly.

```json
  "TopbarDesktop.LinksMenu.all": "Menu",
  "TopbarDesktop.LinksMenu.more": "More",
```

In addition, this new hosted asset (top-bar.json) will contain **logoLink** property. It can contain a link to an external domain. The only scenario, where you should use it, is when you have an existing website (`https://famouswebsite.com`) and you include a marketplace into another domain: `https://marketplace.famouswebsite.com`. Then the logoLink property could be used to navigate your users to the main site.
> Note: logoLink does not support in-app navigation atm. So, if the URL is the marketplace's own domain (`https://marketplace.famouswebsite.com`) then a full page refresh is performed every time user clicks the logo.  

![Screenshot 2024-02-15 at 15 32 35](https://github.com/sharetribe/web-template/assets/717315/689668f0-daa3-415c-9741-34c560f211a0)
