### PR TITLE
Fix: avoid bug in Safari (JSON-LD with array of entities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] Safari has a bug related to reading array directly from JSON-LD script tag.
+  [#418](https://github.com/sharetribe/web-template/pull/418)
 - [fix] There could be rare time-windows when indexing has not caught up with deleted & closed
   listings. This might result those listings to be included to listing queries.
   [#417](https://github.com/sharetribe/web-template/pull/417)

--- a/src/components/Page/Page.js
+++ b/src/components/Page/Page.js
@@ -197,26 +197,29 @@ class PageComponent extends Component {
     const hasSchema = schema != null;
     const schemaFromProps = hasSchema && Array.isArray(schema) ? schema : hasSchema ? [schema] : [];
     const addressMaybe = config.address?.streetAddress ? { address: config.address } : {};
-    const schemaArrayJSONString = JSON.stringify([
-      ...schemaFromProps,
-      {
-        '@context': 'http://schema.org',
-        '@type': 'Organization',
-        '@id': `${marketplaceRootURL}#organization`,
-        url: marketplaceRootURL,
-        name: marketplaceName,
-        sameAs: sameOrganizationAs,
-        logo: config.branding.logoImageMobileURL,
-        ...addressMaybe,
-      },
-      {
-        '@context': 'http://schema.org',
-        '@type': 'WebSite',
-        url: marketplaceRootURL,
-        description: schemaDescription,
-        name: schemaTitle,
-      },
-    ]);
+    const schemaArrayJSONString = JSON.stringify({
+      '@context': 'http://schema.org',
+      '@graph': [
+        ...schemaFromProps,
+        {
+          '@context': 'http://schema.org',
+          '@type': 'Organization',
+          '@id': `${marketplaceRootURL}#organization`,
+          url: marketplaceRootURL,
+          name: marketplaceName,
+          sameAs: sameOrganizationAs,
+          logo: config.branding.logoImageMobileURL,
+          ...addressMaybe,
+        },
+        {
+          '@context': 'http://schema.org',
+          '@type': 'WebSite',
+          url: marketplaceRootURL,
+          description: schemaDescription,
+          name: schemaTitle,
+        },
+      ],
+    });
 
     const scrollPositionStyles = scrollingDisabled
       ? { marginTop: `${-1 * this.scrollPosition}px` }


### PR DESCRIPTION
This is not a serious issue - and in fact it looks like to be a bug on Safari, since it doesn't accept an array as valid JSON-LD. 

The JSON-LD formatted schema is used by Search engine bots and they do recognize this as a valid JSON-LD. Therefore, the main problem is that this might cause noise on Safari's debugging tools.

