### PR TITLE
Fix: Topbar: malformed custom link causes a 500 error on server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] Topbar: malformed custom link causes a 500 error on server.
+  [#457](https://github.com/sharetribe/web-template/pull/457)
 - [fix] ListingPage.shared.js: import for convertMoneyToNumber was not made for priceForSchemaMaybe
   function. [#456](https://github.com/sharetribe/web-template/pull/456)
 - [add] Access control: Transaction rights

--- a/src/containers/TopbarContainer/Topbar/Topbar.js
+++ b/src/containers/TopbarContainer/Topbar/Topbar.js
@@ -70,19 +70,23 @@ const getResolvedCustomLinks = (customLinks, routeConfiguration) => {
     const isInternalLink = type === 'internal' || href.charAt(0) === '/';
     if (isInternalLink) {
       // Internal link
-      const testURL = new URL('http://my.marketplace.com' + href);
-      const matchedRoutes = matchPathname(testURL.pathname, routeConfiguration);
-      if (matchedRoutes.length > 0) {
-        const found = matchedRoutes[0];
-        const to = { search: testURL.search, hash: testURL.hash };
-        return {
-          ...linkConfig,
-          route: {
-            name: found.route?.name,
-            params: found.params,
-            to,
-          },
-        };
+      try {
+        const testURL = new URL('http://my.marketplace.com' + href);
+        const matchedRoutes = matchPathname(testURL.pathname, routeConfiguration);
+        if (matchedRoutes.length > 0) {
+          const found = matchedRoutes[0];
+          const to = { search: testURL.search, hash: testURL.hash };
+          return {
+            ...linkConfig,
+            route: {
+              name: found.route?.name,
+              params: found.params,
+              to,
+            },
+          };
+        }
+      } catch (e) {
+        return linkConfig;
       }
     }
     return linkConfig;


### PR DESCRIPTION
This is for malformed link text like:
![Screenshot 2024-09-25 at 15 58 55](https://github.com/user-attachments/assets/6939ec44-3fae-42bd-adf2-3964f6a6a1c6)


After this PR, it would look like this:
![Screenshot 2024-09-25 at 15 53 40](https://github.com/user-attachments/assets/85916bcc-f0db-4a18-bd4a-fcd169bf3312)

And then lead to 404 page with URL like
`/-%20[Foobar](/p/about)-%20[Bar](/s)`