### PR TITLE
New release v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+## [v5.0.1] 2024-04-30
+
 - [fix] Fix: currentUser was not passed to billing details, which resulted email address missing on
   Stripe side. [#377](https://github.com/sharetribe/web-template/pull/377)
 - [fix] currentUserHasListings info. This is an old bug that emerged when we introduced draft status
@@ -30,6 +32,8 @@ way to update this template, but currently, we follow a pattern:
   [#371](https://github.com/sharetribe/web-template/pull/371)
 - [fix] util/search.js: fix pickInitialValuesForFieldSelectTree.
   [#369](https://github.com/sharetribe/web-template/pull/369)
+
+  [v5.0.1]: https://github.com/sharetribe/web-template/compare/v5.0.0...v5.0.1
 
 ## [v5.0.0] 2024-04-23
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
## [Changes] v5.0.1

- [fix] Fix: currentUser was not passed to billing details, which resulted email address missing on
  Stripe side. [#377](https://github.com/sharetribe/web-template/pull/377)
- [fix] currentUserHasListings info. This is an old bug that emerged when we introduced draft status
  to listing. The fetched listing might not be a published one but a draft listing. The ownListings
  API endpoint is not queryable to get only published listings but luckily we have introduced
  authorId filter to listings end point later on.
  [#376](https://github.com/sharetribe/web-template/pull/376)
- [add] Update translations for de.json, es.json, and fr.json.
  [#374](https://github.com/sharetribe/web-template/pull/374)
- [change] Update one copy text. [#373](https://github.com/sharetribe/web-template/pull/373)
- [change] EditListingDetailsForm: pass categoryLevel as argument to translations.
  [#372](https://github.com/sharetribe/web-template/pull/372)
- [fix] Fix: when changing categories, clear previously saved ones
  [#371](https://github.com/sharetribe/web-template/pull/371)
- [fix] util/search.js: fix pickInitialValuesForFieldSelectTree.
  [#369](https://github.com/sharetribe/web-template/pull/369)

  [Changes]: https://github.com/sharetribe/web-template/compare/v5.0.0...v5.0.1

## Translation changes

### Changed translations
- A new argument categoryLevel is passed for category input field
- Gif is not mentioned as it caused confusion. Animated gifs are not supported by the service we use for generating responsive images.
```json
  "EditListingDetailsForm.categoryLabel": "{categoryLevel, select, categoryLevel1 {Category} other {Subcategory}}",
  "EditListingDetailsForm.categoryPlaceholder": "{categoryLevel, select, categoryLevel1 {Select category} other {Select subcategory}}",
  "EditListingDetailsForm.categoryRequired": "{categoryLevel, select, categoryLevel1 {You need to select a category.} other {You need to select a subcategory.}}",
  "EditListingPhotosForm.imageTypes": ".JPG or .PNG. Max. 20 MB",
  "ProfileSettingsForm.fileInfo": ".JPG or .PNG. Max. 20 MB",
```
### Deleted translation keys
```json
  "EditListingDetailsForm.subCategoryLabel": "Subcategory",
```