### PR TITLE
routeConfiguration: loadData mapping was missing from /confirm (SSO)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] SSO signups didn't show hosted Terms & Privacy policy assets due to missing loadData.
+  [#349](https://github.com/sharetribe/web-template/pull/349)
 - [fix] Input inside sticky element caused scroll effect on keystrokes, when scroll-padding was
   used. [#347](https://github.com/sharetribe/web-template/pull/347)
 - [fix] KeywordsFilter: add missing attribute: htmlFor

--- a/src/routing/routeConfiguration.js
+++ b/src/routing/routeConfiguration.js
@@ -187,6 +187,7 @@ const routeConfiguration = (layoutConfig) => {
       name: 'ConfirmPage',
       component: AuthenticationPage,
       extraProps: { tab: 'confirm' },
+      loadData: pageDataLoadingAPI.AuthenticationPage.loadData,
     },
     {
       path: '/recover-password',


### PR DESCRIPTION
SSO signups didn't show hosted Terms & Privacy policy assets due to missing loadData.