### PR TITLE
Dailight saving time: fix Atlantic/Azores tz issue with getStartOf fn call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,11 @@ way to update this template, but currently, we follow a pattern:
 ---
 
 ## Upcoming version 2024-XX-XX
+
+- [fix] Daylight saving time bug on those time zones that change exactly at midnight.
+  [#338](https://github.com/sharetribe/web-template/pull/338)
 - [add] Update translations for de.json, es.json, and fr.json.
   [#335](https://github.com/sharetribe/web-template/pull/335)
-
 - [fix] TopbarDesktop: when CustomLinksMenu is not in use, reduce the min-width of search input.
   [#334](https://github.com/sharetribe/web-template/pull/334)
 


### PR DESCRIPTION
EditListingAvailbilityExceptionForm: the call for **getStartOf** function with unit 'day' creates an infinite loop.

The underlying issue is that the Moment library returns a bad time as the start of the day:
https://github.com/moment/moment-timezone/issues/409

If we look for the start of the day on _'Atlantic/Azores'_ time zone, Moment returns 23:00 hours (March 30) because of DST (since 00:00 does not exist for Azores). There are a couple of other time zones that work like this too.

Most time zones use 03:00 to avoid this issue with DST.
The fix (for the infinite loop) is to add the 1-day offset as before **+ X hours more** and then ask for _startOf_ 'day' (or week/month). After that, the _startOf_ then returns 01:00 (March 31) aka the actual start of the day.
  
  
  