### PR TITLE
Add autolinking to description, bio, listing & user fields, and messages

### DIFF
--- a/src/containers/ListingPage/ListingPage.module.css
+++ b/src/containers/ListingPage/ListingPage.module.css
@@ -677,9 +677,6 @@
 }
 
 .longWord {
-  /* fallback option */
-  word-break: break-all;
-  /* use break-word if available */
   word-break: break-word;
   hyphens: auto;
 }

--- a/src/containers/ListingPage/SectionTextMaybe.js
+++ b/src/containers/ListingPage/SectionTextMaybe.js
@@ -10,6 +10,7 @@ const SectionTextMaybe = props => {
   const { text, heading, showAsIngress = false } = props;
   const textClass = showAsIngress ? css.ingress : css.text;
   const content = richText(text, {
+    linkify: true,
     longWordMinLength: MIN_LENGTH_FOR_LONG_WORDS,
     longWordClass: css.longWord,
     breakChars: '/',

--- a/src/containers/ListingPage/UserCard/UserCard.js
+++ b/src/containers/ListingPage/UserCard/UserCard.js
@@ -4,6 +4,7 @@ import truncate from 'lodash/truncate';
 import classNames from 'classnames';
 
 import { FormattedMessage } from '../../../util/reactIntl';
+import { richText } from '../../../util/richText';
 import { ensureUser, ensureCurrentUser } from '../../../util/data';
 import { propTypes } from '../../../util/types';
 
@@ -14,6 +15,7 @@ import css from './UserCard.module.css';
 // Approximated collapsed size so that there are ~three lines of text
 // in the desktop layout in the author section of the ListingPage.
 const BIO_COLLAPSED_LENGTH = 170;
+const MIN_LENGTH_FOR_LONG_WORDS = 20;
 
 const truncated = s => {
   return truncate(s, {
@@ -33,7 +35,17 @@ const truncated = s => {
 const ExpandableBio = props => {
   const [expand, setExpand] = useState(false);
   const { className, bio } = props;
-  const truncatedBio = truncated(bio);
+  const bioWithLinks = richText(bio, {
+    linkify: true,
+    longWordMinLength: MIN_LENGTH_FOR_LONG_WORDS,
+    longWordClass: css.longWord,
+  });
+  const truncatedBio = richText(truncated(bio), {
+    linkify: true,
+    longWordMinLength: MIN_LENGTH_FOR_LONG_WORDS,
+    longWordClass: css.longWord,
+    breakChars: '/',
+  });
 
   const handleShowMoreClick = () => {
     setExpand(true);
@@ -45,8 +57,8 @@ const ExpandableBio = props => {
   );
   return (
     <p className={className}>
-      {expand ? bio : truncatedBio}
-      {bio !== truncatedBio && !expand ? showMore : null}
+      {expand ? bioWithLinks : truncatedBio}
+      {bio.length >= BIO_COLLAPSED_LENGTH && !expand ? showMore : null}
     </p>
   );
 };

--- a/src/containers/ListingPage/UserCard/UserCard.module.css
+++ b/src/containers/ListingPage/UserCard/UserCard.module.css
@@ -60,6 +60,11 @@
   }
 }
 
+.longWord {
+  word-break: break-word;
+  hyphens: auto;
+}
+
 .showMore {
   /* Position and dimensions */
   display: inline;

--- a/src/containers/ProfilePage/ProfilePage.js
+++ b/src/containers/ProfilePage/ProfilePage.js
@@ -16,6 +16,8 @@ import {
 import { ensureCurrentUser, ensureUser } from '../../util/data';
 import { withViewport } from '../../util/uiHelpers';
 import { pickCustomFieldProps } from '../../util/fieldHelpers';
+import { richText } from '../../util/richText';
+
 import { isScrollingDisabled } from '../../ducks/ui.duck';
 import { getMarketplaceEntities } from '../../ducks/marketplaceData.duck';
 import {
@@ -41,6 +43,7 @@ import SectionTextMaybe from './SectionTextMaybe';
 import SectionMultiEnumMaybe from './SectionMultiEnumMaybe';
 
 const MAX_MOBILE_SCREEN_WIDTH = 768;
+const MIN_LENGTH_FOR_LONG_WORDS = 20;
 
 export const AsideContent = props => {
   const { user, displayName, isCurrentUser } = props;
@@ -194,6 +197,11 @@ export const MainContent = props => {
   const hasListings = listings.length > 0;
   const isMobileLayout = viewport.width < MAX_MOBILE_SCREEN_WIDTH;
   const hasBio = !!bio;
+  const bioWithLinks = richText(bio, {
+    linkify: true,
+    longWordMinLength: MIN_LENGTH_FOR_LONG_WORDS,
+    longWordClass: css.longWord,
+  });
 
   const listingsContainerClasses = classNames(css.listingsContainer, {
     [css.withBioMissingAbove]: !hasBio,
@@ -211,7 +219,7 @@ export const MainContent = props => {
       <H2 as="h1" className={css.desktopHeading}>
         <FormattedMessage id="ProfilePage.desktopHeading" values={{ name: displayName }} />
       </H2>
-      {hasBio ? <p className={css.bio}>{bio}</p> : null}
+      {hasBio ? <p className={css.bio}>{bioWithLinks}</p> : null}
       <CustomUserFields
         publicData={publicData}
         metadata={metadata}

--- a/src/containers/ProfilePage/ProfilePage.module.css
+++ b/src/containers/ProfilePage/ProfilePage.module.css
@@ -85,6 +85,11 @@
   }
 }
 
+.longWord {
+  word-break: break-word;
+  hyphens: auto;
+}
+
 .bio {
   /* Preserve newlines, but collapse other whitespace */
   white-space: pre-line;

--- a/src/containers/ProfilePage/SectionTextMaybe.js
+++ b/src/containers/ProfilePage/SectionTextMaybe.js
@@ -10,6 +10,7 @@ const SectionTextMaybe = props => {
   const { text, heading, showAsIngress = false } = props;
   const textClass = showAsIngress ? css.ingress : css.text;
   const content = richText(text, {
+    linkify: true,
     longWordMinLength: MIN_LENGTH_FOR_LONG_WORDS,
     longWordClass: css.longWord,
     breakChars: '/',

--- a/src/containers/TransactionPage/ActivityFeed/ActivityFeed.js
+++ b/src/containers/TransactionPage/ActivityFeed/ActivityFeed.js
@@ -4,6 +4,7 @@ import dropWhile from 'lodash/dropWhile';
 import classNames from 'classnames';
 
 import { FormattedMessage, injectIntl, intlShape } from '../../../util/reactIntl';
+import { richText } from '../../../util/richText';
 import { formatDateWithProximity } from '../../../util/dates';
 import { propTypes } from '../../../util/types';
 import {
@@ -20,13 +21,21 @@ import { stateDataShape } from '../TransactionPage.stateData';
 
 import css from './ActivityFeed.module.css';
 
+const MIN_LENGTH_FOR_LONG_WORDS = 20;
+
 const Message = props => {
   const { message, formattedDate } = props;
+  const content = richText(message.attributes.content, {
+    linkify: true,
+    longWordMinLength: MIN_LENGTH_FOR_LONG_WORDS,
+    longWordClass: css.longWord,
+  });
+
   return (
     <div className={css.message}>
       <Avatar className={css.avatar} user={message.sender} />
       <div>
-        <p className={css.messageContent}>{message.attributes.content}</p>
+        <p className={css.messageContent}>{content}</p>
         <p className={css.messageDate}>{formattedDate}</p>
       </div>
     </div>
@@ -40,10 +49,17 @@ Message.propTypes = {
 
 const OwnMessage = props => {
   const { message, formattedDate } = props;
+  const content = richText(message.attributes.content, {
+    linkify: true,
+    linkClass: css.ownMessageContentLink,
+    longWordMinLength: MIN_LENGTH_FOR_LONG_WORDS,
+    longWordClass: css.longWord,
+  });
+
   return (
     <div className={css.ownMessage}>
       <div className={css.ownMessageContentWrapper}>
-        <p className={css.ownMessageContent}>{message.attributes.content}</p>
+        <p className={css.ownMessageContent}>{content}</p>
       </div>
       <p className={css.ownMessageDate}>{formattedDate}</p>
     </div>

--- a/src/containers/TransactionPage/ActivityFeed/ActivityFeed.module.css
+++ b/src/containers/TransactionPage/ActivityFeed/ActivityFeed.module.css
@@ -75,6 +75,15 @@
   color: var(--colorWhite);
   float: right;
 }
+.ownMessageContentLink {
+  color: var(--colorWhite);
+  text-decoration: underline;
+
+  &:hover {
+    text-decoration: none;
+    background-color: var(--marketplaceColorDark);
+  }
+}
 
 .messageDate,
 .ownMessageDate {

--- a/src/containers/TransactionPage/TransactionPanel/InquiryMessageMaybe.js
+++ b/src/containers/TransactionPage/TransactionPanel/InquiryMessageMaybe.js
@@ -2,9 +2,13 @@ import React from 'react';
 import classNames from 'classnames';
 
 import { FormattedMessage } from '../../../util/reactIntl';
+import { richText } from '../../../util/richText';
+
 import { Heading } from '../../../components';
 
 import css from './TransactionPanel.module.css';
+
+const MIN_LENGTH_FOR_LONG_WORDS = 20;
 
 // Functional component as a helper to build ActivityFeed section
 const InquiryMessageMaybe = props => {
@@ -13,12 +17,18 @@ const InquiryMessageMaybe = props => {
   const inquiryMsgClasses = isCustomer ? css.ownInquiryMessage : css.inquiryMessage;
 
   if (showInquiryMessage) {
+    const inquiryMessage = richText(protectedData?.inquiryMessage, {
+      linkify: true,
+      longWordMinLength: MIN_LENGTH_FOR_LONG_WORDS,
+      longWordClass: css.longWord,
+    });
+
     return (
       <div className={classes}>
         <Heading as="h3" rootClassName={css.sectionHeading}>
           <FormattedMessage id="TransactionPanel.inquiryMessageHeading" />
         </Heading>
-        <p className={inquiryMsgClasses}>{protectedData?.inquiryMessage}</p>
+        <p className={inquiryMsgClasses}>{inquiryMessage}</p>
       </div>
     );
   }

--- a/src/containers/TransactionPage/TransactionPanel/TransactionPanel.module.css
+++ b/src/containers/TransactionPage/TransactionPanel/TransactionPanel.module.css
@@ -419,6 +419,11 @@
   }
 }
 
+.longWord {
+  word-break: break-word;
+  hyphens: auto;
+}
+
 /* Passed-in props for FeedSection subcomponent */
 .bookingLocationContainer,
 .deliveryInfoContainer,

--- a/src/util/richText.js
+++ b/src/util/richText.js
@@ -12,9 +12,9 @@ import { ExternalLink } from '../components';
  * Add zero width space (zwsp) around given breakchars (default '/') to make word break possible.
  * E.g. "one/two/three" => ["one", "​/​", "two" "​/​" "three"]
  *
- * @param {string} wordToBreak word to be broken from special character points.
- * @param {string} breakChars string containing possible chars that can be surrounded with zwsp.
- * @return {Array<string>} returns an array containing strings-
+ * @param {String} wordToBreak word to be broken from special character points.
+ * @param {String} breakChars string containing possible chars that can be surrounded with zwsp.
+ * @return {Array<String>} returns an array containing strings-
  */
 export const zwspAroundSpecialCharsSplit = (wordToBreak, breakChars = '/') => {
   if (typeof wordToBreak !== 'string') {
@@ -36,10 +36,10 @@ export const zwspAroundSpecialCharsSplit = (wordToBreak, breakChars = '/') => {
  * Layouts are not fixed sizes - So, long words in text make flexboxed items to grow too big.
  * This wraps long words with span and adds given class to it
  *
- * @param {string} word to be wrapped if requirement (longWordMinLength) is met
- * @param {number} key span needs a key in React/JSX
- * @param {number} longWordMinLength minimum length when word is considered long
- * @param {string} longWordClass class to be added to spans
+ * @param {String} word to be wrapped if requirement (longWordMinLength) is met
+ * @param {Number} key span needs a key in React/JSX
+ * @param {Number} longWordMinLength minimum length when word is considered long
+ * @param {String} longWordClass class to be added to spans
  * @return {node} returns a string or component
  */
 export const wrapLongWord = (word, key, options = {}) => {
@@ -61,8 +61,8 @@ export const wrapLongWord = (word, key, options = {}) => {
 /**
  * Find links from words and surround them with <ExternalLink> component
  *
- * @param {string} word to be linkified if requirement (link) is met
- * @param {number} key span needs a key in React/JSX
+ * @param {String} word to be linkified if requirement (link) is met
+ * @param {Number} key span needs a key in React/JSX
  * @param {Object} options than can contain keys: linkify, linkClass.
  * @return {Array<node>} returns a array containing ExternalLink component or strings
  */
@@ -117,8 +117,11 @@ export const linkifyOrWrapLinkSplit = (word, key, options = {}) => {
  * Wrap long words: options should contain longWordMinLength & longWordClass
  * Linkify found links: options should contain "linkify: true" (linkClass is optional)
  *
- * @param {string} text check text content
- * @param {object} options { longWordMinLength, longWordClass, linkify = false, linkClass }
+ * Note: this autolinks only strings that start with 'http'. In addition, links are assumed
+ *       to lead outside of the app. In-app linking is not supported atm.
+ *
+ * @param {String} text check text content
+ * @param {Object} options { longWordMinLength, longWordClass, linkify = false, linkClass }
  * @return {Array<node>} returns a child array containing strings and inline elements
  */
 export const richText = (text, options) => {

--- a/src/util/richText.js
+++ b/src/util/richText.js
@@ -2,6 +2,9 @@ import React from 'react';
 import flow from 'lodash/flow';
 import flatMap from 'lodash/flatMap';
 import map from 'lodash/map';
+
+import { sanitizeUrl } from './sanitize';
+
 import { ExternalLink } from '../components';
 // NOTE: This file imports components/index.js, which may lead to circular dependency
 
@@ -88,11 +91,13 @@ export const linkifyOrWrapLinkSplit = (word, key, options = {}) => {
   if (word.match(urlRegex)) {
     // Split strings like "(http://www.example.com)" to ["(","http://www.example.com",")"]
     return word.split(urlRegex).map(w => {
-      return !w.match(urlRegex) ? (
+      const isEmptyString = !w.match(urlRegex);
+      const sanitizedURL = !isEmptyString && linkify ? sanitizeUrl(w) : w;
+      return isEmptyString ? (
         w
       ) : linkify ? (
-        <ExternalLink key={key} href={w} className={linkClass}>
-          {w}
+        <ExternalLink key={key} href={sanitizedURL} className={linkClass}>
+          {sanitizedURL}
         </ExternalLink>
       ) : linkClass ? (
         <span key={key} className={linkClass}>

--- a/src/util/richText.test.js
+++ b/src/util/richText.test.js
@@ -284,6 +284,102 @@ describe('richText', () => {
         `<span>Link: (<a href="http://example.com" class="longWord" target="_blank" rel="noopener noreferrer">http://example.com</a>)</span>`
       );
     });
+
+    it('should add link inside non-whitespace-sequence that ends to common puctuation (!:,.;)', () => {
+      // !
+      const wrapper = render(
+        <span>{richText('Check this http://example.com!', { ...options, linkify: true })}</span>
+      );
+      // <span>
+      //   Check this <a href=\"http://example.com\" target=\"_blank\" rel=\"noopener noreferrer\">http://example.com</a>!
+      // </span>
+      const htmlString = wrapper.asFragment().firstChild.outerHTML;
+      expect(htmlString).toEqual(
+        `<span>Check this <a href="http://example.com" class="longWord" target="_blank" rel="noopener noreferrer">http://example.com</a>!</span>`
+      );
+
+      // :
+      const colon = render(
+        <span>
+          {richText('Check this http://example.com: asdf', { ...options, linkify: true })}
+        </span>
+      );
+      expect(colon.asFragment().firstChild.outerHTML).toEqual(
+        `<span>Check this <a href="http://example.com" class="longWord" target="_blank" rel="noopener noreferrer">http://example.com</a>: asdf</span>`
+      );
+
+      // ,
+      // Note: comma is part of break chars by default, therefore zero-width-space is added there
+      const comma = render(
+        <span>
+          {richText('Check this http://example.com, asdf', { ...options, linkify: true })}
+        </span>
+      );
+      expect(comma.asFragment().firstChild.outerHTML).toEqual(
+        `<span>Check this <a href=\"http://example.com\" class=\"longWord\" target=\"_blank\" rel=\"noopener noreferrer\">http://example.com</a>​,​ asdf</span>`
+      );
+
+      // .
+      const dot = render(
+        <span>
+          {richText('Check this http://example.com. Asdf', { ...options, linkify: true })}
+        </span>
+      );
+      expect(dot.asFragment().firstChild.outerHTML).toEqual(
+        `<span>Check this <a href="http://example.com" class="longWord" target="_blank" rel="noopener noreferrer">http://example.com</a>. Asdf</span>`
+      );
+
+      // ;
+      const semicolon = render(
+        <span>
+          {richText('Check this http://example.com; and this http://example.com', {
+            ...options,
+            linkify: true,
+          })}
+        </span>
+      );
+      expect(semicolon.asFragment().firstChild.outerHTML).toEqual(
+        `<span>Check this <a href=\"http://example.com\" class=\"longWord\" target=\"_blank\" rel=\"noopener noreferrer\">http://example.com</a>; and this <a href=\"http://example.com\" class=\"longWord\" target=\"_blank\" rel=\"noopener noreferrer\">http://example.com</a></span>`
+      );
+    });
+
+    it('should not include quote chars to link (http://example.com")', () => {
+      const wrapper = render(
+        <span>{richText('Link: (http://example.com")', { ...options, linkify: true })}</span>
+      );
+      // <span>
+      //   Link: (<a href=\"http://example.com\" target=\"_blank\" rel=\"noopener noreferrer\">http://example.com</a>)
+      // </span>
+      const htmlString = wrapper.asFragment().firstChild.outerHTML;
+      expect(htmlString).toEqual(
+        `<span>Link: (<a href="http://example.com" class="longWord" target="_blank" rel="noopener noreferrer">http://example.com</a>\")</span>`
+      );
+
+      const singleQuote = render(
+        <span>{richText("Link: (http://example.com')", { ...options, linkify: true })}</span>
+      );
+      expect(singleQuote.asFragment().firstChild.outerHTML).toEqual(
+        `<span>Link: (<a href="http://example.com" class="longWord" target="_blank" rel="noopener noreferrer">http://example.com</a>\')</span>`
+      );
+
+      const singleQuote2 = render(
+        <span>{richText("Link: (http://example.com')", { ...options, linkify: true })}</span>
+      );
+      expect(singleQuote2.asFragment().firstChild.outerHTML).toEqual(
+        `<span>Link: (<a href="http://example.com" class="longWord" target="_blank" rel="noopener noreferrer">http://example.com</a>\')</span>`
+      );
+    });
+    it('should not include closing anchor tag to a link (http://example.com</a>")', () => {
+      // Note: the slash ('/') is part of break chars by default, therefore zero-width-space is added there
+      const wrapper = render(
+        <span>{richText('Link: (http://example.com</a>)', { ...options, linkify: true })}</span>
+      );
+      const htmlString = wrapper.asFragment().firstChild.outerHTML;
+      expect(htmlString).toEqual(
+        `<span>Link: (<a href="http://example.com" class="longWord" target="_blank" rel="noopener noreferrer">http://example.com</a>&lt;​/​a&gt;)</span>`
+      );
+    });
+
     it('should not add span around a string if no linkify option is given', () => {
       const wrapper = render(
         <span>


### PR DESCRIPTION
1. Text content is wrapped with **richText** function found from _src/util/richText.js_
2. The _richText_ function detects if text contains a string that starts with **_http_**. 
    - If there is a link like that, it automatically creates a link out of it.
    - The link is sanitazed using **sanitazeUrl** function found from _src/util/sanitize.js_
    - This also adds <span> elements around long words and breaks those words with CSS.
      - At the moment, a word is considered long if it contains **20** characters or more.

Note: this uses `<ExternalLink>`, which means that the link will be opened to another tab on the browser.

Affected texts:

- ListingPage > Listing's **description**
- ListingPage > **Listing fields** with schema type ‘text’
- ListingPage > User's **bio** on `<UserCard>`
- ProfilePage > User's **bio**
- ProfilePage > **User fields** with schema type ‘text’
- TransactionPage > **Messages**
- TransactionPage > **inquiryMessage** (default-inquiry process: the message saved to protected data on checkout)


> NOTE: This can not yet handle links that contain parenthesis:
> `(http://example.org/path_(etc))`
> Currently extracts:
> `(<a href=\"http://example.org/path_\" ...>http://example.org/path_</a>(etc))`
> 