### PR TITLE
React v17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [change] This updates Sharetribe Web Template to use React v17.0.2.
+
+  Some highlights:
+
+  - The callback functions of **_useEffect_ hook** has become asynchronous!
+  - There has been changes to event delegation on React component tree.
+
+    - https://legacy.reactjs.org/blog/2020/10/20/react-v17.html#changes-to-event-delegation
+    - This change didn't seem to have practical consequences on this repository.
+
+  [#477](https://github.com/sharetribe/web-template/pull/477)
+
 - [add] CSP: start using nonce with script-src. This also removes data from script-src.
   [#485](https://github.com/sharetribe/web-template/pull/485)
 - [add] Remove React Dates datepicker library and add a new built-in DatePicker.

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "prop-types": "^15.8.1",
     "query-string": "^7.1.1",
     "raf": "^3.4.0",
-    "react": "^16.13.1",
-    "react-dom": "^16.13.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "react-final-form": "6.5.9",
     "react-final-form-arrays": "3.1.3",
     "react-helmet-async": "^1.3.0",
@@ -80,9 +80,7 @@
     "prettier": "^1.18.2"
   },
   "resolutions": {
-    "moment": "^2.30.1",
-    "react-dates/lodash": "^4.17.21",
-    "react-test-renderer": "^16.13.1"
+    "moment": "^2.30.1"
   },
   "nodemonConfig": {
     "execMap": {

--- a/src/components/IconSpinner/IconSpinner.js
+++ b/src/components/IconSpinner/IconSpinner.js
@@ -44,8 +44,8 @@ const DelayedSpinner = props => {
   const { delay = 600, ...restOfProps } = props;
 
   useEffect(() => {
-    const timer = setTimeout(() => setShowSpinner(true), delay);
-    return () => clearTimeout(timer);
+    const timer = window?.setTimeout(() => setShowSpinner(true), delay);
+    return () => window?.clearTimeout(timer);
   });
 
   return showSpinner ? <IconSpinner {...restOfProps} /> : null;

--- a/src/components/LayoutComposer/LayoutComposer.js
+++ b/src/components/LayoutComposer/LayoutComposer.js
@@ -176,11 +176,16 @@ const parseDefaultAreasFromProps = props => {
  * @return LayoutComposer that expects children to be a function.
  */
 const LayoutComposer = React.forwardRef((props, ref) => {
+  const [mounted, setMounted] = useState(false);
   const [currentAreas, setAreas] = useState(parseDefaultAreasFromProps(props));
 
   useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
     let resizeListeners = [];
-    if (responsiveAreas) {
+    if (mounted && responsiveAreas) {
       resizeListeners = handleResponsiveAreasOnBrowser(responsiveAreas, setAreas);
     }
 
@@ -190,7 +195,7 @@ const LayoutComposer = React.forwardRef((props, ref) => {
         mediaQueryList.removeEventListener('change', resizeListener);
       });
     };
-  }, []);
+  }, [mounted]);
 
   const { components, gridTemplateAreas } = currentAreas;
   const { children, style = {}, areas, responsiveAreas, display, as, ...otherProps } = props;

--- a/src/components/LayoutComposer/LayoutSideNavigation/LayoutWrapperAccountSettingsSideNav.js
+++ b/src/components/LayoutComposer/LayoutSideNavigation/LayoutWrapperAccountSettingsSideNav.js
@@ -2,12 +2,10 @@
  * This is a wrapper component for different Layouts.
  * Navigational 'aside' content should be added to this wrapper.
  */
-import React, { useEffect } from 'react';
-import { node, number, string, shape } from 'prop-types';
-import { compose } from 'redux';
+import React, { useEffect, useState } from 'react';
+import { node, string } from 'prop-types';
 
 import { FormattedMessage } from '../../../util/reactIntl';
-import { withViewport } from '../../../util/uiHelpers';
 
 import { TabNav } from '../../../components';
 
@@ -59,33 +57,27 @@ const scrollToTab = (currentPage, scrollLeft, setScrollLeft) => {
 };
 
 const LayoutWrapperAccountSettingsSideNavComponent = props => {
+  const [mounted, setMounted] = useState(false);
   const [scrollLeft, setScrollLeft] = useGlobalState('scrollLeft');
+
   useEffect(() => {
-    const { currentPage, viewport } = props;
-    let scrollTimeout = null;
+    setMounted(true);
+  }, []);
 
-    const { width } = viewport;
-    const hasViewport = width > 0;
-    const hasHorizontalTabLayout = hasViewport && width <= MAX_HORIZONTAL_NAV_SCREEN_WIDTH;
+  useEffect(() => {
+    if (mounted) {
+      const { currentPage } = props;
+      const hasMatchMedia = typeof window !== 'undefined' && window?.matchMedia;
+      const hasHorizontalTabLayout = hasMatchMedia
+        ? window.matchMedia(`(max-width: ${MAX_HORIZONTAL_NAV_SCREEN_WIDTH}px)`)?.matches
+        : true;
 
-    // Check if scrollToTab call is needed (tab is not visible on mobile)
-    if (hasHorizontalTabLayout) {
-      scrollTimeout = window.setTimeout(() => {
+      // Check if scrollToTab call is needed (tab is not visible on mobile)
+      if (hasHorizontalTabLayout) {
         scrollToTab(currentPage, scrollLeft, setScrollLeft);
-      }, 300);
+      }
     }
-
-    return () => {
-      // Update scroll position when unmounting
-      const el = document.querySelector(`#${currentPage}Tab`);
-      if (el?.parentElement) {
-        setScrollLeft(el?.parentElement.scrollLeft);
-      }
-      if (scrollTimeout) {
-        clearTimeout(scrollTimeout);
-      }
-    };
-  });
+  }, [mounted]);
 
   const { currentPage } = props;
 
@@ -139,16 +131,8 @@ LayoutWrapperAccountSettingsSideNavComponent.propTypes = {
   className: string,
   rootClassName: string,
   currentPage: string,
-
-  // from withViewport
-  viewport: shape({
-    width: number.isRequired,
-    height: number.isRequired,
-  }).isRequired,
 };
 
-const LayoutWrapperAccountSettingsSideNav = compose(withViewport)(
-  LayoutWrapperAccountSettingsSideNavComponent
-);
+const LayoutWrapperAccountSettingsSideNav = LayoutWrapperAccountSettingsSideNavComponent;
 
 export default LayoutWrapperAccountSettingsSideNav;

--- a/src/components/LayoutComposer/LayoutSideNavigation/LayoutWrapperAccountSettingsSideNav.js
+++ b/src/components/LayoutComposer/LayoutSideNavigation/LayoutWrapperAccountSettingsSideNav.js
@@ -45,7 +45,7 @@ const scrollToTab = (currentPage, scrollLeft, setScrollLeft) => {
 
     const needsSmoothScroll = scrollPositionCurrent !== scrollPositionNew;
 
-    if (!hasParentScrolled || (hasParentScrolled && needsSmoothScroll)) {
+    if (parent.scrollTo && (!hasParentScrolled || (hasParentScrolled && needsSmoothScroll))) {
       // Ensure that smooth scroll animation uses old position as starting point after navigation.
       parent.scrollTo({ left: scrollPositionCurrent });
       // Scroll to new position

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInput.module.css
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInput.module.css
@@ -93,6 +93,7 @@ bottom of the container.
 
   @media (--viewportMedium) {
     background-position: center left 36px;
+    margin-bottom: 0;
   }
 }
 

--- a/src/containers/CheckoutPage/CustomTopbar.js
+++ b/src/containers/CheckoutPage/CustomTopbar.js
@@ -10,23 +10,35 @@ import css from './CheckoutPage.module.css';
 
 const CustomTopbar = props => {
   const [isMobile, setIsMobile] = useState(false);
+  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
-    // set initial value
-    const mediaQueryList = window.matchMedia('(max-width: 767px)');
-    setIsMobile(mediaQueryList.matches);
+    setMounted(true);
+  }, []);
 
-    //watch for updates
-    function updateIsMobile(e) {
-      setIsMobile(e.matches);
+  useEffect(() => {
+    let mediaQueryList = null;
+    let updateIsMobile = null;
+
+    if (mounted) {
+      // set initial value
+      mediaQueryList = window.matchMedia('(max-width: 767px)');
+      setIsMobile(mediaQueryList.matches);
+
+      //watch for updates
+      updateIsMobile = e => {
+        setIsMobile(e.matches);
+      };
+      mediaQueryList.addEventListener('change', updateIsMobile);
     }
-    mediaQueryList.addEventListener('change', updateIsMobile);
 
     // clean up after ourselves
-    return function cleanup() {
-      mediaQueryList.removeEventListener('change', updateIsMobile);
+    return () => {
+      if (mediaQueryList && updateIsMobile) {
+        mediaQueryList.removeEventListener('change', updateIsMobile);
+      }
     };
-  });
+  }, [mounted]);
 
   const { className, rootClassName, intl, linkToExternalSite } = props;
   const classes = classNames(rootClassName || css.topbar, className);

--- a/src/containers/EditListingPage/EditListingWizard/EditListingWizard.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingWizard.js
@@ -653,7 +653,6 @@ class EditListingWizard extends Component {
                   stripeAccountLinkError={stripeAccountLinkError}
                   onChange={onPayoutDetailsChange}
                   onSubmit={rest.onPayoutDetailsSubmit}
-                  onGetStripeConnectAccountLink={handleGetStripeConnectAccountLink}
                   stripeConnected={stripeConnected}
                 >
                   {stripeConnected && !returnedAbnormallyFromStripe && showVerificationNeeded ? (

--- a/src/containers/SearchPage/SearchMap/SearchMapWithGoogleMaps.js
+++ b/src/containers/SearchPage/SearchMap/SearchMapWithGoogleMaps.js
@@ -122,7 +122,7 @@ class CustomOverlayView extends Component {
     this.containerElement.parentNode.removeChild(this.containerElement);
     //Remove `unmountComponentAtNode` for react version 16
     //I decided to keep the code here incase React decides not to give out warning when `unmountComponentAtNode` in newer version
-    if (!React.version.match(/^16/)) {
+    if (typeof ReactDOM.unmountComponentAtNode !== 'undefined') {
       ReactDOM.unmountComponentAtNode(this.containerElement);
     }
     this.containerElement = null;
@@ -168,7 +168,7 @@ class CustomOverlayView extends Component {
   }
 
   render() {
-    if (React.version.match(/^16/) && this.containerElement) {
+    if (this.containerElement) {
       return ReactDOM.createPortal(React.Children.only(this.props.children), this.containerElement);
     }
     return false;

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
@@ -65,14 +65,14 @@ const groupMeasuredLinks = (links, containerWidth, menuMoreWidth) => {
 
 const calculateContainerWidth = (containerRefTarget, parentWidth) => {
   // Siblings include logo, search form, (inbox, profile menu || login signup)
-  const siblingArray = Array.from(containerRefTarget.parentNode.childNodes).filter(
-    n => n !== containerRefTarget
-  );
+  const siblingArray = containerRefTarget?.parentNode?.childNodes
+    ? Array.from(containerRefTarget.parentNode.childNodes).filter(n => n !== containerRefTarget)
+    : [];
   const siblingWidthsCombined = siblingArray.reduce((acc, node) => acc + node.offsetWidth, 0);
 
   // .root class of the TopbarDesktop has 24px padding on the right
   // Firefox doesn't support computedStyleMap()
-  const parentStyleMap = containerRefTarget.parentElement.computedStyleMap
+  const parentStyleMap = containerRefTarget?.parentElement?.computedStyleMap
     ? containerRefTarget.parentElement.computedStyleMap()
     : null;
   const topbarPaddingRight = parentStyleMap?.get('padding-right')?.value;
@@ -118,28 +118,33 @@ const CustomLinksMenu = ({ currentPage, customLinks = [], hasClientSideContentRe
 
   useEffect(() => {
     let animationFrameId = null;
+    const body = document.body;
+    const container = containerRef.current;
+
     if (hasClientSideContentReady && moreLabelWidth > 0) {
       // ResizeObserver sets layout data: grouped priority links and links that go to menuLinks dropdown
       observer.current = new ResizeObserver(entries => {
-        const containerRefParentWidth = containerRef.current?.parentNode?.offsetWidth;
-        const bodyOffsetWidth = document.body.offsetWidth;
+        const containerRefParentWidth = container?.parentNode?.offsetWidth;
+        const bodyOffsetWidth = body.offsetWidth;
 
         for (const entry of entries) {
           // Body's width has changed (aka viewport has changed)
-          const isBodyTheTarget = entry.target === document.body;
+          const isBodyTheTarget = entry.target === body;
           // If the width of the TopbarDesktop (aka <nav>) changes, this assumes that the document.body has the correct width.
           const hasWidthOfTopbarDesktopChanged =
             !isBodyTheTarget && containerRefParentWidth !== bodyOffsetWidth;
 
           if (isBodyTheTarget || hasWidthOfTopbarDesktopChanged) {
-            const target = containerRef?.current;
+            const target = container;
             const availableContainerWidth = calculateContainerWidth(target, bodyOffsetWidth);
 
             // The groupedLinks variable contains { priorityLinks, menuLinks }
             const groupedLinks = groupMeasuredLinks(links, availableContainerWidth, moreLabelWidth);
             // The setLayoutData call affects the UI. This pushes the painting to the next frame.
             animationFrameId = window.requestAnimationFrame(() => {
-              setLayoutData({ ...groupedLinks, containerWidth: availableContainerWidth });
+              if (container) {
+                setLayoutData({ ...groupedLinks, containerWidth: availableContainerWidth });
+              }
             });
             // After setLayoutData is called, don't process other entries
             break;
@@ -147,19 +152,23 @@ const CustomLinksMenu = ({ currentPage, customLinks = [], hasClientSideContentRe
         }
       });
 
-      if (containerRef?.current) {
+      if (container) {
         // We need to observe both document body and the component's own container
         // When the window is squeezed, priority links prevent the container to shrink smaller.
         // At that point, we need to calculate the width from the width of the body.
         // It's also possible that some of the other elements get a repaint after window-level repaint (e.g. image loads)
         // In those cases, we just need to
-        observer.current.observe(document.body);
-        observer.current.observe(containerRef.current);
+        observer.current.observe(body);
+        observer.current.observe(container);
       }
     }
     return () => {
-      observer.current?.unobserve(document.body);
-      observer.current?.unobserve(containerRef.current);
+      if (body) {
+        observer.current?.unobserve(body);
+      }
+      if (container) {
+        observer.current?.unobserve(container);
+      }
       if (animationFrameId) {
         window.cancelAnimationFrame(animationFrameId);
       }

--- a/src/containers/TopbarContainer/Topbar/TopbarSearchForm/TopbarSearchForm.module.css
+++ b/src/containers/TopbarContainer/Topbar/TopbarSearchForm/TopbarSearchForm.module.css
@@ -142,6 +142,10 @@
    text is hidden in Mobile Safari without giving some extra space to
    it. */
   margin-bottom: 100px;
+
+  @media (--viewportMedium) {
+    margin-bottom: 0;
+  }
 }
 
 .desktopPredictions {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10951,15 +10951,14 @@ react-dev-utils@^12.0.1:
     strip-ansi "^6.0.1"
     text-table "^0.2.0"
 
-react-dom@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
-  integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
+react-dom@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.19.1"
+    scheduler "^0.20.2"
 
 react-error-overlay@^6.0.11:
   version "6.0.11"
@@ -11027,7 +11026,7 @@ react-is@^16.6.0, react-is@^16.7.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
   integrity sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==
 
-react-is@^16.8.1, react-is@^16.8.6:
+react-is@^16.8.1:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
   integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
@@ -11100,16 +11099,6 @@ react-router@5.3.2:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
-react-test-renderer@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.13.1.tgz#de25ea358d9012606de51e012d9742e7f0deabc1"
-  integrity sha512-Sn2VRyOK2YJJldOqoh8Tn/lWQ+ZiKhyZTPtaO0Q6yNj+QDbmRkVFap6pZPy3YQk8DScRDfyqm/KxKYP9gCMRiQ==
-  dependencies:
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    react-is "^16.8.6"
-    scheduler "^0.19.1"
-
 react-with-direction@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/react-with-direction/-/react-with-direction-1.4.0.tgz#ebdf64d685d0650ce966e872e6431ad5a2485444"
@@ -11124,14 +11113,13 @@ react-with-direction@^1.4.0:
     object.values "^1.1.5"
     prop-types "^15.7.2"
 
-react@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
-  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+react@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    prop-types "^15.6.2"
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -11616,10 +11604,10 @@ saxes@^5.0.1:
   dependencies:
     xmlchars "^2.2.0"
 
-scheduler@^0.19.1:
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
-  integrity sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
**This pull request takes React v17.0.2 into use.**
Read more about [React v17](https://legacy.reactjs.org/blog/2020/10/20/react-v17.html)

## Changes and Notes from React v17 upate:
- There has been changes to [event delegation](https://legacy.reactjs.org/blog/2020/10/20/react-v17.html#changes-to-event-delegation) on React component tree.
  - This change didn't seem to have practical consequences on this repository.
- The callback functions of **_useEffect_ hook** has become asynchronous!
  - This had some consequences on this repository:
    - Topbar / CustomLinksMenu needed to be changed a bit
    - LayoutWrapperAccountSettingsSideNav aka account settings related pages needed to be changed a bit
      - In practice, these were automatic horizontal scroll-into-view tabs on mobile layout.
  - If you have used **useEffect** hook with [callback function](https://legacy.reactjs.org/docs/hooks-reference.html#cleaning-up-an-effect) on your customized client app, you should check that the callback does not rely on DOM objects.
    - If you need to have access to DOM for clean up process, you should use useLayoutEffect instead.


## What about React v18?
We are planning to continue the update work to make the codebase work with React v18. However, we want to first test how the app performs with React v17. In practice, this means that the project that leads to v18 will be on hold for a month or so.

What we know about v18 already:
- MyComponent.**defaultProps** feature is deprecated and the usage causes a flood of warnings.
- Hydration issues:
  - the code-splitting needs to be reviewed on sharetribe-scripts side.
  - the matchmedia usage needs refactoring (ensure that the 1st client-side rendering matches with the SSR)
  - Topbar, SearchMap, and some other components needs some refactoring (ensure the 1st CSR matches with the SSR)
- ReactDOM has been split into react-dom/server & react-dom/client
  - This might have some changes how SSR should be supported.
    