### PR TITLE
New release: v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+## [v4.1.0] 2024-02-26
+
 - [add] new component CustomLinksMenu added to the Topbar. It shows custom links if there's enough
   space available, or adds a new menu component that includes those links in a dropdown list.
   [#320](https://github.com/sharetribe/web-template/pull/320)
@@ -43,6 +45,8 @@ way to update this template, but currently, we follow a pattern:
 - [fix] When delivery method is not set, it's still better to maintain the value as string, because
   it's used as an argument in translations.
   [#316](https://github.com/sharetribe/web-template/pull/316)
+
+  [v4.1.0]: https://github.com/sharetribe/web-template/compare/v4.0.0...v4.1.0
 
 ## [v4.0.0] 2024-02-07
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This prepares the codebase for custom links that come through a new asset (content/top-bar.json). It also includes a possibility to link Logo to some external domain. Read more from the PR #320.

There are also a bunch of small copy-texts, bug fixes, and other improvements added. Check the changelog.

## [Changes] v4.1.0

- [add] new component CustomLinksMenu added to the Topbar. It shows custom links if there's enough
  space available, or adds a new menu component that includes those links in a dropdown list.
  [#320](https://github.com/sharetribe/web-template/pull/320)
- [add] Mention Sharetribe Experts in the README.md
  [#332](https://github.com/sharetribe/web-template/pull/332)
- [fix] AuthenticationPage: fix mobile layout issue when content was too long
  [#330](https://github.com/sharetribe/web-template/pull/330)
- [add] Update translations for de.json, es.json, and fr.json.
  [#328](https://github.com/sharetribe/web-template/pull/328)
- [change] Update social login button labels to be aligned with branding guides
  [#327](https://github.com/sharetribe/web-template/pull/327)
- [fix] Show an error message on the authentication page in case identity provider authentication fails
  [#326](https://github.com/sharetribe/web-template/pull/326)
- [change] Upgrade Sharetribe SDK to 1.20.1
  [#326](https://github.com/sharetribe/web-template/pull/326)
- [change] Update the copy of TransactionPage.default-purchase.customer.purchased.extraInfo
  [#323](https://github.com/sharetribe/web-template/pull/323)
- [add] PageBuilder/SectionContainer: break long words (e.g. links) so that the mobile layout does not
  break. [#322](https://github.com/sharetribe/web-template/pull/322)
- [change] OrderBreakdown: ensure that only those line-items are shown that have been included for
  the currentUser's role (customer vs provider).
  [#321](https://github.com/sharetribe/web-template/pull/321)
- [fix] A listing using the inquiry transaction process should not show the payout details warning
  to the user. [#319](https://github.com/sharetribe/web-template/pull/319)
- [add] Update translations for de.json, es.json, and fr.json.
  [#317](https://github.com/sharetribe/web-template/pull/317)
- [fix] When the delivery method is not set, it's still better to maintain the value as a string, because
  it's used as an argument in translations.
  [#316](https://github.com/sharetribe/web-template/pull/316)

  [Changes]: https://github.com/sharetribe/web-template/compare/v4.0.0...v4.1.0
