### PR TITLE
New release v7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+## [v7.0.0] 2025-01-15
+
+This major release takes the React v17.0.2 into use.
+
 - [fix] EditListingWizard: fix a bug with YouTube field.
   [#533](https://github.com/sharetribe/web-template/pull/533)
 - [fix] CustomExtendedDataField.module.css: add missing customMediaQuery import.
@@ -38,6 +42,8 @@ way to update this template, but currently, we follow a pattern:
   [#524](https://github.com/sharetribe/web-template/pull/524)
 - [change] Update the wording of the numberTooSmall error message for consistency.
   [#522](https://github.com/sharetribe/web-template/pull/522)
+
+  [v7.0.0]: https://github.com/sharetribe/web-template/compare/v6.3.0...v7.0.0
 
 ## [v6.3.0] 2025-01-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This release updates Sharetribe Web Template to work with React v18 (v18.3.1)
- https://react.dev/blog/2022/03/29/react-v18
- https://react.dev/blog/2022/03/08/react-18-upgrade-guide
- https://18.react.dev/
- https://www.github.com/reactwg/react-18/discussions/4

Besides v18, there are also other improvements and fixes.

## Notes for ppl taking update from this repo:

**_react-dom has been split_**
_react-dom/server_ is a separated from the rest of the package. Template loads this separately (but we kept the file structure the same).

**_sharetribe-scripts_**
The dependency had a somewhat embarrasing bug with Loadable Components setup causing hydration issue with v18. The earlier React versions were able to resolve the issue silently, but v18 is more strict to enforce that the server-side rendered (SSR) HTML matches with the HTML created on the first rendering pass on the browser / client-side rendering (CSR).

The fix was small (one-liner), but it caused UI issue on SearchPage (map layout was broken). Therefore, the new release for the sharetribe-scripts is going to be a major one (instead of a patch release).

**_Other hydration issues we encountered_**
There were some components that used `typeof window === 'undefined'` type of checks directly on rendering function. Those will cause hydration issues with React v18 (as SSR returns true and CSR returns false), if the check causes different HTML structure.

Similarly, some components used `matchMedia` to change HTML on for mobile and desktop layouts. With React v18, you need to make the first pass on CSR to match with the SSR. One way to do that is to track when the component is mounted:

```jsx
const MyComponent = props => {
  const [mounted, setMounted] = useState(false);
  useEffect(() => {
    setMounted(true);
  }, []);
  
  const isMobileLayout =
    mounted && window?.matchMedia ? window.matchMedia(`(max-width: 767px)`)?.matches : true;

 return isMobileLayout ? <div>Hello</div> : <main>world</main>;
};
```
With this kind of code, the first CSR rendering does not pick 'desktop' layout. There will be a second rendering pass after the _mounted_ flag is turned to true.

**_Dependency libraries_**
Several dependency libraries have been updated to support React v18.

**_Spreading key prop from list items throws a warning_**
Component's key can't be spread from collection of props anymore.

```diff
-        const { schemaType, ...fieldProps } = customFieldProps;
+        const { schemaType, key, ...fieldProps } = customFieldProps;
         return schemaType === SCHEMA_TYPE_MULTI_ENUM ? (
-          <SectionMultiEnumMaybe {...fieldProps} />
+          <SectionMultiEnumMaybe key={key} {...fieldProps} />
```

_**defaultProps** and propTypes_
React v18.3.1 has deprecated defaultProps in favor of JavaScripts (ES6) native default parameters for spread. This PR changes all the places, where defaultProps has been used. In addition, propTypes will also be removed on next React version (v19). Therefore, we have removed propTypes too and added the same information as JSDoc comment for the exported components.

If you want to postpone defaultProps removal, you could choose v18.2 instead of v18.3.1. The latter gives the warning about deprecation.

Most of the changes in this PR is about propTypes & JSDoc comments.

**_Tests_**
There was changes to the Testing Library setup (we started to use `act` as rendering became more asynchronous with the updated libraries). Note: act is imported differently between React v18.2 and v18.3.1. If you choose to use v18.2, you need to import act from the React Testing Library instead of importing it directly from React.

**_What about server components?_**
We didn't start to use server components at this point. It would affect only few public routes (landing page, search, listing and profile pages mainly) and we already have SSR in place for the public pages. Furthermore, relevant page schema for bots that don’t render JavaScript, won’t be available if loadData is not completed on the server.

You are of course, free to explore and try that approach yourself, but do notice that you'd need to start streaming the server content with **_renderToPipeableStream_** and React’s expectation is that the whole HTML is part of React app. Template renders only part of the DOM: the app UI is rendered to a string that is then injected inside public/index.html document.

Read more about streaming:
- Team (on IBM) ended up doing it like this: https://www.github.com/gregberge/loadable-components/issues/718#issuecomment-1972240715
- Dealing with separate app and index.html: https://stackoverflow.com/a/72859191

**_What about React v19?_**
React v19 is released a month ago, but not all the dependency libraries support it atm. We don't plan to make v19 update anytime soon, but v18.3.1 is the last version before that major update: it already started to warn about deprecated features (like defaultProps & propTypes). Therefore that update might not be as huge as this one was.

## Translation changes
### New keys
```json
  "EditListingAvailabilityPlanForm.delete": "Delete",
```
Note: this key was shared already before with Seats feature release (v6.3.0)

### changed translations
```json
  "CustomExtendedDataField.numberTooSmall": "The number must be greater than or equal to {min}",
```

## [Changes] v7.0.0

This major release takes the React v17.0.2 into use.

- [fix] EditListingWizard: fix a bug with YouTube field.
  [#533](https://github.com/sharetribe/web-template/pull/533)
- [fix] CustomExtendedDataField.module.css: add missing customMediaQuery import.
  [#532](https://github.com/sharetribe/web-template/pull/532)
- [change] This updates Sharetribe Web Template to use React v18 (v18.3.1). Some highlights:

  - Several dependency libraries have been updated.
  - Hydration is much more strict now. First render on client-side must match the server-side
    render.

  [#523](https://github.com/sharetribe/web-template/pull/523)

- [add] Add currently available translations for DE.
  [#529](https://github.com/sharetribe/web-template/pull/529)
- [fix] a link inside the inquiry message was invisible for the sender of the inquiry.
  [#528](https://github.com/sharetribe/web-template/pull/528)
- [add] Add currently available translations for DE, ES, FR.
  [#527](https://github.com/sharetribe/web-template/pull/527)
- [fix] AvailabilityPlanForm had a hard-coded "Delete" text.
  [#525](https://github.com/sharetribe/web-template/pull/525)
- [add] Add currently available translations for DE, ES, FR.
  [#524](https://github.com/sharetribe/web-template/pull/524)
- [change] Update the wording of the numberTooSmall error message for consistency.
  [#522](https://github.com/sharetribe/web-template/pull/522)

  [Changes]: https://github.com/sharetribe/web-template/compare/v6.3.0...v7.0.0
