### PR TITLE
ConfirmSignupForm: show spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [fix] ConfirmSignupForm: show spinner. (Handling for confirmInProgress state was missing.)
+  [#504](https://github.com/sharetribe/web-template/pull/504)
 - [fix] Topbar: if multiple custom links has the same text, the virtual DOM is confused.
   [#502](https://github.com/sharetribe/web-template/pull/502)
 - [fix] PaymentMethodsPage: full page load did not fetch defaultPaymentMethod.

--- a/src/ducks/auth.duck.js
+++ b/src/ducks/auth.duck.js
@@ -124,8 +124,8 @@ export default function reducer(state = initialState, action = {}) {
 // ================ Selectors ================ //
 
 export const authenticationInProgress = state => {
-  const { loginInProgress, logoutInProgress, signupInProgress } = state.auth;
-  return loginInProgress || logoutInProgress || signupInProgress;
+  const { loginInProgress, logoutInProgress, signupInProgress, confirmInProgress } = state.auth;
+  return loginInProgress || logoutInProgress || signupInProgress || confirmInProgress;
 };
 
 // ================ Action creators ================ //


### PR DESCRIPTION
## Description
This PR updates the `authenticationInProgress` function in `auth.duck` to include `confirmInProgress` in the state check. This change ensures that if a confirmation process is in progress, it sets the `inProgress` flag in `ConfirmSignupForm`, displaying a spinner to inform the user that the request is ongoing.

## Changes
- Added `confirmInProgress` to the `authenticationInProgress` function to track the confirmation request state along with login, logout, and signup.

Note: compared to to PR #499, this just adds a changelog entry