### PR TITLE
Change business URL for Stripe's onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ way to update this template, but currently, we follow a pattern:
 ---
 
 ## Upcoming version 2024-XX-XX
+
+- [change] ProfilePage: redirect Stripe's crawler to landing page (profile page might be empty).
+  [#430](https://github.com/sharetribe/web-template/pull/430)
 - [add] Add currently available translations for DE, ES, FR.
   [#429](https://github.com/sharetribe/web-template/pull/429)
 - [add] Handle API's new permission model & permission to post listings

--- a/src/components/StripeConnectAccountForm/StripeConnectAccountForm.js
+++ b/src/components/StripeConnectAccountForm/StripeConnectAccountForm.js
@@ -86,10 +86,11 @@ const CreateStripeAccountFields = props => {
         createResourceLocatorString('ProfilePage', routeConfiguration, { id: uuid }, {});
       const hasMarketplaceRootURL = !!marketplaceRootURL;
       const rootUrl = hasMarketplaceRootURL ? marketplaceRootURL.replace(/\/$/, '') : null;
-      const defaultBusinessURL =
+      const profilePageURL =
         hasMarketplaceRootURL && !rootUrl.includes('localhost')
           ? `${rootUrl}${pathToProfilePage(currentUserId.uuid)}`
           : `https://test-marketplace.com${pathToProfilePage(currentUserId.uuid)}`;
+      const defaultBusinessURL = `${profilePageURL}?mode=storefront`;
       form.change('businessProfileURL', defaultBusinessURL);
     }
 

--- a/src/containers/ProfilePage/ProfilePage.js
+++ b/src/containers/ProfilePage/ProfilePage.js
@@ -30,6 +30,7 @@ import {
   Reviews,
   ButtonTabNavHorizontal,
   LayoutSideNavigation,
+  NamedRedirect,
 } from '../../components';
 
 import TopbarContainer from '../../containers/TopbarContainer/TopbarContainer';
@@ -259,6 +260,19 @@ export const ProfilePageComponent = props => {
   const config = useConfiguration();
   const intl = useIntl();
   const { scrollingDisabled, currentUser, userShowError, user, ...rest } = props;
+
+  // Stripe's onboarding needs a business URL for each seller, but the profile page can be
+  // too empty for the provider at the time they are creating their first listing.
+  // To remedy the situation, we redirect Stripe's crawler to the landing page of the marketplace.
+  // TODO: When there's more content on the profile page, we should consider by-passing this redirection.
+  const searchParams = rest?.location?.search;
+  const isStorefront = searchParams
+    ? new URLSearchParams(searchParams)?.get('mode') === 'storefront'
+    : false;
+  if (isStorefront) {
+    return <NamedRedirect name="LandingPage" />;
+  }
+
   const ensuredCurrentUser = ensureCurrentUser(currentUser);
   const profileUser = ensureUser(user);
   const isCurrentUser =


### PR DESCRIPTION
Stripe's onboarding needs a business URL for each seller, but the profile page can be too empty for the provider at the time they are creating their first listing. (It can just show "Hi, I'm John".)

The profile page does not even have a listing at the time, because provider needs to have valid Stripe Connect account before a listing can be published (i.e. before it's bookable for customers).

To remedy the situation, this PR redirects Stripe's crawler to the landing page of the marketplace (with HTTP status 302).

The reason, why we didn't just send LandingPage URL, is that it gives the possibility to improve the ProfilePage later. E.g. when there's more content on the profile page, it's possible to consider by-passing this redirection. This way Stripe gets user-specific URL, which they can inspect later on.

Anyway, there's not enough information atm. about how much and what kind of content Stripe's evaluation algorithm needs. Although, LandingPage seems to satisfy it.

Future: we are also going to add support for **_private marketplaces_**, which means that Stripe won't be able to access profile page at all. This is another scenario, where redirection to LandingPage makes sense.