### PR TITLE
auth.duck.js: login should wait currentUser entity to be loaded 

### DIFF
--- a/src/ducks/auth.duck.js
+++ b/src/ducks/auth.duck.js
@@ -179,8 +179,8 @@ export const login = (username, password) => (dispatch, getState, sdk) => {
   // just dispatches the login error action.
   return sdk
     .login({ username, password })
+    .then(() => dispatch(fetchCurrentUser({ afterLogin: true })))
     .then(() => dispatch(loginSuccess()))
-    .then(() => dispatch(fetchCurrentUser()))
     .catch(e => dispatch(loginError(storableError(e))));
 };
 

--- a/src/ducks/auth.test.js
+++ b/src/ducks/auth.test.js
@@ -1,8 +1,16 @@
 import * as log from '../util/log';
 import { storableError } from '../util/errors';
-import { clearCurrentUser, currentUserShowRequest, currentUserShowSuccess } from './user.duck';
+import { createCurrentUser } from '../util/testData';
+import {
+  clearCurrentUser,
+  currentUserShowRequest,
+  currentUserShowSuccess,
+  fetchCurrentUserNotificationsRequest,
+  fetchCurrentUserNotificationsSuccess,
+} from './user.duck';
 import reducer, {
   authenticationInProgress,
+  authInfoRequest,
   authInfoSuccess,
   login,
   loginRequest,
@@ -188,7 +196,15 @@ describe('auth duck', () => {
     it('should dispatch success and fetch current user', () => {
       const initialState = reducer();
       const getState = () => ({ auth: initialState });
-      const sdk = { login: jest.fn(() => Promise.resolve({})) };
+      const fakeCurrentUser = createCurrentUser({ id: 'test-user' });
+      const fakeCurrentUserResponse = { data: { data: fakeCurrentUser, include: [] } };
+      const fakeTransactionsResponse = { data: { data: [], include: [] } };
+      const sdk = {
+        login: jest.fn(() => Promise.resolve({})),
+        authInfo: jest.fn(() => Promise.resolve({})),
+        currentUser: { show: jest.fn(() => Promise.resolve(fakeCurrentUserResponse)) },
+        transactions: { query: jest.fn(() => Promise.resolve(fakeTransactionsResponse)) },
+      };
       const dispatch = createFakeDispatch(getState, sdk);
       const username = 'x.x@example.com';
       const password = 'pass';
@@ -197,13 +213,13 @@ describe('auth duck', () => {
         expect(sdk.login.mock.calls).toEqual([[{ username, password }]]);
         expect(dispatchedActions(dispatch)).toEqual([
           loginRequest(),
-          loginSuccess(),
           currentUserShowRequest(),
-
-          // Test restriction: Since the getState mock always returns
-          // the initial state, user isn't marked as logged in and
-          // current user is still null.
-          currentUserShowSuccess(null),
+          currentUserShowSuccess(fakeCurrentUser),
+          fetchCurrentUserNotificationsRequest(),
+          authInfoRequest(),
+          fetchCurrentUserNotificationsSuccess([]),
+          authInfoSuccess({}),
+          loginSuccess(),
         ]);
       });
     });
@@ -335,11 +351,17 @@ describe('auth duck', () => {
 
   describe('signup thunk', () => {
     it('should dispatch success and login', () => {
+      const fakeCurrentUser = createCurrentUser({ id: 'test-user' });
+      const fakeCurrentUserResponse = { data: { data: fakeCurrentUser, include: [] } };
+      const fakeTransactionsResponse = { data: { data: [], include: [] } };
       const sdk = {
         currentUser: {
           create: jest.fn(() => Promise.resolve({})),
+          show: jest.fn(() => Promise.resolve(fakeCurrentUserResponse)),
         },
         login: jest.fn(() => Promise.resolve({})),
+        authInfo: jest.fn(() => Promise.resolve({})),
+        transactions: { query: jest.fn(() => Promise.resolve(fakeTransactionsResponse)) },
       };
       const getState = () => ({ auth: state });
       const dispatch = createFakeDispatch(getState, sdk);
@@ -363,13 +385,13 @@ describe('auth duck', () => {
           signupRequest(),
           signupSuccess(),
           loginRequest(),
-          loginSuccess(),
           currentUserShowRequest(),
-
-          // Test restriction: Since the getState mock always returns
-          // the initial state, user isn't marked as logged in and
-          // current user is still null.
-          currentUserShowSuccess(null),
+          currentUserShowSuccess(fakeCurrentUser),
+          fetchCurrentUserNotificationsRequest(),
+          authInfoRequest(),
+          fetchCurrentUserNotificationsSuccess([]),
+          authInfoSuccess({}),
+          loginSuccess(),
         ]);
       });
     });

--- a/src/ducks/user.duck.js
+++ b/src/ducks/user.duck.js
@@ -193,7 +193,7 @@ const fetchCurrentUserHasListingsError = e => ({
   payload: e,
 });
 
-const fetchCurrentUserNotificationsRequest = () => ({
+export const fetchCurrentUserNotificationsRequest = () => ({
   type: FETCH_CURRENT_USER_NOTIFICATIONS_REQUEST,
 });
 
@@ -323,7 +323,8 @@ export const fetchCurrentUser = options => (dispatch, getState, sdk) => {
   const state = getState();
   const { currentUserHasListings, currentUserShowTimestamp } = state.user || {};
   const { isAuthenticated } = state.auth;
-  const { callParams = null, updateHasListings = true, updateNotifications = true } = options || {};
+  const { callParams = null, updateHasListings = true, updateNotifications = true, afterLogin } =
+    options || {};
 
   // Double fetch might happen when e.g. profile page is making a full page load
   const aSecondAgo = new Date().getTime() - 1000;
@@ -333,7 +334,7 @@ export const fetchCurrentUser = options => (dispatch, getState, sdk) => {
   // Set in-progress, no errors
   dispatch(currentUserShowRequest());
 
-  if (!isAuthenticated) {
+  if (!isAuthenticated && !afterLogin) {
     // Make sure current user is null
     dispatch(currentUserShowSuccess(null));
     return Promise.resolve({});


### PR DESCRIPTION
before calling loginSuccess. This would ensure that currentUser entity is available for loadData functions on different pages on CSR. This became apparent on private marketplace affected routes: they should be able to load data after auth redirection.