### PR TITLE
New release v5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+## [v5.3.0] 2024-08-13
+
 - [change] ProfilePage: redirect Stripe's crawler to landing page (profile page might be empty).
   [#430](https://github.com/sharetribe/web-template/pull/430)
 - [add] Add currently available translations for DE, ES, FR.
@@ -40,6 +42,8 @@ way to update this template, but currently, we follow a pattern:
 - [fix] There could be rare time-windows when indexing has not caught up with deleted & closed
   listings. This might result those listings to be included to listing queries.
   [#417](https://github.com/sharetribe/web-template/pull/417)
+
+  [v5.3.0]: https://github.com/sharetribe/web-template/compare/v5.2.1...v5.3.0
 
 ## [v5.2.1] 2024-07-02
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This adds support for upcoming permission feature: marketplace operator can grant/remove user's right to post listing.
The fetchCurrentUser call includes a new relationship: **effectivePermissionSet**. That resourece is the source of truth whether the user can create and publish listings or open previously closed listing. Read more from [the pull request](https://github.com/sharetribe/web-template/pull/426).

In addition, there are smaller fixes and improvements. Here's a couple of them highlighted:
- Stripe's onboarding needs a business URL for each seller, but the profile page can be too empty for the provider at the time they are creating their first listing. (It can just show "Hi, I'm John".) There has been reports from some new marketplaces that Stripe might block those sellers based on that info. We have decided to redirect Stripe to landing page - as that has more content for Stripe's algorithm to understand what's the business is about. 
#430
- Add support for parentheses on autolinked URLs on listing's description, user's bio, and messages.

## Translations

```json
  "NoAccessPage.postListings.schemaTitle": "No publishing rights",
  "NoAccessPage.postListings.heading": "You can't publish listings",
  "NoAccessPage.postListings.content": "You need to receive publishing rights from the {marketplaceName} team.",
```

## Changes
- [change] ProfilePage: redirect Stripe's crawler to landing page (profile page might be empty).
  [#430](https://github.com/sharetribe/web-template/pull/430)
- [add] Add currently available translations for DE, ES, FR.
  [#429](https://github.com/sharetribe/web-template/pull/429)
- [add] Handle API's new permission model & permission to post listings

  - CurrentUser fetch includes a new relationship: effectivePermissionSet
  - There is a new Page component: NoAccessPage
  - If user has no posting rights: they can't create or edit a draft listing and they can't open a
    previously closed published listing. Instead, they are redirected to NoAccessPage

  [#426](https://github.com/sharetribe/web-template/pull/426)

- [fix] Routes.js: reTry can be undefined in some cases (reTry.scrollIntoView)
  [#427](https://github.com/sharetribe/web-template/pull/427)
- [change] ProfilePage: remove withViewport and refactor a bit.
  [#424](https://github.com/sharetribe/web-template/pull/424)
- [change] Update express.js (v4.19.2) and nodemon (3.1.4).
  [#421](https://github.com/sharetribe/web-template/pull/421)
- [add] richText.js: support parentheses on autolinked URLs.
  [#419](https://github.com/sharetribe/web-template/pull/419)
- [fix] Safari has a bug related to reading array directly from JSON-LD script tag.
  [#418](https://github.com/sharetribe/web-template/pull/418)
- [fix] There could be rare time-windows when indexing has not caught up with deleted & closed
  listings. This might result those listings to be included to listing queries.
  [#417](https://github.com/sharetribe/web-template/pull/417)

  [v5.3.0]: https://github.com/sharetribe/web-template/compare/v5.2.1...v5.3.0