### PR TITLE
Don't show out of stock for booking listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] Remove stock from schema if there's no stock in use.
+  [#405](https://github.com/sharetribe/web-template/pull/405)
 - [fix] Remove left-behind slash from inquiry-new-inquiry email template reference.
   [#406](https://github.com/sharetribe/web-template/pull/406)
 - [fix] The subject line of purchase-new-order email had a wrong variable name.

--- a/src/containers/ListingPage/ListingPageCarousel.js
+++ b/src/containers/ListingPage/ListingPageCarousel.js
@@ -279,8 +279,13 @@ export const ListingPageComponent = props => {
       }
     : {};
   const currentStock = currentListing.currentStock?.attributes?.quantity || 0;
-  const schemaAvailability =
-    currentStock > 0 ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock';
+  const schemaAvailability = !currentListing.currentStock
+    ? null
+    : currentStock > 0
+    ? 'https://schema.org/InStock'
+    : 'https://schema.org/OutOfStock';
+
+  const availabilityMaybe = schemaAvailability ? { availability: schemaAvailability } : {};
 
   return (
     <Page
@@ -300,7 +305,7 @@ export const ListingPageComponent = props => {
           '@type': 'Offer',
           url: productURL,
           ...schemaPriceMaybe,
-          availability: schemaAvailability,
+          ...availabilityMaybe,
         },
       }}
     >

--- a/src/containers/ListingPage/ListingPageCoverPhoto.js
+++ b/src/containers/ListingPage/ListingPageCoverPhoto.js
@@ -279,8 +279,13 @@ export const ListingPageComponent = props => {
       }
     : {};
   const currentStock = currentListing.currentStock?.attributes?.quantity || 0;
-  const schemaAvailability =
-    currentStock > 0 ? 'https://schema.org/InStock' : 'https://schema.org/OutOfStock';
+  const schemaAvailability = !currentListing.currentStock
+    ? null
+    : currentStock > 0
+    ? 'https://schema.org/InStock'
+    : 'https://schema.org/OutOfStock';
+
+  const availabilityMaybe = schemaAvailability ? { availability: schemaAvailability } : {};
 
   const handleViewPhotosClick = e => {
     // Stop event from bubbling up to prevent image click handler
@@ -307,7 +312,7 @@ export const ListingPageComponent = props => {
           '@type': 'Offer',
           url: productURL,
           ...schemaPriceMaybe,
-          availability: schemaAvailability,
+          ...availabilityMaybe,
         },
       }}
     >


### PR DESCRIPTION
For availability based listings, the page schema would always show "Out of stock". With this change, listings with availability plan do not have any stock information in their page schema.