### PR TITLE
New patch release: v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+## [v6.0.1] 2024-11-01
+
 - [fix] GA4 integration had a copy-paste bug.
   [#489](https://github.com/sharetribe/web-template/pull/489)
 - [fix] FieldDateTimeInput.module.css: fix typo.
@@ -22,6 +24,8 @@ way to update this template, but currently, we follow a pattern:
   [#478](https://github.com/sharetribe/web-template/pull/478)
 - [change] Update default email templates to get link and button colors from asset.
   [#478](https://github.com/sharetribe/web-template/pull/478)
+
+  [v6.0.1]: https://github.com/sharetribe/web-template/compare/v6.0.0...v6.0.1
 
 ## [v6.0.0] 2024-10-29
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Fixes a bug on GA4 integration.

## [Changes] v6.0.1

- [fix] GA4 integration had a copy-paste bug.
  [#489](https://github.com/sharetribe/web-template/pull/489)
- [fix] FieldDateTimeInput.module.css: fix typo.
  [#487](https://github.com/sharetribe/web-template/pull/487)
- [change] Update default email templates to use ICU's `j` pattern for datetimes.
  [#478](https://github.com/sharetribe/web-template/pull/478)
- [change] Update default email templates to get link and button colors from asset.
  [#478](https://github.com/sharetribe/web-template/pull/478)

  [Changes]: https://github.com/sharetribe/web-template/compare/v6.0.0...v6.0.1
