### PR TITLE
Make Block's propType blockId optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [change] Make the propType blockId optional for all Block types. [#444](https://github.com/sharetribe/web-template/pull/444)
 - [change] Updates to the configuration script. Marketplace name is now prompted in the mandatory
   settings. [#440](https://github.com/sharetribe/web-template/pull/440)
 - [change] Update one copy text. [#439](https://github.com/sharetribe/web-template/pull/439)

--- a/src/containers/PageBuilder/BlockBuilder/BlockDefault/BlockDefault.js
+++ b/src/containers/PageBuilder/BlockBuilder/BlockDefault/BlockDefault.js
@@ -73,7 +73,7 @@ BlockDefault.defaultProps = {
 };
 
 BlockDefault.propTypes = {
-  blockId: string.isRequired,
+  blockId: string,
   className: string,
   rootClassName: string,
   mediaClassName: string,

--- a/src/containers/PageBuilder/BlockBuilder/BlockFooter/BlockFooter.js
+++ b/src/containers/PageBuilder/BlockBuilder/BlockFooter/BlockFooter.js
@@ -36,7 +36,7 @@ BlockFooter.defaultProps = {
 };
 
 BlockFooter.propTypes = {
-  blockId: string.isRequired,
+  blockId: string,
   className: string,
   rootClassName: string,
   textClassName: string,

--- a/src/containers/PageBuilder/BlockBuilder/BlockSocialMediaLink/BlockSocialMediaLink.js
+++ b/src/containers/PageBuilder/BlockBuilder/BlockSocialMediaLink/BlockSocialMediaLink.js
@@ -36,7 +36,7 @@ BlockSocialMediaLink.defaultProps = {
 };
 
 BlockSocialMediaLink.propTypes = {
-  blockId: string.isRequired,
+  blockId: string,
   className: string,
   rootClassName: string,
   link: propTypeLink,


### PR DESCRIPTION
This PR makes the propType `blockId` optional for all Block types. This follows the changes in Console where the Block ID is no longer a required field. 