### PR TITLE
Fix rare indexing issues on search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] There could be rare time-windows when indexing has not caught up with deleted & closed
+  listings. This might result those listings to be included to listing queries.
+  [#417](https://github.com/sharetribe/web-template/pull/417)
+
 ## [v5.2.1] 2024-07-02
 
 - [fix] fix: calculateShippingFee (when shippingPriceInSubunitsAdditionalItems is 0, no shipping fee

--- a/src/containers/ProfilePage/ProfilePage.duck.js
+++ b/src/containers/ProfilePage/ProfilePage.duck.js
@@ -144,7 +144,10 @@ export const queryUserListings = (userId, config) => (dispatch, getState, sdk) =
     })
     .then(response => {
       // Pick only the id and type properties from the response listings
-      const listingRefs = response.data.data.map(({ id, type }) => ({ id, type }));
+      const listings = response.data.data;
+      const listingRefs = listings
+        .filter(l => l => !l.attributes.deleted && l.attributes.state === 'published')
+        .map(({ id, type }) => ({ id, type }));
       dispatch(addMarketplaceEntities(response));
       dispatch(queryListingsSuccess(listingRefs));
       return response;

--- a/src/containers/SearchPage/SearchPage.duck.js
+++ b/src/containers/SearchPage/SearchPage.duck.js
@@ -41,7 +41,12 @@ const initialState = {
   currentPageResultIds: [],
 };
 
-const resultIds = data => data.data.map(l => l.id);
+const resultIds = data => {
+  const listings = data.data;
+  return listings
+    .filter(l => !l.attributes.deleted && l.attributes.state === 'published')
+    .map(l => l.id);
+};
 
 const listingPageReducer = (state = initialState, action = {}) => {
   const { type, payload } = action;
@@ -294,6 +299,8 @@ export const loadData = (params, search, config) => (dispatch, getState, sdk) =>
         'title',
         'geolocation',
         'price',
+        'deleted',
+        'state',
         'publicData.listingType',
         'publicData.transactionProcessAlias',
         'publicData.unitType',


### PR DESCRIPTION
There could be moments where indexing has not caught up with listing deletion or state change (eg. from 'published' to 'closed').

So, it's safer to always fetch 'deleted' and 'state' attributes and discard listings that doesn't have correct data.