### PR TITLE
V5.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,19 +14,20 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
-- [change] Make the propType blockId optional for all Block types. [#444](https://github.com/sharetribe/web-template/pull/444)
-- [change] Updates to the configuration script. Marketplace name is now prompted in the mandatory
-  settings. [#440](https://github.com/sharetribe/web-template/pull/440)
-- [change] Update one copy text. [#439](https://github.com/sharetribe/web-template/pull/439)
 - [add] Add currently available translations for DE, ES, FR.
   [#445](https://github.com/sharetribe/web-template/pull/445)
-
-## [v5.4.0] 2024-08-20
-
+- [change] Make the propType blockId optional for all Block types.
+  [#444](https://github.com/sharetribe/web-template/pull/444)
 - [change] Update Sentry (v6.19.7 -> v8.26.0). Add ignoreErrors setup, add CSP directives and avoid
   some errors. [#441](https://github.com/sharetribe/web-template/pull/441)
 - [fix] ListingPage: the optional chaining for processType variable was faulty.
   [#443](https://github.com/sharetribe/web-template/pull/443)
+- [change] Updates to the configuration script. Marketplace name is now prompted in the mandatory
+  settings. [#440](https://github.com/sharetribe/web-template/pull/440)
+- [change] Update one copy text. [#439](https://github.com/sharetribe/web-template/pull/439)
+
+## [v5.4.0] 2024-08-20
+
 - [change] auth.duck.js: login flow should wait for currentUser entity be loaded.
   [#436](https://github.com/sharetribe/web-template/pull/436)
 - [add] Access control: private marketplace mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+## [v5.5.0] 2024-09-03
+
 - [add] Add currently available translations for DE, ES, FR.
   [#445](https://github.com/sharetribe/web-template/pull/445)
 - [change] Make the propType blockId optional for all Block types.
@@ -25,6 +27,8 @@ way to update this template, but currently, we follow a pattern:
 - [change] Updates to the configuration script. Marketplace name is now prompted in the mandatory
   settings. [#440](https://github.com/sharetribe/web-template/pull/440)
 - [change] Update one copy text. [#439](https://github.com/sharetribe/web-template/pull/439)
+
+  [v5.5.0]: https://github.com/sharetribe/web-template/compare/v5.4.0...v5.5.0
 
 ## [v5.4.0] 2024-08-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "5.4.0",
+  "version": "5.5.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This release fixes the visibility of a no-payout-details banner on ListingPage. It also updates Sentry integration and CSP policy.

## Translation changes
```diff
+   "NoAccessPage.userPendingApproval.content": "Your account needs to be approved by the {marketplaceName} team before you can start using it.",  
-   "NoAccessPage.userPendingApproval.content": "You need approval from the {marketplaceName} team to get access to the marketplace.",
```

## [Changes] 2024-09-03
- [add] Add currently available translations for DE, ES, FR.
  [#445](https://github.com/sharetribe/web-template/pull/445)
- [change] Make the propType blockId optional for all Block types.
  [#444](https://github.com/sharetribe/web-template/pull/444)
- [change] Update Sentry (v6.19.7 -> v8.26.0). Add ignoreErrors setup, add CSP directives and avoid
  some errors. [#441](https://github.com/sharetribe/web-template/pull/441)
- [fix] ListingPage: the optional chaining for processType variable was faulty.
  [#443](https://github.com/sharetribe/web-template/pull/443)
- [change] Updates to the configuration script. Marketplace name is now prompted in the mandatory
  settings. [#440](https://github.com/sharetribe/web-template/pull/440)
- [change] Update one copy text. [#439](https://github.com/sharetribe/web-template/pull/439)

  [Changes]: https://github.com/sharetribe/web-template/compare/v5.4.0...v5.5.0
