### PR TITLE
Fix sticky element containing input and scroll-padding

### DIFF
--- a/src/containers/ListingPage/ListingPage.module.css
+++ b/src/containers/ListingPage/ListingPage.module.css
@@ -580,10 +580,12 @@
 .sectionAuthor {
   padding: 0 24px;
   margin-top: 42px;
+  scroll-margin-top: calc(var(--topbarHeight) + 24px);
 
   @media (--viewportMedium) {
     padding: 0;
     margin-top: 40px;
+    scroll-margin-top: calc(var(--topbarHeightDesktop) + 24px);
   }
   @media (--viewportLarge) {
     padding: 8px 0;

--- a/src/containers/ListingPage/SectionAuthorMaybe.js
+++ b/src/containers/ListingPage/SectionAuthorMaybe.js
@@ -32,7 +32,7 @@ const SectionAuthorMaybe = props => {
   const isInquiryProcess = processName === INQUIRY_PROCESS_NAME;
 
   return (
-    <div id="author" className={css.sectionAuthor}>
+    <section id="author" className={css.sectionAuthor}>
       <Heading as="h2" rootClassName={css.sectionHeadingWithExtraMargin}>
         <FormattedMessage id="ListingPage.aboutProviderTitle" />
       </Heading>
@@ -60,7 +60,7 @@ const SectionAuthorMaybe = props => {
           inProgress={sendInquiryInProgress}
         />
       </Modal>
-    </div>
+    </section>
   );
 };
 

--- a/src/containers/ListingPage/SectionDetailsMaybe.js
+++ b/src/containers/ListingPage/SectionDetailsMaybe.js
@@ -45,7 +45,7 @@ const SectionDetailsMaybe = props => {
   const existingListingFields = listingFields.reduce(pickListingFields, []);
 
   return existingListingFields.length > 0 ? (
-    <div className={css.sectionDetails}>
+    <section className={css.sectionDetails}>
       <Heading as="h2" rootClassName={css.sectionHeading}>
         <FormattedMessage id="ListingPage.detailsTitle" />
       </Heading>
@@ -57,7 +57,7 @@ const SectionDetailsMaybe = props => {
           </li>
         ))}
       </ul>
-    </div>
+    </section>
   ) : null;
 };
 

--- a/src/containers/ListingPage/SectionGallery.js
+++ b/src/containers/ListingPage/SectionGallery.js
@@ -9,13 +9,13 @@ const SectionGallery = props => {
   const imageVariants = ['scaled-small', 'scaled-medium', 'scaled-large', 'scaled-xlarge'];
   const thumbnailVariants = [variantPrefix, `${variantPrefix}-2x`, `${variantPrefix}-4x`];
   return (
-    <div className={css.productGallery} data-testid="carousel">
+    <section className={css.productGallery} data-testid="carousel">
       <ListingImageGallery
         images={images}
         imageVariants={imageVariants}
         thumbnailVariants={thumbnailVariants}
       />
-    </div>
+    </section>
   );
 };
 

--- a/src/containers/ListingPage/SectionHero.js
+++ b/src/containers/ListingPage/SectionHero.js
@@ -37,7 +37,7 @@ const SectionHero = props => {
   ) : null;
 
   return (
-    <div className={css.sectionHero} data-testid="hero">
+    <section className={css.sectionHero} data-testid="hero">
       <div className={css.imageWrapperForSectionHero} onClick={handleViewPhotosClick}>
         {listing.id && isOwnListing ? (
           <div onClick={e => e.stopPropagation()} className={css.actionBarContainerForHeroLayout}>
@@ -82,7 +82,7 @@ const SectionHero = props => {
           imageVariants={['scaled-small', 'scaled-medium', 'scaled-large', 'scaled-xlarge']}
         />
       </Modal>
-    </div>
+    </section>
   );
 };
 

--- a/src/containers/ListingPage/SectionMapMaybe.js
+++ b/src/containers/ListingPage/SectionMapMaybe.js
@@ -31,7 +31,7 @@ class SectionMapMaybe extends Component {
     const map = <Map {...mapProps} useStaticMap={this.state.isStatic} />;
 
     return (
-      <div className={classes}>
+      <section className={classes} id="listing-location">
         <Heading as="h2" rootClassName={css.sectionHeadingWithExtraMargin}>
           <FormattedMessage id="ListingPage.locationTitle" />
         </Heading>
@@ -47,7 +47,7 @@ class SectionMapMaybe extends Component {
         ) : (
           <div className={css.map}>{map}</div>
         )}
-      </div>
+      </section>
     );
   }
 }

--- a/src/containers/ListingPage/SectionMultiEnumMaybe.js
+++ b/src/containers/ListingPage/SectionMultiEnumMaybe.js
@@ -10,7 +10,7 @@ const SectionMultiEnumMaybe = props => {
   }
 
   return (
-    <div className={css.sectionMultiEnum}>
+    <section className={css.sectionMultiEnum}>
       <Heading as="h2" rootClassName={css.sectionHeading}>
         {heading}
       </Heading>
@@ -20,7 +20,7 @@ const SectionMultiEnumMaybe = props => {
         selectedOptions={selectedOptions}
         twoColumns={options.length > 5}
       />
-    </div>
+    </section>
   );
 };
 

--- a/src/containers/ListingPage/SectionReviews.js
+++ b/src/containers/ListingPage/SectionReviews.js
@@ -8,7 +8,7 @@ const SectionReviews = props => {
   const { reviews, fetchReviewsError } = props;
 
   return (
-    <div className={css.sectionReviews}>
+    <section className={css.sectionReviews}>
       <Heading as="h2" rootClassName={css.sectionHeadingWithExtraMargin}>
         <FormattedMessage id="ListingPage.reviewsTitle" values={{ count: reviews.length }} />
       </Heading>
@@ -18,7 +18,7 @@ const SectionReviews = props => {
         </H2>
       ) : null}
       <Reviews reviews={reviews} />
-    </div>
+    </section>
   );
 };
 

--- a/src/containers/ListingPage/SectionTextMaybe.js
+++ b/src/containers/ListingPage/SectionTextMaybe.js
@@ -16,14 +16,14 @@ const SectionTextMaybe = props => {
   });
 
   return text ? (
-    <div className={css.sectionText}>
+    <section className={css.sectionText}>
       {heading ? (
         <Heading as="h2" rootClassName={css.sectionHeading}>
           {heading}
         </Heading>
       ) : null}
       <p className={textClass}>{content}</p>
-    </div>
+    </section>
   ) : null;
 };
 

--- a/src/containers/PageBuilder/BlockBuilder/BlockContainer/BlockContainer.module.css
+++ b/src/containers/PageBuilder/BlockBuilder/BlockContainer/BlockContainer.module.css
@@ -1,2 +1,11 @@
+@import '../../../../styles/customMediaQueries.css';
+
 .root {
+  &:target {
+    scroll-margin-top: calc(var(--topbarHeight) + 24px);
+
+    @media (--viewportMedium) {
+      scroll-margin-top: calc(var(--topbarHeightDesktop) + 24px);
+    }
+  }
 }

--- a/src/containers/PageBuilder/SectionBuilder/SectionContainer/SectionContainer.module.css
+++ b/src/containers/PageBuilder/SectionBuilder/SectionContainer/SectionContainer.module.css
@@ -10,6 +10,13 @@
   &:nth-of-type(odd) {
     background-color: var(--colorWhite);
   }
+
+  &:target {
+    scroll-margin-top: var(--topbarHeight);
+    @media (--viewportMedium) {
+      scroll-margin-top: var(--topbarHeightDesktop);
+    }
+  }
 }
 
 .sectionContent {

--- a/src/styles/marketplaceDefaults.css
+++ b/src/styles/marketplaceDefaults.css
@@ -198,6 +198,18 @@ body {
   color: var(--colorWhite);
 }
 
+/* Default elements that are targets */
+/* In addition, let's ensure that section components have scroll-margin */
+/* Since target does not work in every situation */
+:target,
+section {
+  scroll-margin-top: var(--topbarHeight);
+
+  @media (--viewportMedium) {
+    scroll-margin-top: var(--topbarHeightDesktop);
+  }
+}
+
 a {
   /* Position and dimensions */
   display: inline;

--- a/src/styles/marketplaceDefaults.css
+++ b/src/styles/marketplaceDefaults.css
@@ -369,11 +369,6 @@ html {
   color: var(--colorGrey700);
   padding: 0;
   margin: 0;
-  scroll-padding-top: calc(var(--topbarHeight) + 1px);
-
-  @media (--viewportMedium) {
-    scroll-padding-top: calc(var(--topbarHeightDesktop) + 1px);
-  }
 }
 
 ul {


### PR DESCRIPTION
Bug related to a sticky element that has input and uses scroll-padding causes a strange effect when the input element is activated.

https://github.com/w3c/csswg-drafts/issues/7931

This affects Topbar on Chromium browsers.

We fixed the problem by removing scroll-padding and started to use scroll-margin per targeted element, which gives more room for individual adjustments.