### PR TITLE
New release: v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,19 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+## [v5.1.0] 2024-05-21
+
 - [add] support for extended data fields with type `long`
   [#364](https://github.com/sharetribe/web-template/pull/364)
+- [change] the login-as feature has changed:
+
+  - Use `sdk.loginAs` instead of `sdk.login`, which is deprecated for this purpose
+  - Use `authInfo.isLoggedInAs` instead of relying on auth token's `scope` to determine if current
+    session is operator user logged in as marketplace user.
+  - Note: when taking update from upstream, check also commit be7e2b9b4.
+
+  [#386](https://github.com/sharetribe/web-template/pull/386)
+
 - [fix] the email template for default-purchase process
   (purchase-order-canceled-from-disputed-provider-html.html) contained copy-paste related typo.
   [#390](https://github.com/sharetribe/web-template/pull/389)
@@ -44,11 +55,8 @@ way to update this template, but currently, we follow a pattern:
 - [fix] Styleguide shows multiple versions of some components. The 'id' attributes need to be
   unique. [#380](https://github.com/sharetribe/web-template/pull/380)
 - [change] Update SDK to v1.21.0 [#386](https://github.com/sharetribe/web-template/pull/386)
-- [change] Use `authInfo.isLoggedInAs` instead of relying on auth token's
-  `scope` to determine if current session is operator user logged in as
-  marketplace user [#386](https://github.com/sharetribe/web-template/pull/386)
-- [change] For login as, use `sdk.loginAs` instead of `sdk.login`, which is
-  deprecated for this purpose [#386](https://github.com/sharetribe/web-template/pull/386)
+
+  [v5.1.0]: https://github.com/sharetribe/web-template/compare/v5.0.1...v5.1.0
 
 ## [v5.0.1] 2024-04-30
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This  release contains several small updates:
- Updates SDK to v1.21.0
- Changes _login-as_ feature
- Adds autolinking to  **bio** in profile page, **description** in listing page, **listing fields** & **user fields** that are of schema type 'text', and **messages** between customer and provider. Note: only links starting with **_http_** are considered and the link is detected and added on UI rendering phase.
- Prepares codebase to **get the color of `<PrimeryButton>` from branding asset**.

## Translation changes
### New translation keys
```json
  "CustomExtendedDataField.numberTooSmall": "The number must be larger than or equal to {min}",
  "CustomExtendedDataField.numberTooBig":  "The number must be less than or equal to {max}",
  "LimitedAccessBanner.fullRightsMessage": "You're logged in as {firstName} {lastName}. You have full access rights. In a Live environment, you will have limited rights.",
  "LimitedAccessBanner.fallbackMessage": "You're logged in as {firstName} {lastName}.",
  "IntegerRangeFilter.labelSelectedPlain": "{minValue} - {maxValue}",
```
### Changed translations
```diff
-  "LimitedAccessBanner.message": "You are logged in as {firstName} {lastName}. You have limited rights for actions. You cannot initiate transactions, take actions in them or send messages on behalf of transacting parties.",
+  "LimitedAccessBanner.message": "You're logged in as {firstName} {lastName}. You have limited access rights. You can't initiate transactions, move them forward, or send messages on the user's behalf.",
```

## [Changes] v5.1.0

- [add] support for extended data fields with type `long`
  [#364](https://github.com/sharetribe/web-template/pull/364)
- [change] the login-as feature has changed:

  - Use `sdk.loginAs` instead of `sdk.login`, which is deprecated for this purpose
  - Use `authInfo.isLoggedInAs` instead of relying on auth token's `scope` to determine if current
    session is operator user logged in as marketplace user.
  - Note: when taking update from upstream, check also commit be7e2b9b4.

  [#386](https://github.com/sharetribe/web-template/pull/386)

- [fix] the email template for default-purchase process
  (purchase-order-canceled-from-disputed-provider-html.html) contained copy-paste related typo.
  [#390](https://github.com/sharetribe/web-template/pull/389)
- [add] Autolink text on the UI. Those links must start with 'http' to be recognized.

  - ListingPage > Listing's description
  - ListingPage > Listing fields with schema type ‘text’
  - ListingPage > User's bio on <UserCard>
  - ProfilePage > User's bio
  - ProfilePage > User fields with schema type ‘text’
  - TransactionPage > Messages
  - TransactionPage > inquiryMessage

  [#385](https://github.com/sharetribe/web-template/pull/385)

- [change] handle listings with draft and pending-approval state with login-as feature.
  [#387](https://github.com/sharetribe/web-template/pull/387)
- [Add] Get the color of the PrimeryButton from branding asset.
  [#379](https://github.com/sharetribe/web-template/pull/379)
- [change] Add preview resolution for listing in PreviewResolverPage
  [#384](https://github.com/sharetribe/web-template/pull/384)
- [add] Support for a target path parameter (target_path) in the login as user functionality
  [#383](https://github.com/sharetribe/web-template/pull/383)
- [change] listingMinimumPriceSubUnits: update code comments (0 is not valid value in hosted asset).
  [#381](https://github.com/sharetribe/web-template/pull/381)
- [fix] Styleguide shows multiple versions of some components. The 'id' attributes need to be
  unique. [#380](https://github.com/sharetribe/web-template/pull/380)
- [change] Update SDK to v1.21.0 [#386](https://github.com/sharetribe/web-template/pull/386)

  [Changes]: https://github.com/sharetribe/web-template/compare/v5.0.1...v5.1.0
