### PR TITLE
PageBuilder: break long words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [add] PageBuilder/SectionContainer: break long words (e.g. links) so that mobile layout does not
+  break. [#322](https://github.com/sharetribe/web-template/pull/322)
 - [change] OrderBreakdown: ensure that only those line-items are shown that have been included for
   the currentUser's role (customer vs provider).
   [#321](https://github.com/sharetribe/web-template/pull/321)

--- a/src/containers/PageBuilder/SectionBuilder/SectionContainer/SectionContainer.module.css
+++ b/src/containers/PageBuilder/SectionBuilder/SectionContainer/SectionContainer.module.css
@@ -15,6 +15,7 @@
 .sectionContent {
   padding: 32px 0;
   position: relative;
+  word-break: break-word;
 
   @media (--viewportMedium) {
     padding: 64px 0;


### PR DESCRIPTION
It was reported that if there's a long string in the sections the mobile layout breaks. Such a scenario could happen if you add a long URL (without converting it into a link using markdown).