### PR TITLE
New release v5.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+## [v5.6.0] 2024-10-01
+
 - [add] Add support for CTAs on NoAccessPage
   [#455](https://github.com/sharetribe/web-template/pull/455)
 - [add] Add currently available translations for DE, ES, FR.
@@ -40,6 +42,8 @@ way to update this template, but currently, we follow a pattern:
   [#448](https://github.com/sharetribe/web-template/pull/448)
 - [fix] Currencies that the Stripe does not support should not cause 500 errors.
   [#447](https://github.com/sharetribe/web-template/pull/447)
+
+  [v5.6.0]: https://github.com/sharetribe/web-template/compare/v5.5.0...v5.6.0
 
 ## [v5.5.0] 2024-09-03
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This release introduces support for restricting user transaction rights and adding a Call To Action link on the NoAccessPage component.

## Translations changes

### New translation keys:
```json
"InquiryForm.noTransactionRightsError": "Oops, something went wrong. You don't have transaction rights. <NoAccessLink>Read more about transaction rights.</NoAccessLink>",
```

### Changed translations
```diff
- "InquiryForm.userPendingApprovalError": "Oops, something went wrong. You don't have permission to make inquiries",
+ "InquiryForm.userPendingApprovalError": "Oops, something went wrong. Your account is waiting for approval.",
```

## [Changes] 2024-10-01

- [add] Add support for CTAs on NoAccessPage
  [#455](https://github.com/sharetribe/web-template/pull/455)
- [add] Add currently available translations for DE, ES, FR.
  [#458](https://github.com/sharetribe/web-template/pull/458)
- [fix] Topbar: malformed custom link causes a 500 error on server.
  [#457](https://github.com/sharetribe/web-template/pull/457)
- [fix] ListingPage.shared.js: import for convertMoneyToNumber was not made for priceForSchemaMaybe
  function. [#456](https://github.com/sharetribe/web-template/pull/456)
- [add] Access control: Transaction rights

  - When a user does not have the "initiateTransactions" permission in their
    `effectivePermissionSet` relationship and they try to initiate an order or send an inquiry, they
    are redirected to the NoAccessPage.

  [#450](https://github.com/sharetribe/web-template/pull/450)

- [fix] InquiryForm: test code was committed earlier.
  [#452](https://github.com/sharetribe/web-template/pull/452)
- [fix] EmailVerification: enforce that currentUser is fetched after verification.
  [#451](https://github.com/sharetribe/web-template/pull/451)
- [fix] ListingPage: fix 0 as value of listing fields.
  [#449](https://github.com/sharetribe/web-template/pull/449)
- [fix] EditListingDetailsPanel: fix 0 as value of listing fields.
  [#448](https://github.com/sharetribe/web-template/pull/448)
- [fix] Currencies that the Stripe does not support should not cause 500 errors.
  [#447](https://github.com/sharetribe/web-template/pull/447)

  [Changes]: https://github.com/sharetribe/web-template/compare/v5.5.0...v5.6.0