### PR TITLE
Use collectionOptions with Stripe onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [change] StripeConnectAccount: use 'collectionOptions' instead of deprecated 'collect'. The
+  future_requirements uses 'include' by default.
+  [#392](https://github.com/sharetribe/web-template/pull/392)
 - [fix] mergeDefaultTypesAndFieldsForDebugging was set to true, which is wrong. The 0 handling with
   min and max was wrong. [#393](https://github.com/sharetribe/web-template/pull/393)
 

--- a/src/ducks/stripeConnectAccount.duck.js
+++ b/src/ducks/stripeConnectAccount.duck.js
@@ -276,12 +276,17 @@ export const getStripeConnectAccountLink = params => (dispatch, getState, sdk) =
   const { failureURL, successURL, type } = params;
   dispatch(getAccountLinkRequest());
 
+  // Read more from collection_options and verification updates from Stripe's Docs:
+  // https://docs.stripe.com/connect/handle-verification-updates
   return sdk.stripeAccountLinks
     .create({
       failureURL,
       successURL,
       type,
-      collect: 'currently_due',
+      collectionOptions: {
+        fields: 'currently_due',
+        future_requirements: 'include',
+      },
     })
     .then(response => {
       // Return the account link


### PR DESCRIPTION
StripeConnectAccount: use 'collectionOptions' instead of deprecated 'collect'. The future_requirements uses 'include' by default.

https://docs.stripe.com/connect/handle-verification-updates
