### PR TITLE
Datepicker: add some missing features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [change] Refactor SingleDatePicker and DateRangePicker by combining date and its formatting. It
+  updates dateData if passed-in input value changes.
+  [#492](https://github.com/sharetribe/web-template/pull/492)
+
 ## [v6.0.1] 2024-11-01
 
 - [fix] GA4 integration had a copy-paste bug.

--- a/src/components/DatePicker/DatePickers/DatePicker.test.js
+++ b/src/components/DatePicker/DatePickers/DatePicker.test.js
@@ -230,10 +230,13 @@ describe('SingleDatePicker', () => {
     const inputDateFormatOptions = { day: 'numeric', month: 'short', weekday: 'short' };
     const todayInputString = intl.formatDate(startDay, inputDateFormatOptions);
     userEvent.click(screen.getByDisplayValue(todayInputString));
-    const calendarDate = screen.getByRole('button', { name: `${calendarDateString} is selected` });
-    expect(calendarDate).toBeInTheDocument();
-    expect(calendarDate).toHaveAttribute('tabIndex', '0');
-    expect(calendarDate).toHaveClass('dateSelected');
+
+    const calendarDateBtn = screen.getByRole('button', {
+      name: `${calendarDateString} is selected`,
+    });
+    expect(calendarDateBtn).toBeInTheDocument();
+    expect(calendarDateBtn).toHaveAttribute('tabIndex', '0');
+    expect(calendarDateBtn).toHaveClass('dateSelected');
 
     userEvent.keyboard('[ArrowRight][Enter]');
     const nextDayInputString = intl.formatDate(addDays(startDay, 1), inputDateFormatOptions);

--- a/src/components/DatePicker/DatePickers/DateRangePicker.js
+++ b/src/components/DatePicker/DatePickers/DateRangePicker.js
@@ -218,6 +218,9 @@ export const DateRangePicker = props => {
     onKeyDown: handleOnKeyDownOnInput,
     ...(readOnly ? { readOnly } : {}),
   };
+  const inputClasses = classNames(css.input, inputClassName, {
+    [css.inputPlaceholder]: !value || value.length === 0,
+  });
 
   return (
     <OutsideClickHandler className={classes} onOutsideClick={handleBlur}>
@@ -226,7 +229,7 @@ export const DateRangePicker = props => {
           <div className={css.inputs}>
             <input
               id={startDateId}
-              className={classNames(css.input, inputClassName)}
+              className={inputClasses}
               placeholder={startDatePlaceholderText}
               value={dateRangeData.formatted[0] || ''}
               data-type={INPUT_START}
@@ -234,7 +237,7 @@ export const DateRangePicker = props => {
             />
             <input
               id={endDateId}
-              className={classNames(css.input, inputClassName)}
+              className={inputClasses}
               placeholder={endDatePlaceholderText}
               value={dateRangeData.formatted[1] || ''}
               data-type={INPUT_END}

--- a/src/components/DatePicker/DatePickers/DateRangePicker.js
+++ b/src/components/DatePicker/DatePickers/DateRangePicker.js
@@ -18,21 +18,20 @@ const dateFormatOptions = {
   day: 'numeric',
 };
 
+const stringify = arr => (arr ? arr.map(v => (v ? v.getTime() : '')).join(',') : '');
+
 export const DateRangePicker = props => {
   const intl = useIntl();
+  const [mounted, setMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
-  const [dateRange, setDateRange] = useState(props.value || null);
-  const [rawValues, setRawValues] = useState(
-    props.value ? props.value.map(value => intl.formatDate(value, dateFormatOptions)) : ['', '']
-  );
-  const element = useRef(null);
+  const [dateRangeData, setDateRangeData] = useState({
+    dateRange: props.value || null,
+    formatted: props.value
+      ? props.value.map(value => intl.formatDate(value, dateFormatOptions))
+      : ['', ''],
+  });
 
-  useEffect(() => {
-    // Call onMonthChanged function if it has been passed in among props.
-    if (!isOpen && props.onClose) {
-      props.onClose();
-    }
-  }, [isOpen]);
+  const element = useRef(null);
 
   const {
     className,
@@ -53,11 +52,35 @@ export const DateRangePicker = props => {
     ...rest
   } = props;
 
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // If value has changed, update internal state
+  useEffect(() => {
+    if (mounted && stringify(value) !== stringify(dateRangeData.dateRange)) {
+      // If mounted, changes to value should be reflected to 'dateRange' state
+      setDateRangeData({
+        dateRange: value,
+        formatted: value.map(value => intl.formatDate(value, dateFormatOptions)),
+      });
+    }
+  }, [mounted, value]);
+
+  useEffect(() => {
+    // Call onClose function if it has been passed in among props.
+    if (!isOpen && props.onClose) {
+      props.onClose();
+    }
+  }, [isOpen]);
+
   const id = `${formId}_DateRangePicker`;
   const classes = classNames(rootClassName || css.root, className, css.outsideClickWrapper);
   const startDateMaybe =
-    Array.isArray(dateRange) && dateRange[0] instanceof Date && !isNaN(dateRange[0])
-      ? { startDate: getISODateString(dateRange[0]) }
+    Array.isArray(dateRangeData.dateRange) &&
+    dateRangeData.dateRange[0] instanceof Date &&
+    !isNaN(dateRangeData.dateRange[0])
+      ? { startDate: getISODateString(dateRangeData.dateRange[0]) }
       : {};
 
   const handleChange = value => {
@@ -66,15 +89,21 @@ export const DateRangePicker = props => {
     }
 
     const cleanedValues = value.map(d => getStartOfDay(d));
-    setDateRange(cleanedValues);
 
     if (cleanedValues.length === 1) {
-      setRawValues([intl.formatDate(cleanedValues[0], dateFormatOptions), '']);
+      setDateRangeData({
+        dateRange: cleanedValues,
+        formatted: [intl.formatDate(cleanedValues[0], dateFormatOptions), ''],
+      });
+
       if (onChange) {
         onChange(cleanedValues);
       }
     } else if (cleanedValues.length === 2) {
-      setRawValues(cleanedValues.map(value => intl.formatDate(value, dateFormatOptions)));
+      setDateRangeData({
+        dateRange: cleanedValues,
+        formatted: cleanedValues.map(value => intl.formatDate(value, dateFormatOptions)),
+      });
 
       setIsOpen(false);
 
@@ -87,6 +116,12 @@ export const DateRangePicker = props => {
       if (onChange) {
         onChange(cleanedValues);
       }
+    } else {
+      // This should not be reached, unless the range is empty.
+      setDateRangeData({
+        dateRange: cleanedValues,
+        formatted: cleanedValues.map(value => intl.formatDate(value, dateFormatOptions)),
+      });
     }
   };
 
@@ -100,40 +135,53 @@ export const DateRangePicker = props => {
 
     if (!inputStr) {
       const newDateRange =
-        inputType === INPUT_START && rawValues[1] && dateRange[1]
-          ? [dateRange[1]]
-          : inputType !== INPUT_START && rawValues[0] && dateRange[0]
-          ? [dateRange[0]]
+        inputType === INPUT_START && dateRangeData.formatted[1] && dateRangeData.dateRange[1]
+          ? [dateRangeData.dateRange[1]]
+          : inputType !== INPUT_START && dateRangeData.formatted[0] && dateRangeData.dateRange[0]
+          ? [dateRangeData.dateRange[0]]
           : [];
-      setDateRange(newDateRange);
+      setDateRangeData({
+        dateRange: newDateRange,
+        formatted: getUpdatedRange(inputStr, dateRangeData.formatted),
+      });
 
       if (onChange) {
-        const newRawValues = getUpdatedRange(null, rawValues);
+        const newFormattedValues = getUpdatedRange(null, dateRangeData.formatted);
         const boundaryMaybe = newDateRange[0];
-        const valuesForParent = newRawValues.map(v => (v && boundaryMaybe ? boundaryMaybe : null));
+        const valuesForParent = newFormattedValues.map(v =>
+          v && boundaryMaybe ? boundaryMaybe : null
+        );
         onChange(valuesForParent);
       }
-    }
-
-    if (isValidDateString(inputStr)) {
+      return;
+    } else if (isValidDateString(inputStr)) {
       const d = new Date(inputStr);
-      const updatedRange = getUpdatedRange(d, dateRange);
+      const updatedRange = getUpdatedRange(d, dateRangeData.dateRange);
       if (updatedRange?.[0] && updatedRange?.[1]) {
         if (isBlockedBetween(updatedRange)) {
-          setRawValues([updatedRange[0], '']);
-          handleChange([updatedRange[0]]);
+          // Delete end date
+          setDateRangeData({
+            dateRange: [updatedRange[0]],
+            formatted: [intl.formatDate(updatedRange[0], dateFormatOptions), ''],
+          });
+
           return;
         } else {
-          handleChange(updatedRange);
+          handleChange(updatedRange.sort((d1, d2) => d1 - d2));
           return;
         }
       } else if (updatedRange?.[0] || updatedRange?.[1]) {
-        setRawValues([updatedRange[0], '']);
+        // If only 1 date has been selected, create array with 1 item
         handleChange([updatedRange?.[0] || updatedRange?.[1]]);
+        return;
       }
     }
 
-    setRawValues(getUpdatedRange(inputStr, rawValues));
+    // If code execution ends up here, then the dateRange is empty or malformed
+    setDateRangeData({
+      dateRange: dateRangeData.dateRange,
+      formatted: getUpdatedRange(inputStr, dateRangeData.formatted),
+    });
   };
 
   const handleBlur = () => {
@@ -180,7 +228,7 @@ export const DateRangePicker = props => {
               id={startDateId}
               className={classNames(css.input, inputClassName)}
               placeholder={startDatePlaceholderText}
-              value={rawValues[0] || ''}
+              value={dateRangeData.formatted[0] || ''}
               data-type={INPUT_START}
               {...inputProps}
             />
@@ -188,7 +236,7 @@ export const DateRangePicker = props => {
               id={endDateId}
               className={classNames(css.input, inputClassName)}
               placeholder={endDatePlaceholderText}
-              value={rawValues[1] || ''}
+              value={dateRangeData.formatted[1] || ''}
               data-type={INPUT_END}
               {...inputProps}
             />
@@ -202,9 +250,9 @@ export const DateRangePicker = props => {
               showMonthStepper={true}
               onChange={handleChange}
               isBlockedBetween={isBlockedBetween}
-              value={dateRange}
-              rangeStartHasValue={rawValues?.[0]?.length > 0}
-              rangeEndHasValue={rawValues?.[1]?.length > 0}
+              value={dateRangeData.dateRange}
+              rangeStartHasValue={dateRangeData.formatted?.[0]?.length > 0}
+              rangeEndHasValue={dateRangeData.formatted?.[1]?.length > 0}
               {...startDateMaybe}
               {...rest}
             />

--- a/src/components/DatePicker/DatePickers/DateRangePicker.module.css
+++ b/src/components/DatePicker/DatePickers/DateRangePicker.module.css
@@ -41,6 +41,16 @@
   }
 }
 
+.inputPlaceholder {
+  background-image: url('data:image/svg+xml;utf8,<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><g stroke="%2396969C" transform="translate(1 1)"><rect stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" x=".292" y="1.459" width="13.417" height="12.25" rx="1"/><path d="M3.208.292V3.21M10.792.292V3.21M.292 4.376h13.416" stroke-linecap="round" stroke-linejoin="round"/><rect x="3.5" y="6.5" width="1" height="1" rx=".5"/><rect x="6.5" y="6.5" width="1" height="1" rx=".5"/><rect x="9.5" y="6.5" width="1" height="1" rx=".5"/><rect x="3.5" y="9.5" width="1" height="1" rx=".5"/><rect x="6.5" y="9.5" width="1" height="1" rx=".5"/><rect x="9.5" y="9.5" width="1" height="1" rx=".5"/></g></g></svg>');
+  background-repeat: no-repeat;
+  background-position: 8px 9px;
+
+  @media (--viewportMedium) {
+    background-position: 8px 14px;
+  }
+}
+
 .open {
   & input {
     border-radius: 6px 6px 0 0;

--- a/src/components/DatePicker/DatePickers/SingleDatePicker.js
+++ b/src/components/DatePicker/DatePickers/SingleDatePicker.js
@@ -143,7 +143,7 @@ export const SingleDatePicker = props => {
         >
           <input
             id={id}
-            className={css.input}
+            className={classNames(css.input, { [css.inputPlaceholder]: !value })}
             placeholder={placeholderText}
             value={dateData.formatted}
             {...inputProps}

--- a/src/components/DatePicker/DatePickers/SingleDatePicker.js
+++ b/src/components/DatePicker/DatePickers/SingleDatePicker.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useIntl } from 'react-intl';
 import classNames from 'classnames';
 
@@ -17,18 +17,21 @@ const dateFormatOptions = {
 
 export const SingleDatePicker = props => {
   const intl = useIntl();
+  const [mounted, setMounted] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
-  const [date, setDate] = useState(props.value || null);
-  const [rawValue, setRawValue] = useState(
-    props.value ? intl.formatDate(props.value, dateFormatOptions) : ''
-  );
+  const [dateData, setDateData] = useState({
+    date: props.value || null,
+    formatted: props.value ? intl.formatDate(props.value, dateFormatOptions) : '',
+  });
   const element = useRef(null);
+
   const {
     className,
     rootClassName,
     inputClassName,
     popupClassName,
     id,
+    name,
     placeholderText,
     isDayBlocked,
     onChange,
@@ -36,16 +39,33 @@ export const SingleDatePicker = props => {
     readOnly,
     ...rest
   } = props;
+
+  // If value has changed, update internal state
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (mounted) {
+      // If mounted, changes to value should be reflected to 'date' state
+      setDateData({
+        date: value,
+        formatted: value ? intl.formatDate(value, dateFormatOptions) : '',
+      });
+    }
+  }, [mounted, value]);
+
   const pickerId = `${id}_SingleDatePicker`;
 
   const classes = classNames(rootClassName || css.root, className, css.outsideClickWrapper);
   const startDateMaybe =
-    date instanceof Date && !isNaN(date) ? { startDate: getISODateString(date) } : {};
+    dateData.date instanceof Date && !isNaN(dateData.date)
+      ? { startDate: getISODateString(dateData.date) }
+      : {};
 
   const handleChange = value => {
     const startOfDay = getStartOfDay(value);
-    setDate(startOfDay);
-    setRawValue(intl.formatDate(startOfDay, dateFormatOptions));
+    setDateData({ date: startOfDay, formatted: intl.formatDate(startOfDay, dateFormatOptions) });
     setIsOpen(false);
 
     if (element.current) {
@@ -60,24 +80,22 @@ export const SingleDatePicker = props => {
   const handleOnChangeOnInput = e => {
     const inputStr = e.target.value;
     if (!inputStr) {
-      setDate(null);
-    }
-
-    const d = new Date(inputStr);
-    if (d instanceof Date && !isNaN(d)) {
-      handleChange(d);
+      setDateData({ date: null, formatted: inputStr });
+      return;
     }
 
     if (isValidDateString(inputStr)) {
       const d = new Date(inputStr);
       if (isDayBlocked(d)) {
-        setRawValues('');
-        handleChange(d);
+        setDateData({ date: dateData.date, formatted: '' });
+        return;
+      } else {
+        setDateData({ date: d, formatted: intl.formatDate(d, dateFormatOptions) });
         return;
       }
     }
 
-    setRawValue(inputStr);
+    setDateData({ date: dateData.date, formatted: inputStr });
   };
 
   const handleBlur = () => {
@@ -127,7 +145,7 @@ export const SingleDatePicker = props => {
             id={id}
             className={css.input}
             placeholder={placeholderText}
-            value={rawValue}
+            value={dateData.formatted}
             {...inputProps}
           />
         </div>
@@ -139,7 +157,7 @@ export const SingleDatePicker = props => {
               showMonthStepper={true}
               onChange={handleChange}
               isDayBlocked={isDayBlocked}
-              value={date}
+              value={dateData.date}
               {...startDateMaybe}
               {...rest}
             />

--- a/src/components/DatePicker/DatePickers/SingleDatepicker.module.css
+++ b/src/components/DatePicker/DatePickers/SingleDatepicker.module.css
@@ -20,6 +20,16 @@
   }
 }
 
+.inputPlaceholder {
+  background-image: url('data:image/svg+xml;utf8,<svg width="16" height="16" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd"><g stroke="%2396969C" transform="translate(1 1)"><rect stroke-width="1.25" stroke-linecap="round" stroke-linejoin="round" x=".292" y="1.459" width="13.417" height="12.25" rx="1"/><path d="M3.208.292V3.21M10.792.292V3.21M.292 4.376h13.416" stroke-linecap="round" stroke-linejoin="round"/><rect x="3.5" y="6.5" width="1" height="1" rx=".5"/><rect x="6.5" y="6.5" width="1" height="1" rx=".5"/><rect x="9.5" y="6.5" width="1" height="1" rx=".5"/><rect x="3.5" y="9.5" width="1" height="1" rx=".5"/><rect x="6.5" y="9.5" width="1" height="1" rx=".5"/><rect x="9.5" y="9.5" width="1" height="1" rx=".5"/></g></g></svg>');
+  background-repeat: no-repeat;
+  background-position: 8px 9px;
+
+  @media (--viewportMedium) {
+    background-position: 8px 14px;
+  }
+}
+
 .open {
   & .input {
     border-radius: 6px 6px 0 0;

--- a/src/components/DatePicker/FieldDateRangePicker/FieldDateRangePicker.example.js
+++ b/src/components/DatePicker/FieldDateRangePicker/FieldDateRangePicker.example.js
@@ -9,6 +9,9 @@ import { Button } from '../../../components';
 
 import FieldDateRangePicker from './FieldDateRangePicker';
 
+const TODAY = new Date();
+const OVERMORROW = new Date(TODAY.getTime() + 2 * 24 * 60 * 60 * 1000);
+const DAY_AFTER_OVERMORROW = new Date(TODAY.getTime() + 3 * 24 * 60 * 60 * 1000);
 const identity = v => v;
 
 const FormComponent = props => (
@@ -92,6 +95,57 @@ export const Empty = {
     },
     onSubmit: values => {
       console.log('Submitting a form with values:', values);
+    },
+  },
+  group: 'inputs',
+};
+
+export const InitialData = {
+  component: FormComponent,
+  props: {
+    style: { marginBottom: '140px' },
+    dateInputProps: {
+      name: 'bookingDates',
+      isDaily: false,
+      startDateId: 'EmptyDateRange_bookingStartDate',
+      startDateLabel: 'Start date',
+      startDatePlaceholderText: startDatePlaceholderText,
+      endDateId: 'EmptyDateRange_bookingEndDate',
+      endDateLabel: 'End date',
+      endDatePlaceholderText: endDatePlaceholderText,
+      format: identity,
+      validate: composeValidators(
+        required('Required'),
+        bookingDatesRequired('Start date is not valid', 'End date is not valid')
+      ),
+      onBlur: () => console.log('onBlur called from DateRangeInput props.'),
+      onFocus: () => console.log('onFocus called from DateRangeInput props.'),
+      isBlockedBetween: () => {
+        return false;
+      },
+      isDayBlocked: () => {
+        return false;
+      },
+      isOutsideRange: () => {
+        return false;
+      },
+    },
+    onChange: formState => {
+      const { startDate, endDate } = formState.values?.bookingDates || {};
+      if (startDate || endDate) {
+        console.log(
+          'Changed to',
+          startDate ? formatDate(startDate) : startDate,
+          '-',
+          endDate ? formatDate(endDate) : endDate
+        );
+      }
+    },
+    onSubmit: values => {
+      console.log('Submitting a form with values:', values);
+    },
+    initialValues: {
+      bookingDates: { startDate: OVERMORROW, endDate: DAY_AFTER_OVERMORROW },
     },
   },
   group: 'inputs',

--- a/src/components/DatePicker/FieldSingleDatePicker/FieldSingleDatePicker.example.js
+++ b/src/components/DatePicker/FieldSingleDatePicker/FieldSingleDatePicker.example.js
@@ -1,14 +1,18 @@
 import React from 'react';
 import { Form as FinalForm, FormSpy } from 'react-final-form';
-import { Button } from '../../../components';
+
 import { required, bookingDateRequired, composeValidators } from '../../../util/validators';
+import { Button } from '../../../components';
+
 import FieldSingleDatePicker from './FieldSingleDatePicker';
 
+const TODAY = new Date();
+const OVERMORROW = new Date(TODAY.getTime() + 2 * 24 * 60 * 60 * 1000);
 const identity = v => v;
 
 const options = { weekday: 'short', month: 'long', day: 'numeric' };
 const formatDate = date => new Intl.DateTimeFormat('en-US', options).format(date);
-const placeholderText = formatDate(new Date());
+const placeholderText = formatDate(TODAY);
 
 const FormComponent = props => (
   <FinalForm
@@ -72,6 +76,38 @@ export const Empty = {
     },
     onSubmit: values => {
       console.log('Submitting a form with values:', values);
+    },
+  },
+  group: 'inputs',
+};
+
+export const InitialData = {
+  component: FormComponent,
+  props: {
+    style: { marginBottom: '140px' },
+    dateInputProps: {
+      name: 'bookingDate',
+      useMobileMargins: false,
+      id: `EmptyDateInputForm.bookingDate`,
+      label: 'Date',
+      placeholderText,
+      format: identity,
+      validate: composeValidators(required('Required'), bookingDateRequired('Date is not valid')),
+      onBlur: () => console.log('onBlur called from DateInput props.'),
+      onFocus: () => console.log('onFocus called from DateInput props.'),
+    },
+    onChange: formState => {
+      const { date } = formState.values;
+      if (date) {
+        const formattedDate = formatDate(date);
+        console.log('Changed to', formattedDate);
+      }
+    },
+    onSubmit: values => {
+      console.log('Submitting a form with values:', values);
+    },
+    initialValues: {
+      bookingDate: { date: OVERMORROW },
     },
   },
   group: 'inputs',


### PR DESCRIPTION
These make form API changes work:
`formApi.change('bookingDates', { startDate: new Date('2024-11-15'), endDate: new Date('2024-11-18') })`

I.e. using form API didn't work correctly.
The changed day was not reflected on the input field.
(Final Form kept track, though)

This refactors SingleDatePicker and DateRangePicker by combining date and its formatting.
It updates date/dateRange data if passed-in input value changes.