### PR TITLE
Open discard modal only if scrolling is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ way to update this template, but currently, we follow a pattern:
 ---
 
 ## Upcoming version 2024-XX-XX
+- [fix] Open discard modal on ManageListingsPage only if scrolling is disabled. 
+  Fixes an issue where opening the discard draft modal on mobile scrolled the page to the very bottom.
+  [#497](https://github.com/sharetribe/web-template/pull/497)
+
 
 ## [v6.1.0] 2024-11-06
 

--- a/src/containers/ManageListingsPage/ManageListingsPage.js
+++ b/src/containers/ManageListingsPage/ManageListingsPage.js
@@ -210,13 +210,15 @@ export const ManageListingsPageComponent = props => {
               />
             ))}
           </div>
-          <DiscardDraftModal
-            id="ManageListingsPage"
-            isOpen={discardDraftModalOpen}
-            onManageDisableScrolling={onManageDisableScrolling}
-            onCloseModal={() => setDiscardDraftModalOpen(false)}
-            onDiscardDraft={handleDiscardDraft}
-          />
+          {onManageDisableScrolling && discardDraftModalOpen ? (
+            <DiscardDraftModal
+              id="ManageListingsPage"
+              isOpen={discardDraftModalOpen}
+              onManageDisableScrolling={onManageDisableScrolling}
+              onCloseModal={() => setDiscardDraftModalOpen(false)}
+              onDiscardDraft={handleDiscardDraft}
+            />
+          ) : null}
 
           <PaginationLinksMaybe
             listingsAreLoaded={listingsAreLoaded}


### PR DESCRIPTION
Fixes an issue where opening the discard draft modal on mobile scrolled the page to the very bottom.