### PR TITLE
fix: Menu has a regression bug that's visible on ManageListingCard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] ManageListingCard: Menu has a regression bug on mobile layout. Note: if Menu component needs
+  to use full screenwidth on mobile, add preferScreenWidthOnMobile.
+  [#494](https://github.com/sharetribe/web-template/pull/494)
 - [change] Refactor SingleDatePicker and DateRangePicker by combining date and its formatting. It
   updates dateData if passed-in input value changes.
   [#492](https://github.com/sharetribe/web-template/pull/492)

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -17,7 +17,7 @@
  */
 
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import { bool, func, node, number, string } from 'prop-types';
 import classNames from 'classnames';
 
 import { MenuContent, MenuLabel } from '../../components';
@@ -112,7 +112,7 @@ class Menu extends Component {
       const usePositionLeftFromLabel = contentPosition === CONTENT_TO_LEFT;
       const contentPlacementOffset = this.props.contentPlacementOffset;
 
-      if (windowWidth <= MAX_MOBILE_SCREEN_WIDTH) {
+      if (this.props.preferScreenWidthOnMobile && windowWidth <= MAX_MOBILE_SCREEN_WIDTH) {
         // Take full screen width on mobile
         return {
           left: -1 * (rect.left - 24),
@@ -213,9 +213,8 @@ Menu.defaultProps = {
   isOpen: null,
   onToggleActive: null,
   useArrow: true,
+  preferScreenWidthOnMobile: false,
 };
-
-const { bool, func, node, number, string } = PropTypes;
 
 Menu.propTypes = {
   children: node.isRequired,
@@ -226,6 +225,7 @@ Menu.propTypes = {
   useArrow: bool,
   isOpen: bool,
   onToggleActive: func,
+  preferScreenWidthOnMobile: bool,
 };
 
 export default Menu;

--- a/src/containers/SearchPage/SortBy/SortByPopup.js
+++ b/src/containers/SearchPage/SortBy/SortByPopup.js
@@ -63,6 +63,7 @@ const SortByPopup = props => {
       contentPosition="left"
       onToggleActive={onToggleActive}
       isOpen={isOpen}
+      preferScreenWidthOnMobile
     >
       <MenuLabel rootClassName={menuLabelClasses}>
         {menuLabel}


### PR DESCRIPTION
Menu has a regression bug on UI for mobile layout. It's visible on the ManageListingCard:
![Screenshot 2024-11-06 at 13 57 17](https://github.com/user-attachments/assets/d230fec9-860d-4656-8dad-840c878a0d82)

The UI should look like this with the 3-dot menu on the ManageListingCard:
![Screenshot 2024-11-06 at 13 57 44](https://github.com/user-attachments/assets/e342cf8d-52e1-4a16-aea0-4caef7c0643a)

The reason why full-width is needed on some occasions:
![Screenshot 2024-11-06 at 13 58 10](https://github.com/user-attachments/assets/7ae55c1c-7f71-42ea-8d74-2211f51294a1)
This is now reached if property _preferScreenWidthOnMobile_ is passed to Menu.

Note: if the 3-dot menu is expanded at some point with more menu items, it's likely that we move towards full-width usage there too.