### PR TITLE
New release v5.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+## [v5.6.1] 2024-10-07
+
 - [fix] Updated JSON asset schema structure from Console: Removed the enabled field, now using only
   the type attribute for CTA status.
 - [add] Add currently available translations for DE, ES, FR.
   [#461](https://github.com/sharetribe/web-template/pull/461)
+
+  [v5.6.1]: https://github.com/sharetribe/web-template/compare/v5.6.0...v5.6.1
 
 ## [v5.6.0] 2024-10-01
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This release changes the logic of how a Call To Action button is rendered, as a change was made on how the permission assets are structured. Instead of using the `enabled` attribute, the CTA is enabled using the `type` attribute.