### PR TITLE
New release: v5.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+## [v5.4.0] 2024-08-20
+
+- [change] auth.duck.js: login flow should wait for currentUser entity be loaded.
+  [#436](https://github.com/sharetribe/web-template/pull/436)
 - [add] Access control: private marketplace mode
 
   - Fetch a new asset: /general/access-control.json to check private: true/false flag
@@ -39,6 +43,8 @@ way to update this template, but currently, we follow a pattern:
 
 - [fix] SearchPage: SearchFiltersMobile (modal) should be above topbar.
   [#432](https://github.com/sharetribe/web-template/pull/432)
+
+  [v5.4.0]: https://github.com/sharetribe/web-template/compare/v5.3.0...v5.4.0
 
 ## [v5.3.0] 2024-08-13
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This release prepares the template to work with 2 new access control features:
- The currentUser entity will have **state** attribute. 
  - The possible values are 'pending-approval', 'active', and 'banned'.
  - **The _'pending-approval'_ state is completely new**.
    - This state is only used if marketplace operator has manually enabled the user approval process from Access control asset
- **Private marketplace mode**
  - Set through Access control page on Console
  - The asset _/general/access-control.json_ is fetched o check marketplace.private: true/false flag

**Note**: it might take some time before those features are fully released. I.e. this just prepares Sharetribe Web Template for the upcoming change.

## Translations
```json
  "InquiryForm.userPendingApprovalError": "Oops, something went wrong. You don't have permission to make inquiries",
  "NoAccessPage.userPendingApproval.schemaTitle": "No user approval",
  "NoAccessPage.userPendingApproval.heading": "Your account is waiting for approval",
  "NoAccessPage.userPendingApproval.content": "Your account needs to be approved by the {marketplaceName} team before you can start using it.",  
```

## Changes

- [change] auth.duck.js: login flow should wait for currentUser entity be loaded.
  [#436](https://github.com/sharetribe/web-template/pull/436)
- [add] Access control: private marketplace mode

  - Fetch a new asset: /general/access-control.json to check private: true/false flag
  - Make SearchPage, ListingPage, ProfilePage, Styleguide require authentication
  - Ensure currentUser entity is loaded before loadData on client-side
  - Restrict data load & add redirections for SearchPage, ListingPage, and ProfilePage

  [#434](https://github.com/sharetribe/web-template/pull/434)

- [add] Access control: 'pending-approval' state for users.

  - Users will get "state", which is exposed through currentUser's attribute
  - A new state is "pending-approval", which restricts user from initiating transactions and posting
    listings.
  - In addition, 'banned' users will also have state 'banned'.
  - Extra: Routes.js: do not allow banned users to auth pages
  - [fix]: InboxPage.duck.js: include deleted and banned attributes
  - [fix]: ModalMissingInformation: only 'active' users get this modal shown
  - [fix]: Inquiry modal: open the modal after authentication
  - Some util-file imports have been reordered (might cause conflicts)

  [#428](https://github.com/sharetribe/web-template/pull/428)

- [fix] SearchPage: SearchFiltersMobile (modal) should be above topbar.
  [#432](https://github.com/sharetribe/web-template/pull/432)

  [v5.4.0]: https://github.com/sharetribe/web-template/compare/v5.3.0...v5.4.0
