### PR TITLE
New patch release: v5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+## [v5.2.1] 2024-07-02
+
 - [fix] fix: calculateShippingFee (when shippingPriceInSubunitsAdditionalItems is 0, no shipping fee
   was included) [#414](https://github.com/sharetribe/web-template/pull/414)
 - [fix] Remove stock from schema if there's no stock in use.
@@ -32,6 +34,8 @@ way to update this template, but currently, we follow a pattern:
   [#403](https://github.com/sharetribe/web-template/pull/403)
 - [change] FilterComponent: relax generated name-attribute for inputs: allow camelCase.
   [#402](https://github.com/sharetribe/web-template/pull/402)
+
+  [v5.2.1]: https://github.com/sharetribe/web-template/compare/v5.2.0...v5.2.1
 
 ## [v5.2.0] 2024-05-28
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This is a patch release to fix one significant bug: when additional shipping fee was set to 0, there was no shipping fee included.

## [Changes] v5.2.1

- [fix] fix: calculateShippingFee (when shippingPriceInSubunitsAdditionalItems is 0, no shipping fee
  was included) [#414](https://github.com/sharetribe/web-template/pull/414)
- [fix] Remove stock from schema if there's no stock in use.
  [#405](https://github.com/sharetribe/web-template/pull/405)
- [fix] Remove left-behind slash from inquiry-new-inquiry email template reference.
  [#406](https://github.com/sharetribe/web-template/pull/406)
- [fix] The subject line of purchase-new-order email had a wrong variable name.
  [#413](https://github.com/sharetribe/web-template/pull/413)
- [change] Fix another typo in FR translations.
  [#409](https://github.com/sharetribe/web-template/pull/409)
- [change] Fix a typo in FR translations.
  [#408](https://github.com/sharetribe/web-template/pull/408)
- [add] Add currently available translations for de, es, fr.
  [#404](https://github.com/sharetribe/web-template/pull/404)
- [fix] The example files of SignupForm and ConfirmSignupForm had wrong data.
  [#403](https://github.com/sharetribe/web-template/pull/403)
- [change] FilterComponent: relax generated name-attribute for inputs: allow camelCase.
  [#402](https://github.com/sharetribe/web-template/pull/402)

  [Changes]: https://github.com/sharetribe/web-template/compare/v5.2.0...v5.2.1
