### PR TITLE
Fix currentUserHasListings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] currentUserHasListings info. This is an old bug that emerged when we introduced draft status
+  to listing. The fetched listing might not be a published one but a draft listing. The ownListings
+  API endpoint is not queryable to get only published listings but luckily we have introduced
+  authorId filter to listings end point later on.
+  [#376](https://github.com/sharetribe/web-template/pull/376)
 - [add] Update translations for de.json, es.json, and fr.json.
   [#374](https://github.com/sharetribe/web-template/pull/374)
-- [change] Update one copy text.
-  [#373](https://github.com/sharetribe/web-template/pull/373)
+- [change] Update one copy text. [#373](https://github.com/sharetribe/web-template/pull/373)
 - [change] EditListingDetailsForm: pass categoryLevel as argument to translations.
   [#372](https://github.com/sharetribe/web-template/pull/372)
 - [fix] Fix: when changing categories, clear previously saved ones

--- a/src/ducks/user.duck.js
+++ b/src/ducks/user.duck.js
@@ -243,13 +243,14 @@ export const fetchCurrentUserHasListings = () => (dispatch, getState, sdk) => {
   }
 
   const params = {
-    // Since we are only interested in if the user has
+    // Since we are only interested in if the user has published
     // listings, we only need at most one result.
+    authorId: currentUser.id.uuid,
     page: 1,
     perPage: 1,
   };
 
-  return sdk.ownListings
+  return sdk.listings
     .query(params)
     .then(response => {
       const hasListings = response.data.data && response.data.data.length > 0;


### PR DESCRIPTION
This is an old bug that emerged when we introduced draft status to listing.
The fetched listing might not be a published one but a draft listing.

The _ownListings_ API endpoint is not queryable to get only published listings, but luckily we have introduced **_authorId_** filter to _listings_ API end point later on.