### PR TITLE
Format money did not use options of settingsCurrency.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [change] formatMoney should use correct formattingOptions (JPY gets correct formatting)
+  [#356](https://github.com/sharetribe/web-template/pull/356)
 - [change] Twitter's brand and logo has changed to X.
   [#355](https://github.com/sharetribe/web-template/pull/355)
 - [fix] Verify that browser's clock is not more than a minute out of sync.

--- a/src/config/settingsCurrency.js
+++ b/src/config/settingsCurrency.js
@@ -29,8 +29,9 @@ export const subUnitDivisors = {
  *
  * @param {string} currency
  */
-export const currencyFormatting = currency => {
-  if (!subUnitDivisors[currency]) {
+export const currencyFormatting = (currency, options) => {
+  const { enforceSupportedCurrencies = true } = options || {};
+  if (enforceSupportedCurrencies && !subUnitDivisors[currency]) {
     const currencies = Object.keys(subUnitDivisors);
     throw new Error(
       `Configuration missing for currency: ${currency}. Supported currencies: ${currencies.join(

--- a/src/util/currency.js
+++ b/src/util/currency.js
@@ -5,7 +5,7 @@ import Decimal from 'decimal.js';
 import appSettings from '../config/settings';
 import { types as sdkTypes } from '../util/sdkLoader';
 
-const { subUnitDivisors } = appSettings;
+const { subUnitDivisors, getCurrencyFormatting } = appSettings;
 const { Money } = sdkTypes;
 
 // https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
@@ -251,14 +251,10 @@ export const formatMoney = (intl, value) => {
   const valueAsNumber = convertMoneyToNumber(value);
 
   // See: https://github.com/yahoo/react-intl/wiki/API#formatnumber
-  const numberFormatOptions = {
-    style: 'currency',
-    currency: value.currency,
-    currencyDisplay: 'symbol',
-    useGrouping: true,
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  };
+  // If you have used currencies that are not listed in src/config/settingsCurrency.js,
+  // you might want to use option { enforceSupportedCurrencies: false }
+  const options = {};
+  const numberFormatOptions = getCurrencyFormatting(value.currency, options);
 
   return intl.formatNumber(valueAsNumber, numberFormatOptions);
 };


### PR DESCRIPTION
This way JPY gets correct currency formatting (no fractions)