### PR TITLE
Update SDK to v1.21.1 - Fix the issue with extended data with `length` key and a number value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] Update SDK to v1.21.1. Fixes bug with extended data with a key `length`
+  and a number type value.
+  [#398](https://github.com/sharetribe/web-template/pull/398)
 - [fix] util/sanitize.js: handle publicData = null case which happens with banned user
   [#397](https://github.com/sharetribe/web-template/pull/397)
 - [fix] en.json: typo on 'ModalMissingInformation.verifyEmailText'

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "remark-parse": "^9.0.0",
     "remark-rehype": "^8.1.0",
     "seedrandom": "^3.0.5",
-    "sharetribe-flex-sdk": "^1.21.0",
+    "sharetribe-flex-sdk": "^1.21.1",
     "sharetribe-scripts": "6.0.1",
     "sitemap": "^7.1.1",
     "smoothscroll-polyfill": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11533,10 +11533,10 @@ shallowequal@^1.1.0:
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
-sharetribe-flex-sdk@^1.21.0:
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/sharetribe-flex-sdk/-/sharetribe-flex-sdk-1.21.0.tgz#29c025215c8137a7dbf1a87ee9ee863da30eda25"
-  integrity sha512-RZyoU2hCHw6e6Ixgmt8AM9Umtg4lbW5D8GCyiDoNxMwyKgkglb0B9AKagT4WlgDJOr396UJo0xcfIoAEiQCBDg==
+sharetribe-flex-sdk@^1.21.1:
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/sharetribe-flex-sdk/-/sharetribe-flex-sdk-1.21.1.tgz#49f046db67a19d09ecf985d1c136b343c3f2b11b"
+  integrity sha512-3wqUhcqhfglnB2ndMwRzutXQyY3VzYr8vMktDKEINrLZ56X576tvN0ky+x70ichzGplv2TEk6nEdPWwb+41bbw==
   dependencies:
     axios "^1.5.1"
     js-cookie "^2.1.3"


### PR DESCRIPTION
Update SDK to v1.21.1 - Fix the issue with extended data with `length` key and a number value