### PR TITLE
Currencies that the Stripe does not support should not cause 500 errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] Currencies that the Stripe does not support should not cause 500 errors.
+  [#447](https://github.com/sharetribe/web-template/pull/447)
+
 ## [v5.5.0] 2024-09-03
 
 - [add] Add currently available translations for DE, ES, FR.

--- a/src/components/OrderPanel/OrderPanel.js
+++ b/src/components/OrderPanel/OrderPanel.js
@@ -80,6 +80,14 @@ const priceData = (price, currency, intl) => {
   return {};
 };
 
+const formatMoneyIfSupportedCurrency = (price, intl) => {
+  try {
+    return formatMoney(intl, price);
+  } catch (e) {
+    return `(${price.currency})`;
+  }
+};
+
 const openOrderModal = (isOwnListing, isClosed, history, location) => {
   if (isOwnListing || isClosed) {
     window.scrollTo(0, 0);
@@ -146,7 +154,7 @@ const PriceMaybe = props => {
     </div>
   ) : (
     <div className={css.priceContainer}>
-      <p className={css.price}>{formatMoney(intl, price)}</p>
+      <p className={css.price}>{formatMoneyIfSupportedCurrency(price, intl)}</p>
       <div className={css.perUnit}>
         <FormattedMessage id="OrderPanel.perUnit" values={{ unitType }} />
       </div>

--- a/src/containers/ListingPage/ListingPage.shared.js
+++ b/src/containers/ListingPage/ListingPage.shared.js
@@ -39,6 +39,29 @@ export const priceData = (price, marketplaceCurrency, intl) => {
 };
 
 /**
+ * Converts Money object to number, which is needed for the search schema (for Google etc.)
+ *
+ * @param {Money} price
+ * @returns {Money|null}
+ */
+export const priceForSchemaMaybe = (price, intl) => {
+  try {
+    const schemaPrice = convertMoneyToNumber(price);
+    return schemaPrice
+      ? {
+          price: intl.formatNumber(schemaPrice, {
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2,
+          }),
+          priceCurrency: price.currency,
+        }
+      : {};
+  } catch (e) {
+    return {};
+  }
+};
+
+/**
  * Get category's label.
  *
  * @param {Array} categories array of category objects (key & label)

--- a/src/containers/ListingPage/ListingPageCarousel.js
+++ b/src/containers/ListingPage/ListingPageCarousel.js
@@ -70,6 +70,7 @@ import {
   handleContactUser,
   handleSubmitInquiry,
   handleSubmit,
+  priceForSchemaMaybe,
 } from './ListingPage.shared';
 import ActionBarMaybe from './ActionBarMaybe';
 import SectionTextMaybe from './SectionTextMaybe';
@@ -272,15 +273,6 @@ export const ListingPageComponent = props => {
   // Read more about product schema
   // https://developers.google.com/search/docs/advanced/structured-data/product
   const productURL = `${config.marketplaceRootURL}${location.pathname}${location.search}${location.hash}`;
-  const schemaPriceMaybe = price
-    ? {
-        price: intl.formatNumber(convertMoneyToNumber(price), {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2,
-        }),
-        priceCurrency: price.currency,
-      }
-    : {};
   const currentStock = currentListing.currentStock?.attributes?.quantity || 0;
   const schemaAvailability = !currentListing.currentStock
     ? null
@@ -307,7 +299,7 @@ export const ListingPageComponent = props => {
         offers: {
           '@type': 'Offer',
           url: productURL,
-          ...schemaPriceMaybe,
+          ...priceForSchemaMaybe(price, intl),
           ...availabilityMaybe,
         },
       }}

--- a/src/containers/ListingPage/ListingPageCoverPhoto.js
+++ b/src/containers/ListingPage/ListingPageCoverPhoto.js
@@ -70,6 +70,7 @@ import {
   handleContactUser,
   handleSubmitInquiry,
   handleSubmit,
+  priceForSchemaMaybe,
 } from './ListingPage.shared';
 import SectionHero from './SectionHero';
 import SectionTextMaybe from './SectionTextMaybe';
@@ -272,15 +273,6 @@ export const ListingPageComponent = props => {
   // Read more about product schema
   // https://developers.google.com/search/docs/advanced/structured-data/product
   const productURL = `${config.marketplaceRootURL}${location.pathname}${location.search}${location.hash}`;
-  const schemaPriceMaybe = price
-    ? {
-        price: intl.formatNumber(convertMoneyToNumber(price), {
-          minimumFractionDigits: 2,
-          maximumFractionDigits: 2,
-        }),
-        priceCurrency: price.currency,
-      }
-    : {};
   const currentStock = currentListing.currentStock?.attributes?.quantity || 0;
   const schemaAvailability = !currentListing.currentStock
     ? null
@@ -314,7 +306,7 @@ export const ListingPageComponent = props => {
         offers: {
           '@type': 'Offer',
           url: productURL,
-          ...schemaPriceMaybe,
+          ...priceForSchemaMaybe(price, intl),
           ...availabilityMaybe,
         },
       }}


### PR DESCRIPTION
Fix: currencies, that are not supported by the default Stripe integration, should not cause server error (500) on ListingPage(s).