### PR TITLE
Remove extra backslash from email template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] Remove left-behind slash from inquiry-new-inquiry email template reference.
+  [#406](https://github.com/sharetribe/web-template/pull/406)
 - [fix] The subject line of purchase-new-order email had a wrong variable name.
   [#413](https://github.com/sharetribe/web-template/pull/413)
 - [change] Fix another typo in FR translations.

--- a/ext/transaction-processes/default-inquiry/templates/inquiry-new-inquiry/inquiry-new-inquiry-html.html
+++ b/ext/transaction-processes/default-inquiry/templates/inquiry-new-inquiry/inquiry-new-inquiry-html.html
@@ -13,7 +13,7 @@
             <tr style="width:100%">
               <td>
                 <h1 style="color:#484848;font-size:26px;line-height:1.3;font-weight:700">{{t "InquiryNewInquiry.Title" "You have received a new inquiry" }}</h1>
-                <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">\{{t "InquiryNewInquiry.Content" "{customerDisplayName} sent you an inquiry in {marketplaceName} about {listingTitle}."  customerDisplayName=customer.display-name marketplaceName=marketplace.name listingTitle=listing.title }}</p>
+                <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848">{{t "InquiryNewInquiry.Content" "{customerDisplayName} sent you an inquiry in {marketplaceName} about {listingTitle}."  customerDisplayName=customer.display-name marketplaceName=marketplace.name listingTitle=listing.title }}</p>
                 <h2 style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848;font-weight:700">{{t "InquiryNewInquiry.MessageTitle" "Inquiry message:" }}</h2>
                 <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848;background-color:#F2F3F3;padding:18px 24px;border-radius:8px;white-space:pre-line;">{{protected-data.inquiryMessage}}</p>
                   <table style="padding:16px 0 0" align="center" role="presentation" cellSpacing="0" cellPadding="0" border="0" width="100%">


### PR DESCRIPTION
The extra backslash causes the translation helper to not work properly, and results in the template printing the translation helper instead of the message.

Before:
<img width="684" alt="Screenshot 2024-06-06 at 11 28 28" src="https://github.com/sharetribe/web-template/assets/89082356/35eb4097-ba53-4e5a-a083-bef6275c5c44">

After:
<img width="670" alt="Screenshot 2024-06-06 at 11 28 41" src="https://github.com/sharetribe/web-template/assets/89082356/697a3a1d-d05c-4295-b704-3f14784ede17">
