### PR TITLE
Align block content

### DIFF
--- a/src/containers/PageBuilder/BlockBuilder/BlockDefault/BlockDefault.js
+++ b/src/containers/PageBuilder/BlockBuilder/BlockDefault/BlockDefault.js
@@ -31,9 +31,18 @@ const BlockDefault = props => {
     media,
     responsiveImageSizes,
     options,
+    alignment,
   } = props;
   const classes = classNames(rootClassName || css.root, className);
   const hasTextComponentFields = hasDataInFields([title, text, callToAction], options);
+
+  const alignmentClasses = {
+    left: css.alignLeft,
+    center: css.alignCenter,
+    right: css.alignRight,
+  };
+
+  const alignmentClass = alignmentClasses[alignment];
 
   return (
     <BlockContainer id={blockId} className={classes}>
@@ -44,7 +53,7 @@ const BlockDefault = props => {
         options={options}
       />
       {hasTextComponentFields ? (
-        <div className={classNames(textClassName, css.text)}>
+        <div className={classNames(textClassName, alignmentClass, css.text)}>
           <Field data={title} options={options} />
           <Field data={text} options={options} />
           <Field data={callToAction} className={ctaButtonClass} options={options} />

--- a/src/containers/PageBuilder/BlockBuilder/BlockDefault/BlockDefault.module.css
+++ b/src/containers/PageBuilder/BlockBuilder/BlockDefault/BlockDefault.module.css
@@ -15,3 +15,42 @@
     margin-top: 0;
   }
 }
+
+.alignLeft {
+  text-align: left;
+}
+
+.alignCenter {
+  text-align: center;
+
+  & > ul,
+  & > ol {
+    text-align: left;
+    width: fit-content;
+    /* center */
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  & > p {
+    /* center */
+    margin-left: auto;
+    margin-right: auto;
+  }
+}
+
+.alignRight {
+  text-align: right;
+  & > ul,
+  & > ol {
+    text-align: left;
+    width: fit-content;
+    /* push to right */
+    margin-left: auto;
+  }
+
+  & > p {
+    /* push to right */
+    margin-left: auto;
+  }
+}

--- a/src/containers/PageBuilder/BlockBuilder/BlockSocialMediaLink/BlockSocialMediaLink.module.css
+++ b/src/containers/PageBuilder/BlockBuilder/BlockSocialMediaLink/BlockSocialMediaLink.module.css
@@ -6,6 +6,10 @@
   &:first-child .link {
     padding-left: 0px;
   }
+
+  &:last-child .link {
+    padding-right: 0px;
+  }
 }
 
 .link {


### PR DESCRIPTION
This PR prepares the template for an alignment option for content page blocks. The alignment option can have one of three values: 
- left
- center
- right

If the block has an alignment set to one of those values, the content of the block is aligned accordingly.

<img width="1000" alt="Screenshot 2024-10-14 at 15 53 22" src="https://github.com/user-attachments/assets/39ef4cda-3612-4d42-b2d1-93d786825466">
