### PR TITLE
Allow hiding top bar search based on config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [add] Add support for hiding the Topbar search based on configuration. 
+  [#531](https://github.com/sharetribe/web-template/pull/531)
+
 ## [v7.0.0] 2025-01-15
 
 - [fix] ListingPage: fetchMonthlyTimeSlots didn't work correctly with day unitType.

--- a/src/containers/SearchPage/SearchPage.test.js
+++ b/src/containers/SearchPage/SearchPage.test.js
@@ -209,6 +209,11 @@ const getConfig = (variantType, customListingFields) => {
       ...hostedConfig.layout,
       searchPage: { variantType },
     },
+    topbar: {
+      searchBar: {
+        display: 'always',
+      },
+    },
   };
 };
 

--- a/src/containers/TopbarContainer/Topbar/Topbar.js
+++ b/src/containers/TopbarContainer/Topbar/Topbar.js
@@ -28,6 +28,10 @@ import css from './Topbar.module.css';
 
 const MAX_MOBILE_SCREEN_WIDTH = 1024;
 
+const SEARCH_DISPLAY_ALWAYS = 'always';
+const SEARCH_DISPLAY_NOT_LANDING_PAGE = 'notLandingPage';
+const SEARCH_DISPLAY_ONLY_SEARCH_PAGE = 'onlySearchPage';
+
 const redirectToURLWithModalState = (history, location, modalStateParam) => {
   const { pathname, search, state } = location;
   const searchString = `?${stringify({ [modalStateParam]: 'open', ...parse(search) })}`;
@@ -244,6 +248,31 @@ const TopbarComponent = props => {
 
   const classes = classNames(rootClassName || css.root, className);
 
+  const { display: searchFormDisplay = SEARCH_DISPLAY_ALWAYS } = config?.topbar?.searchBar || {};
+
+  // Search form is shown conditionally depending on configuration and
+  // the current page.
+  const showSearchOnAllPages = searchFormDisplay === SEARCH_DISPLAY_ALWAYS;
+  const showSearchOnSearchPage =
+    searchFormDisplay === SEARCH_DISPLAY_ONLY_SEARCH_PAGE && resolvedCurrentPage === 'SearchPage';
+  const showSearchNotOnLandingPage =
+    searchFormDisplay === SEARCH_DISPLAY_NOT_LANDING_PAGE && resolvedCurrentPage !== 'LandingPage';
+
+  const showSearchForm =
+    showSearchOnAllPages || showSearchOnSearchPage || showSearchNotOnLandingPage;
+
+  const mobileSearchButtonMaybe = showSearchForm ? (
+    <Button
+      rootClassName={css.searchMenu}
+      onClick={() => redirectToURLWithModalState(history, location, 'mobilesearch')}
+      title={intl.formatMessage({ id: 'Topbar.searchIcon' })}
+    >
+      <SearchIcon className={css.searchMenuIcon} />
+    </Button>
+  ) : (
+    <div className={css.searchMenu} />
+  );
+
   return (
     <div className={classes}>
       <LimitedAccessBanner
@@ -268,13 +297,7 @@ const TopbarComponent = props => {
           alt={intl.formatMessage({ id: 'Topbar.logoIcon' })}
           linkToExternalSite={config?.topbar?.logoLink}
         />
-        <Button
-          rootClassName={css.searchMenu}
-          onClick={() => redirectToURLWithModalState(history, location, 'mobilesearch')}
-          title={intl.formatMessage({ id: 'Topbar.searchIcon' })}
-        >
-          <SearchIcon className={css.searchMenuIcon} />
-        </Button>
+        {mobileSearchButtonMaybe}
       </div>
       <div className={css.desktop}>
         <TopbarDesktop
@@ -290,6 +313,7 @@ const TopbarComponent = props => {
           onSearchSubmit={handleSubmit}
           config={config}
           customLinks={customLinks}
+          showSearchForm={showSearchForm}
         />
       </div>
       <Modal

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -123,6 +123,7 @@ const ProfileMenu = ({ currentPage, currentUser, onLogout }) => {
  * @param {Object?} props.initialSearchFormValues
  * @param {Object} props.intl
  * @param {Object} props.config
+ * @param {boolean} props.showSearchForm
  * @returns {JSX.Element} search icon
  */
 const TopbarDesktop = props => {
@@ -140,6 +141,7 @@ const TopbarDesktop = props => {
     onLogout,
     onSearchSubmit,
     initialSearchFormValues = {},
+    showSearchForm,
   } = props;
   const [mounted, setMounted] = useState(false);
 
@@ -168,6 +170,21 @@ const TopbarDesktop = props => {
   const signupLinkMaybe = isAuthenticatedOrJustHydrated ? null : <SignupLink />;
   const loginLinkMaybe = isAuthenticatedOrJustHydrated ? null : <LoginLink />;
 
+  const searchFormMaybe = showSearchForm ? (
+    <TopbarSearchForm
+      className={classNames(css.searchLink, { [css.takeAvailableSpace]: giveSpaceForSearch })}
+      desktopInputRoot={css.topbarSearchWithLeftPadding}
+      onSubmit={onSearchSubmit}
+      initialValues={initialSearchFormValues}
+      appConfig={config}
+    />
+  ) : (
+    <div
+      className={classNames(css.spacer, { [css.takeAvailableSpace]: giveSpaceForSearch })}
+      desktopInputRoot={css.topbarSearchWithLeftPadding}
+    />
+  );
+
   return (
     <nav className={classes}>
       <LinkedLogo
@@ -176,13 +193,7 @@ const TopbarDesktop = props => {
         alt={intl.formatMessage({ id: 'TopbarDesktop.logo' }, { marketplaceName })}
         linkToExternalSite={config?.topbar?.logoLink}
       />
-      <TopbarSearchForm
-        className={classNames(css.searchLink, { [css.takeAvailableSpace]: giveSpaceForSearch })}
-        desktopInputRoot={css.topbarSearchWithLeftPadding}
-        onSubmit={onSearchSubmit}
-        initialValues={initialSearchFormValues}
-        appConfig={config}
-      />
+      {searchFormMaybe}
 
       <CustomLinksMenu
         currentPage={currentPage}

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.module.css
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.module.css
@@ -44,6 +44,12 @@
   margin-right: auto;
 }
 
+.spacer {
+  min-width: 320px;
+  height: 100%;
+  margin-right: auto;
+}
+
 .search {
   font-weight: var(--fontWeightMedium);
   font-size: 15px;


### PR DESCRIPTION
Add support for hiding the top bar search based on configuration. The configuration options, that are also defined in Console, are
- always display search in top bar
- don't display search in top bar on Landing page
- only display search in top bar on Search page

<img width="990" alt="no-search-top-bar" src="https://github.com/user-attachments/assets/4a05050d-0f1f-4a09-9b74-2f07ac2ed92e" />
