### PR TITLE
Fix email verification not fetching current user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] EmailVerification: enforce that currentUser is fetched after verification.
+  [#451](https://github.com/sharetribe/web-template/pull/451)
 - [fix] ListingPage: fix 0 as value of listing fields.
   [#449](https://github.com/sharetribe/web-template/pull/449)
 - [fix] EditListingDetailsPanel: fix 0 as value of listing fields.

--- a/src/containers/EmailVerificationPage/EmailVerificationPage.js
+++ b/src/containers/EmailVerificationPage/EmailVerificationPage.js
@@ -68,7 +68,7 @@ export const EmailVerificationPageComponent = props => {
   // The first attempt to verify email is done when the page is loaded
   // If the verify API call is successfull and the user has verified email
   // We can redirect user forward from email verification page.
-  if (isVerified && user && user.attributes.emailVerified) {
+  if (isVerified && user.attributes.emailVerified && user.attributes.pendingEmail == null) {
     return <NamedRedirect name="LandingPage" />;
   }
 

--- a/src/ducks/emailVerification.duck.js
+++ b/src/ducks/emailVerification.duck.js
@@ -64,6 +64,6 @@ export const verify = verificationToken => (dispatch, getState, sdk) => {
   return sdk.currentUser
     .verifyEmail({ verificationToken })
     .then(() => dispatch(verificationSuccess()))
-    .then(() => dispatch(fetchCurrentUser()))
+    .then(() => dispatch(fetchCurrentUser({ enforce: true })))
     .catch(e => dispatch(verificationError(storableError(e))));
 };

--- a/src/ducks/user.duck.js
+++ b/src/ducks/user.duck.js
@@ -323,12 +323,17 @@ export const fetchCurrentUser = options => (dispatch, getState, sdk) => {
   const state = getState();
   const { currentUserHasListings, currentUserShowTimestamp } = state.user || {};
   const { isAuthenticated } = state.auth;
-  const { callParams = null, updateHasListings = true, updateNotifications = true, afterLogin } =
-    options || {};
+  const {
+    callParams = null,
+    updateHasListings = true,
+    updateNotifications = true,
+    afterLogin,
+    enforce = false, // Automatic emailVerification might be called too fast
+  } = options || {};
 
   // Double fetch might happen when e.g. profile page is making a full page load
   const aSecondAgo = new Date().getTime() - 1000;
-  if (currentUserShowTimestamp > aSecondAgo) {
+  if (!enforce && currentUserShowTimestamp > aSecondAgo) {
     return Promise.resolve({});
   }
   // Set in-progress, no errors


### PR DESCRIPTION
When user clicks verify email button on email they received, browser opens the example.com/verify-email?t=1234 link.

1) CSR: app is hydrated and **fetchCurrentUser** is fetched
2) EmailVerificationPage: loadData calls verify thunk function
  a) sdk.currentUser.verifyEmail is called first
  b) and then **fetchCurrentUser**.
  
Recently, we removed double calls to _fetchCurrentUser_, by applying a small buffer, when subsequent calls to _fetchCurrentUser_ actually make the call. (This can happen on pages that needs to fetch currentUser inside their loadData function).

Unfortunately, it was forgotten that email verification has a requirement for the order of those calls: (verify call first, and fetchCurrentUser second). This PR enforces the call of fetchCurrentUser on EmailVerificationPage.