### PR TITLE
Add static 404 page for bots that scan (php) vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
-- [update] Update copy text for Publishing listing permission to Posting listing.
+- [add] Filter out bot requests that scan websites for vulnerabilities before they reach React app.
+  [#479](https://github.com/sharetribe/web-template/pull/479)
+- [change] Update copy text for Publishing listing permission to Posting listing.
   [#482](https://github.com/sharetribe/web-template/pull/482)
 
 ## [v5.8.0] 2024-10-22

--- a/public/404.html
+++ b/public/404.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>500 Server error</title>
+    <title>404 Page not found error</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <style>
@@ -24,15 +24,6 @@
         color: #4A4A4A;
         margin-top: 24px;
         margin-bottom: 24px;
-      }
-
-      p {
-        font-weight: 500;
-        font-size: 18px;
-        line-height: 24px;
-        letter-spacing: -0.11px;
-        margin-top: 12px;
-        margin-bottom: 12px;
       }
 
       .content {
@@ -98,13 +89,6 @@
           letter-spacing: -0.9px;
         }
 
-        p {
-          font-size: 20px;
-          line-height: 32px;
-          margin-top: 16px;
-          margin-bottom: 16px;
-        }
-
         .content {
           margin: 232px auto;
         }
@@ -125,9 +109,8 @@
   </head>
   <body>
     <div class="content">
-      <div class="errorCode">500</div>
-      <h1>Sorry, it seems we did something wrong.</h1>
-      <p>It might have been just a temporary issue, try refreshing the page or redo the action you were trying to do. If the issue occurs again, please contact us.</p>
+      <div class="errorCode">404</div>
+      <h1>Sorry, we couldn't find that page.</h1>
       <a class="buttonLink" href="/">Go to homepage</a>
     </div>
   </body>

--- a/server/index.js
+++ b/server/index.js
@@ -60,7 +60,19 @@ const cspReportUrl = '/csp-report';
 const cspEnabled = CSP === 'block' || CSP === 'report';
 const app = express();
 
-const errorPage = fs.readFileSync(path.join(buildPath, '500.html'), 'utf-8');
+const errorPage500 = fs.readFileSync(path.join(buildPath, '500.html'), 'utf-8');
+const errorPage404 = fs.readFileSync(path.join(buildPath, '404.html'), 'utf-8');
+
+// Filter out bot requests that scan websites for php vulnerabilities
+// from paths like /asdf/index.php, //cms/wp-includes/wlwmanifest.xml, etc.
+// There's no need to pass those to React app rendering as it causes unnecessary asset fetches.
+// Note: you might want to do this on the edge server instead.
+app.use(
+  /.*(\.php|\.php7|\/wp-.*\/.*|cgi-bin.*|htdocs\.rar|htdocs\.zip|root\.7z|root\.rar|root\.zip|www\.7z|www\.rar|wwwroot\.7z)$/,
+  (req, res) => {
+    return res.status(404).send(errorPage404);
+  }
+);
 
 // The helmet middleware sets various HTTP headers to improve security.
 // See: https://www.npmjs.com/package/helmet
@@ -248,7 +260,7 @@ app.get('*', (req, res) => {
     })
     .catch(e => {
       log.error(e, 'server-side-render-failed');
-      res.status(500).send(errorPage);
+      res.status(500).send(errorPage500);
     });
 });
 


### PR DESCRIPTION
Filter out bot requests that scan websites for php vulnerabilities etc. This might look in your logs with attempts to find paths like /wp-admin/index.php, //cms/wp-includes/wlwmanifest.xml, etc. 

There's no need to pass those requests to the React app rendering as it causes unnecessary asset fetches to initialize the server-side rendering.

_Note_: you might want to do this on the edge server instead.


404 page for bots that scan php vulnerabilities:
![Screenshot 2024-10-22 at 20 04 38](https://github.com/user-attachments/assets/5a5838d1-e0e6-4ac3-8e42-2bd85cd2483d)

`/.*(\.php|\.php7|\/wp-.*\/.*|cgi-bin.*|htdocs\.rar|htdocs\.zip|root\.7z|root\.rar|root\.zip|www\.7z|www\.rar|wwwroot\.7z)$/`
![Screenshot 2024-10-23 at 11 50 06](https://github.com/user-attachments/assets/a4a6c59f-99b1-4c89-b7ac-e30c2069f559)
