### PR TITLE
Fix category cancel action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] util/search.js: fix pickInitialValuesForFieldSelectTree.
+  [#369](https://github.com/sharetribe/web-template/pull/369)
+
 ## [v5.0.0] 2024-04-23
 
 This major release prepares the codebase for the new concepts: user fields and categories. The

--- a/src/util/search.js
+++ b/src/util/search.js
@@ -84,8 +84,9 @@ export const isAnyFilterActive = (filterKeys, urlQueryParams, filterConfigs) => 
 export const pickInitialValuesForFieldSelectTree = (prefix, values) => {
   const pickValuesFn = (picked, entry) => {
     const [key, value] = entry;
-    const startsWithPrefix = key.indexOf(prefix) > -1;
-    return startsWithPrefix ? { ...picked, [key]: value } : picked;
+    const prefixIndex = key.indexOf(prefix);
+    const startsWithPrefix = prefixIndex > -1;
+    return startsWithPrefix ? { ...picked, [key.slice(prefixIndex)]: value } : picked;
   };
   const prefixCollection = Object.entries(values).reduce(pickValuesFn, {});
   return prefixCollection;


### PR DESCRIPTION
URL search parameter format `pub_categoryLevel1` was passed through and not the clean data: `categoryLevel1`.