### PR TITLE
SingeDatePicker: fix passed-in value handling 

### DIFF
--- a/src/components/DatePicker/DatePickers/SingleDatePicker.js
+++ b/src/components/DatePicker/DatePickers/SingleDatePicker.js
@@ -46,7 +46,7 @@ export const SingleDatePicker = props => {
   }, []);
 
   useEffect(() => {
-    if (mounted) {
+    if (mounted && value?.getTime() !== dateData?.date?.getTime()) {
       // If mounted, changes to value should be reflected to 'date' state
       setDateData({
         date: value,


### PR DESCRIPTION
SingeDatePicker: don't update value to dateData if it has the same timestamp

Calendar month navigation was not working when date was set. This happened because useEffect was setting dateData every render and that causes the month of the selected date to be shown.