### PR TITLE
Private marketplace mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [add] Access control: private marketplace mode
+
+  - Fetch a new asset: /general/access-control.json to check private: true/false flag
+  - Make SearchPage, ListingPage, ProfilePage, Styleguide require authentication
+  - Ensure currentUser entity is loaded before loadData on client-side
+  - Restrict data load & add redirections for SearchPage, ListingPage, and ProfilePage
+
+  [#434](https://github.com/sharetribe/web-template/pull/434)
+
 - [add] Access control: 'pending-approval' state for users.
 
   - Users will get "state", which is exposed through currentUser's attribute

--- a/server/api-util/sdk.js
+++ b/server/api-util/sdk.js
@@ -186,3 +186,23 @@ exports.fetchBranding = sdk => {
     return response;
   });
 };
+
+// Fetch branding asset with 'latest' alias.
+// This is needed for generating webmanifest on server-side.
+exports.fetchAccessControlAsset = sdk => {
+  return sdk
+    .assetsByAlias({ paths: ['/general/access-control.json'], alias: 'latest' })
+    .then(response => {
+      // Let's throw an error if we can't fetch branding for some reason
+      const accessControlAsset = response?.data?.data?.[0];
+      if (!accessControlAsset) {
+        const message = 'access-control configuration was not available.';
+        const error = new Error(message);
+        error.status = 404;
+        error.statusText = message;
+        error.data = {};
+        throw error;
+      }
+      return response;
+    });
+};

--- a/server/resources/README.md
+++ b/server/resources/README.md
@@ -29,6 +29,11 @@ from `REACT_APP_MARKETPLACE_ROOT_URL`. This transformation is done by the actual
 **Note**: on localhost, this file is served from the Dev port on apiServer.js (3500 aka
 http://localhost:3500/robots.txt) for debugging purposes.
 
+### Robots.txt on private marketplace
+
+There's a more restrictive version of the robots.txt (robotsPrivateMarketplace.txt), which is used
+if access-control.json asset has private mode set active.
+
 ## Sitemap
 
 A [sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview) is a file
@@ -60,6 +65,8 @@ The sitemap-index.xml contains links to 3 different sub sitemaps:
 - sitemap-recent-listings.xml
 - sitemap-recent-pages.xml
 
+**Note**: sitemap-recent-listings.xml is not served if the private marketplace mode is activated.
+
 ### /sitemap-default.xml
 
 This sitemap contains links to public built-in pages of the client app. It also shows
@@ -71,10 +78,14 @@ sitemap. E.g. if you have added a category "hats", you could highlight that for 
 by adding `searchHats: { url: '/s?pub_category=hats' }` to variable **defaultPublicPaths** on
 sitemap.js.
 
+**Note**: search page is not served if the private marketplace mode is activated.
+
 ### /sitemap-recent-listings.xml
 
 The recent listings is the heaviest file to be returned. Marketplace API returns max 10,000 recent
 listings, from which the XML syntax is created and the result is compressed.
+
+**Note**: sitemap-recent-listings.xml is not served if the private marketplace mode is activated.
 
 ### /sitemap-recent-pages.xml
 

--- a/server/resources/robotsPrivateMarketplace.txt
+++ b/server/resources/robotsPrivateMarketplace.txt
@@ -1,0 +1,21 @@
+#
+# Hello bot! There are some routes that need authentication. You should avoid them :)
+#
+
+User-agent: *
+Disallow: /s
+Disallow: /u
+Disallow: /l
+Disallow: /profile-settings
+Disallow: /inbox
+Disallow: /order
+Disallow: /sale
+Disallow: /listings
+Disallow: /account
+Disallow: /reset-password
+Disallow: /verify-email
+Disallow: /preview
+Disallow: /styleguide
+Crawl-Delay: 5
+
+Sitemap: https://my.marketplace.com/sitemap-index.xml

--- a/src/app.js
+++ b/src/app.js
@@ -148,7 +148,7 @@ const MomentLocaleLoader = props => {
 
 const Configurations = props => {
   const { appConfig, children } = props;
-  const routeConfig = routeConfiguration(appConfig.layout);
+  const routeConfig = routeConfiguration(appConfig.layout, appConfig?.accessControl);
   const locale = isTestEnv ? 'en' : appConfig.localization.locale;
 
   return (

--- a/src/config/configDefault.js
+++ b/src/config/configDefault.js
@@ -92,6 +92,9 @@ const defaultConfig = {
     topbar: '/content/top-bar.json',
     branding: '/design/branding.json',
     layout: '/design/layout.json',
+    userTypes: '/users/user-types.json',
+    userFields: '/users/user-fields.json',
+    categories: '/listings/listing-categories.json',
     listingTypes: '/listings/listing-types.json',
     listingFields: '/listings/listing-fields.json',
     search: '/listings/listing-search.json',
@@ -99,14 +102,12 @@ const defaultConfig = {
     analytics: '/integrations/analytics.json',
     googleSearchConsole: '/integrations/google-search-console.json',
     maps: '/integrations/map.json',
-    categories: '/listings/listing-categories.json',
     // These assets are not yet editable through Console.
     // However, Sharetribe onboarding might generate them.
     // You could still rely on built-in variables and comment these out.
     localization: '/general/localization.json',
+    accessControl: '/general/access-control.json',
     // NOTE: we don't fetch commission configuration here but on the server-side
-    userTypes: '/users/user-types.json',
-    userFields: '/users/user-fields.json',
   },
 
   // Optional

--- a/src/containers/ListingPage/ListingPageCarousel.js
+++ b/src/containers/ListingPage/ListingPageCarousel.js
@@ -17,7 +17,10 @@ import {
   LISTING_PAGE_PARAM_TYPE_DRAFT,
   LISTING_PAGE_PARAM_TYPE_EDIT,
   createSlug,
+  NO_ACCESS_PAGE_USER_PENDING_APPROVAL,
 } from '../../util/urlHelpers';
+import { isErrorUserPendingApproval, isForbiddenError } from '../../util/errors.js';
+import { isUserAuthorized } from '../../util/userHelpers.js';
 import { convertMoneyToNumber } from '../../util/currency';
 import {
   ensureListing,
@@ -489,6 +492,31 @@ const EnhancedListingPage = props => {
   const intl = useIntl();
   const history = useHistory();
   const location = useLocation();
+
+  const showListingError = props.showListingError;
+  const isVariant = props.params?.variant?.length > 0;
+  if (isForbiddenError(showListingError) && !isVariant) {
+    // This can happen if private marketplace mode is active
+    return (
+      <NamedRedirect
+        name="SignupPage"
+        state={{ from: `${location.pathname}${location.search}${location.hash}` }}
+      />
+    );
+  }
+
+  const currentUser = props.currentUser;
+  const isPrivateMarketplace = config.accessControl.marketplace.private === true;
+  const isUnauthorizedUser = currentUser && !isUserAuthorized(currentUser);
+  const hasUserPendingApprovalError = isErrorUserPendingApproval(showListingError);
+  if ((isPrivateMarketplace && isUnauthorizedUser) || hasUserPendingApprovalError) {
+    return (
+      <NamedRedirect
+        name="NoAccessPage"
+        params={{ missingAccessRight: NO_ACCESS_PAGE_USER_PENDING_APPROVAL }}
+      />
+    );
+  }
 
   return (
     <ListingPageComponent

--- a/src/containers/SearchPage/SearchPageWithMap.js
+++ b/src/containers/SearchPage/SearchPageWithMap.js
@@ -7,23 +7,25 @@ import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
 import classNames from 'classnames';
 
-import { useIntl, intlShape, FormattedMessage } from '../../util/reactIntl';
 import { useConfiguration } from '../../context/configurationContext';
 import { useRouteConfiguration } from '../../context/routeConfigurationContext';
 
-import { createResourceLocatorString, pathByRouteName } from '../../util/routes';
+import { useIntl, intlShape, FormattedMessage } from '../../util/reactIntl';
 import {
   isAnyFilterActive,
   isMainSearchTypeKeywords,
   isOriginInUse,
   getQueryParamNames,
 } from '../../util/search';
-import { parse } from '../../util/urlHelpers';
+import { NO_ACCESS_PAGE_USER_PENDING_APPROVAL, parse } from '../../util/urlHelpers';
+import { createResourceLocatorString, pathByRouteName } from '../../util/routes';
 import { propTypes } from '../../util/types';
+import { isErrorUserPendingApproval, isForbiddenError } from '../../util/errors';
+import { isUserAuthorized } from '../../util/userHelpers';
 import { getListingsById } from '../../ducks/marketplaceData.duck';
 import { manageDisableScrolling, isScrollingDisabled } from '../../ducks/ui.duck';
 
-import { H3, H5, ModalInMobile, Page } from '../../components';
+import { H3, H5, ModalInMobile, NamedRedirect, Page } from '../../components';
 import TopbarContainer from '../../containers/TopbarContainer/TopbarContainer';
 
 import { setActiveListing } from './SearchPage.duck';
@@ -628,6 +630,30 @@ const EnhancedSearchPage = props => {
   const history = useHistory();
   const location = useLocation();
 
+  const searchListingsError = props.searchListingsError;
+  if (isForbiddenError(searchListingsError)) {
+    // This can happen if private marketplace mode is active
+    return (
+      <NamedRedirect
+        name="SignupPage"
+        state={{ from: `${location.pathname}${location.search}${location.hash}` }}
+      />
+    );
+  }
+
+  const { currentUser, ...restOfProps } = props;
+  const isPrivateMarketplace = config.accessControl.marketplace.private === true;
+  const isUnauthorizedUser = currentUser && !isUserAuthorized(currentUser);
+  const hasUserPendingApprovalError = isErrorUserPendingApproval(searchListingsError);
+  if ((isPrivateMarketplace && isUnauthorizedUser) || hasUserPendingApprovalError) {
+    return (
+      <NamedRedirect
+        name="NoAccessPage"
+        params={{ missingAccessRight: NO_ACCESS_PAGE_USER_PENDING_APPROVAL }}
+      />
+    );
+  }
+
   return (
     <SearchPageComponent
       config={config}
@@ -635,12 +661,13 @@ const EnhancedSearchPage = props => {
       intl={intl}
       history={history}
       location={location}
-      {...props}
+      {...restOfProps}
     />
   );
 };
 
 const mapStateToProps = state => {
+  const { currentUser } = state.user;
   const {
     currentPageResultIds,
     pagination,
@@ -652,6 +679,7 @@ const mapStateToProps = state => {
   const listings = getListingsById(state, currentPageResultIds);
 
   return {
+    currentUser,
     listings,
     pagination,
     scrollingDisabled: isScrollingDisabled(state),

--- a/src/ducks/user.duck.js
+++ b/src/ducks/user.duck.js
@@ -251,12 +251,12 @@ export const fetchCurrentUserHasListings = () => (dispatch, getState, sdk) => {
   const params = {
     // Since we are only interested in if the user has published
     // listings, we only need at most one result.
-    authorId: currentUser.id.uuid,
+    states: 'published',
     page: 1,
     perPage: 1,
   };
 
-  return sdk.listings
+  return sdk.ownListings
     .query(params)
     .then(response => {
       const hasListings = response.data.data && response.data.data.length > 0;

--- a/src/index.js
+++ b/src/index.js
@@ -60,15 +60,15 @@ const render = (store, shouldHydrate) => {
   const info = authInfoLoaded ? Promise.resolve({}) : store.dispatch(authInfo());
   info
     .then(() => {
-      store.dispatch(fetchCurrentUser());
       // Ensure that Loadable Components is ready
       // and fetch hosted assets in parallel before initializing the ClientApp
       return Promise.all([
         loadableReady(),
         store.dispatch(fetchAppAssets(defaultConfig.appCdnAssets, cdnAssetsVersion)),
+        store.dispatch(fetchCurrentUser()),
       ]);
     })
-    .then(([_, fetchedAppAssets]) => {
+    .then(([_, fetchedAppAssets, cu]) => {
       const { translations: translationsRaw, ...rest } = fetchedAppAssets || {};
       // We'll handle translations as a separate data.
       // It's given to React Intl instead of pushing to config Context

--- a/src/routing/routeConfiguration.js
+++ b/src/routing/routeConfiguration.js
@@ -61,13 +61,16 @@ const RedirectToLandingPage = () => <NamedRedirect name="LandingPage" />;
 
 // Our routes are exact by default.
 // See behaviour from Routes.js where Route is created.
-const routeConfiguration = (layoutConfig) => {
+const routeConfiguration = (layoutConfig, accessControlConfig) => {
   const SearchPage = layoutConfig.searchPage?.variantType === 'map' 
     ? SearchPageWithMap 
     : SearchPageWithGrid;
   const ListingPage = layoutConfig.listingPage?.variantType === 'carousel' 
     ? ListingPageCarousel 
     : ListingPageCoverPhoto;
+
+  const isPrivateMarketplace = accessControlConfig?.marketplace?.private === true;
+  const authForPrivateMarketplace = isPrivateMarketplace ? { auth: true } : {};
   
   return [
     {
@@ -85,6 +88,7 @@ const routeConfiguration = (layoutConfig) => {
     {
       path: '/s',
       name: 'SearchPage',
+      ...authForPrivateMarketplace,
       component: SearchPage,
       loadData: pageDataLoadingAPI.SearchPage.loadData,
     },
@@ -96,6 +100,7 @@ const routeConfiguration = (layoutConfig) => {
     {
       path: '/l/:slug/:id',
       name: 'ListingPage',
+      ...authForPrivateMarketplace,
       component: ListingPage,
       loadData: pageDataLoadingAPI.ListingPage.loadData,
     },
@@ -145,6 +150,7 @@ const routeConfiguration = (layoutConfig) => {
     {
       path: '/l/:id',
       name: 'ListingPageCanonical',
+      ...authForPrivateMarketplace,
       component: ListingPage,
       loadData: pageDataLoadingAPI.ListingPage.loadData,
     },
@@ -156,6 +162,7 @@ const routeConfiguration = (layoutConfig) => {
     {
       path: '/u/:id',
       name: 'ProfilePage',
+      ...authForPrivateMarketplace,
       component: ProfilePage,
       loadData: pageDataLoadingAPI.ProfilePage.loadData,
     },
@@ -327,26 +334,31 @@ const routeConfiguration = (layoutConfig) => {
     {
       path: '/styleguide',
       name: 'Styleguide',
+      ...authForPrivateMarketplace,
       component: StyleguidePage,
     },
     {
       path: '/styleguide/g/:group',
       name: 'StyleguideGroup',
+      ...authForPrivateMarketplace,
       component: StyleguidePage,
     },
     {
       path: '/styleguide/c/:component',
       name: 'StyleguideComponent',
+      ...authForPrivateMarketplace,
       component: StyleguidePage,
     },
     {
       path: '/styleguide/c/:component/:example',
       name: 'StyleguideComponentExample',
+      ...authForPrivateMarketplace,
       component: StyleguidePage,
     },
     {
       path: '/styleguide/c/:component/:example/raw',
       name: 'StyleguideComponentExampleRaw',
+      ...authForPrivateMarketplace,
       component: StyleguidePage,
       extraProps: { raw: true },
     },

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -73,6 +73,18 @@ const hasClashWithBuiltInPublicDataKey = listingFields => {
   return hasClash;
 };
 
+/**
+ * This ensures that accessControl config has private marketplace flag in place.
+ *
+ * @param {Object} accessControlConfig (returned by access-control.json)
+ * @returns {Object} accessControl config
+ */
+const validAccessControl = accessControlConfig => {
+  const accessControl = accessControlConfig || {};
+  const marketplace = accessControl?.marketplace || {};
+  return { ...accessControl, marketplace: { private: false, ...marketplace } };
+};
+
 /////////////////////////
 // Merge localizations //
 /////////////////////////
@@ -1379,6 +1391,9 @@ export const mergeConfig = (configAsset = {}, defaultConfigs = {}) => {
     ...defaultConfigs,
 
     marketplaceRootURL: cleanedRootURL,
+
+    // AccessControl config contains a flag whether the marketplace is private.
+    accessControl: validAccessControl(configAsset.accessControl),
 
     // Overwrite default configs if hosted config is available
     listingMinimumPriceSubUnits,

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -10,6 +10,8 @@
  */
 
 import {
+  ERROR_CODE_FORBIDDEN,
+  ERROR_CODE_NOT_FOUND,
   ERROR_CODE_TRANSACTION_LISTING_NOT_FOUND,
   ERROR_CODE_TRANSACTION_INVALID_TRANSITION,
   ERROR_CODE_TRANSACTION_ALREADY_REVIEWED_BY_CUSTOMER,
@@ -26,6 +28,7 @@ import {
   ERROR_CODE_STOCK_OLD_TOTAL_MISMATCH,
   ERROR_CODE_PERMISSION_DENIED_POST_LISTINGS,
   ERROR_CODE_PERMISSION_DENIED_PENDING_APPROVAL,
+  ERROR_CODE_USER_PENDING_APPROVAL,
 } from './types';
 // NOTE: This file imports types.js, which may lead to circular dependency
 
@@ -45,6 +48,16 @@ const hasErrorWithCode = (error, code) => {
 const responseAPIErrors = error => {
   return error && error.data && error.data.errors ? error.data.errors : [];
 };
+
+/**
+ * 403 Forbidden
+ */
+export const isForbiddenError = error => hasErrorWithCode(error, ERROR_CODE_FORBIDDEN);
+
+/**
+ * 404 Not Found
+ */
+export const isNotFoundError = error => hasErrorWithCode(error, ERROR_CODE_NOT_FOUND);
 
 /**
  * 429 Too Many Requests error
@@ -255,6 +268,13 @@ export const isErrorNoPermissionForUserPendingApproval = error =>
   error &&
   error.status === 403 &&
   hasErrorWithCode(error, ERROR_CODE_PERMISSION_DENIED_PENDING_APPROVAL);
+
+/**
+ * Check if the given API error (from `sdk.listings.query(params)`
+ * is due to denied permission for users in pending-approval state.
+ */
+export const isErrorUserPendingApproval = error =>
+  error && error.status === 403 && hasErrorWithCode(error, ERROR_CODE_USER_PENDING_APPROVAL);
 
 /**
  * Check if the given API error (from

--- a/src/util/types.js
+++ b/src/util/types.js
@@ -645,6 +645,7 @@ export const ERROR_CODE_MISSING_STRIPE_ACCOUNT = 'transaction-missing-stripe-acc
 export const ERROR_CODE_STOCK_OLD_TOTAL_MISMATCH = 'old-total-mismatch';
 export const ERROR_CODE_PERMISSION_DENIED_POST_LISTINGS = 'permission-denied-post-listings';
 export const ERROR_CODE_PERMISSION_DENIED_PENDING_APPROVAL = 'permission-denied-pending-approval';
+export const ERROR_CODE_USER_PENDING_APPROVAL = 'user-pending-approval';
 
 const ERROR_CODES = [
   ERROR_CODE_TRANSACTION_LISTING_NOT_FOUND,
@@ -666,6 +667,7 @@ const ERROR_CODES = [
   ERROR_CODE_STOCK_OLD_TOTAL_MISMATCH,
   ERROR_CODE_PERMISSION_DENIED_POST_LISTINGS,
   ERROR_CODE_PERMISSION_DENIED_PENDING_APPROVAL,
+  ERROR_CODE_USER_PENDING_APPROVAL,
 ];
 
 // API error


### PR DESCRIPTION
This allows you to make your marketplace private.

## Upcoming API Impact
When the marketplace is set to private, the following API endpoints become restricted:
- GET "/users/show"
- GET "/listings/show"
- GET "/listings/query"
- GET "/timeslots/query"
- GET "/reviews/query"
- GET "/reviews/show"
- GET "/sitemap_data/query_listings"

## Affected public routes on template
The following public routes are impacted and become private:
- SearchPage (`/s`)
- ListingPage (`/l/:slug/:id` & `/l/:id`)
- ProfilePage (`/u/:id`)
- Styleguide (`/styleguide`)

## Behavioral changes when private marketplace is enabled
- The **_unauthenticated_** users:
  - Redirected to the _SignupPage_ when attempting to access any of the affected routes.
- The **_pending-approval_** users:
  - Redirected to the **NoAccessPage** (`/no-user-approval`) when attempting to access search, listing, or profile page.
- The **_active_** users:
  - Can access and view the content of the affected routes normally.

## SEO considerations
- **_/robots.txt_**: disallow also `/s`, `/l`,  and `/u`
  - There's a simple memory cache added (1 day) to reduce the load on your Node server.
- **_/sitemap-index.xml_**: don't list the _sitemap-recent-listings.xml_
- **_/sitemap-recent-listings.xml_**: 404 File Not Found
- **_/sitemap-default.xml_**: `/s` is not included.

## Notes
It's also possible that the **_access-control.json_ asset is out of sync**! 
This can happen because there's a cache on live environments. In addition, a client app fetches it only on full page load.
- Outdated asset with `marketplace.private: true`: app behaves as private marketplace
- Outdated asset with `marketplace.private: false`: app shows those pages
  - If API returns 403 Forbidden for the query & show endpoints, user is redirected to SignupPage or NoAccessPage
  
> To test how the app handles out-of-sync scenarios:
> 1. Ensure the marketplace is public.
> 2. Reload the client app (to load the current _access-control.json_ asset).
> 3. Switch the marketplace to private.
> 4. Click on links leading to the SearchPage, ListingPage, or ProfilePage. Depending on the user's authentication & state, different results should appear.

### About implementation:
The routeConfiguration.js needs info from _/general/access-control.json_ asset. If the marketplace has "private" flag on, it adds `auth:true` flag to the aforementioned routes.

Then the affected pages (SearchPage, ListingPage, and ProfilePage)
a) restrict what data they fetch on loadData
b) redirect users to Signup or NoAccessPage depending on the private marketplace mode & error thrown by API.

On client-side rendering, there's fetch for the currentUser entity and it's enforced to happen before loadData call is made. However, on SSR the currentUser entity is not fetched. (We try to avoid the SSR from being user-specific.)