### PR TITLE
Disallow upgrading to Node.js v23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2024-XX-XX
 
+- [change] Node v23.2 is failing. Add engine rule for node (">=18.20.1 <23.2.0") for now.
+  [#505](https://github.com/sharetribe/web-template/pull/505)
 - [change] Update mapbox-gl-js (v1.0.0 => v3.7.0) and mapbox-sdk-js (0.6.0 => 0.16.1) Note: Mapbox
   license changed in v2 (and pricing for non-mapbox related map tiles)
   https://github.com/mapbox/mapbox-gl-js/releases/tag/v2.0.0

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     ]
   },
   "engines": {
-    "node": ">=18.20.1"
+    "node": ">=18.20.1 <23.2.0"
   },
   "prettier": {
     "singleQuote": true,


### PR DESCRIPTION
Build script fails when our fork of create-react-app's build script is executed:
```sh
$ sharetribe-scripts build
Creating an optimized production build...
Failed to compile.

Unexpected end of JSON input
```

This looks pretty much the same issue which has been reported on nodejs repository:
https://github.com/nodejs/node/issues/55826