### PR TITLE
Fix: offer's schema should use dot as subunit separator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## [v7.0.0] 2025-01-15
 
+- [change] Google's search schema requires a price that uses dot as decimal separator.
+  [#535](https://github.com/sharetribe/web-template/pull/535)
+
 This major release takes the React v17.0.2 into use.
 
 - [fix] EditListingWizard: fix a bug with YouTube field.

--- a/src/containers/ListingPage/ListingPage.shared.js
+++ b/src/containers/ListingPage/ListingPage.shared.js
@@ -48,15 +48,12 @@ export const priceData = (price, marketplaceCurrency, intl) => {
  * @param {Money} price
  * @returns {Money|null}
  */
-export const priceForSchemaMaybe = (price, intl) => {
+export const priceForSchemaMaybe = price => {
   try {
     const schemaPrice = convertMoneyToNumber(price);
     return schemaPrice
       ? {
-          price: intl.formatNumber(schemaPrice, {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
-          }),
+          price: schemaPrice.toFixed(2),
           priceCurrency: price.currency,
         }
       : {};

--- a/src/containers/ListingPage/ListingPageCarousel.js
+++ b/src/containers/ListingPage/ListingPageCarousel.js
@@ -309,7 +309,7 @@ export const ListingPageComponent = props => {
         offers: {
           '@type': 'Offer',
           url: productURL,
-          ...priceForSchemaMaybe(price, intl),
+          ...priceForSchemaMaybe(price),
           ...availabilityMaybe,
         },
       }}

--- a/src/containers/ListingPage/ListingPageCoverPhoto.js
+++ b/src/containers/ListingPage/ListingPageCoverPhoto.js
@@ -311,7 +311,7 @@ export const ListingPageComponent = props => {
         offers: {
           '@type': 'Offer',
           url: productURL,
-          ...priceForSchemaMaybe(price, intl),
+          ...priceForSchemaMaybe(price),
           ...availabilityMaybe,
         },
       }}


### PR DESCRIPTION
Let's not localize the price schema, but use Number with fixed number of decimal places.
https://schema.org/price