### PR TITLE
Fix banned user on transaction page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] util/sanitize.js: handle publicData = null case which happens with banned user
+  [#397](https://github.com/sharetribe/web-template/pull/397)
 - [fix] en.json: typo on 'ModalMissingInformation.verifyEmailText'
   [#396](https://github.com/sharetribe/web-template/pull/396)
 - [fix] Ensure that there is listingType, transactionProcessAlias and unitType defined.

--- a/src/util/sanitize.js
+++ b/src/util/sanitize.js
@@ -162,16 +162,14 @@ const sanitizedExtendedDataFields = (value, config) => {
  * @returns
  */
 const sanitizeConfiguredPublicData = (publicData, config = {}) => {
-  const sanitizedConfiguredPublicData = Object.entries(publicData).reduce((sanitized, entry) => {
+  // The publicData could be null (e.g. for banned user)
+  const publicDataObj = publicData || {};
+  return Object.entries(publicDataObj).reduce((sanitized, entry) => {
     const [key, value] = entry;
     const foundListingFieldConfig = config?.listingFields?.find(d => d.key === key);
     const foundUserFieldConfig = config?.userFields?.find(d => d.key === key);
-    const sanitizedValue = [
-      'listingType',
-      'transactionProcessAlias',
-      'unitType',
-      'userType',
-    ].includes(key)
+    const knownKeysWithString = ['listingType', 'transactionProcessAlias', 'unitType', 'userType'];
+    const sanitizedValue = knownKeysWithString.includes(key)
       ? sanitizeText(value)
       : foundListingFieldConfig
       ? sanitizedExtendedDataFields(value, foundListingFieldConfig)
@@ -186,7 +184,6 @@ const sanitizeConfiguredPublicData = (publicData, config = {}) => {
       [key]: sanitizedValue,
     };
   }, {});
-  return sanitizedConfiguredPublicData;
 };
 
 /**


### PR DESCRIPTION
Transaction page for banned user showed fetch error (that's a bug). 
There was a bug introduced to sanitize.js: some past refactoring had forgotten that API could return null for the publicData.