### PR TITLE
TransactionPage.duck.js: fix fetchMonthlyTimeSlots for inquiries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## [v7.0.0] 2025-01-15
 
+- [fix] ListingPage: fetchMonthlyTimeSlots didn't work correctly with day unitType.
+  [#536](https://github.com/sharetribe/web-template/pull/536)
 - [change] Google's search schema requires a price that uses dot as decimal separator.
   [#535](https://github.com/sharetribe/web-template/pull/535)
 

--- a/src/containers/ListingPage/ListingPage.duck.js
+++ b/src/containers/ListingPage/ListingPage.duck.js
@@ -342,17 +342,15 @@ export const sendInquiry = (listing, message) => (dispatch, getState, sdk) => {
 };
 
 // Helper function for loadData call.
+// Note: listing could be ownListing entity too
 const fetchMonthlyTimeSlots = (dispatch, listing) => {
   const hasWindow = typeof window !== 'undefined';
-  const attributes = listing.attributes;
-  // Listing could be ownListing entity too, so we just check if attributes key exists
-  const hasTimeZone =
-    attributes && attributes.availabilityPlan && attributes.availabilityPlan.timezone;
+  const { availabilityPlan, publicData } = listing?.attributes || {};
+  const tz = availabilityPlan?.timezone;
 
   // Fetch time-zones on client side only.
-  if (hasWindow && listing.id && hasTimeZone) {
-    const tz = listing.attributes.availabilityPlan.timezone;
-    const unitType = attributes?.publicData?.unitType;
+  if (hasWindow && listing.id && !!tz) {
+    const unitType = publicData?.unitType;
     const timeUnit = unitType === 'hour' ? 'hour' : 'day';
     const nextBoundary = findNextBoundary(new Date(), timeUnit, tz);
 

--- a/src/containers/TransactionPage/TransactionPage.duck.js
+++ b/src/containers/TransactionPage/TransactionPage.duck.js
@@ -332,15 +332,14 @@ export const fetchTimeSlots = (listingId, start, end, timeZone) => (dispatch, ge
 // Helper function for loadData call.
 const fetchMonthlyTimeSlots = (dispatch, listing) => {
   const hasWindow = typeof window !== 'undefined';
-  const attributes = listing.attributes;
-  // Listing could be ownListing entity too, so we just check if attributes key exists
-  const hasTimeZone =
-    attributes && attributes.availabilityPlan && attributes.availabilityPlan.timezone;
+  const { availabilityPlan, publicData } = listing?.attributes || {};
+  const tz = availabilityPlan?.timezone;
 
   // Fetch time-zones on client side only.
-  if (hasWindow && listing.id && hasTimeZone) {
-    const tz = listing.attributes.availabilityPlan.timezone;
-    const nextBoundary = findNextBoundary(new Date(), 'hour', tz);
+  if (hasWindow && listing.id && !!tz) {
+    const unitType = publicData?.unitType;
+    const timeUnit = unitType === 'hour' ? 'hour' : 'day';
+    const nextBoundary = findNextBoundary(new Date(), timeUnit, tz);
 
     const nextMonth = getStartOf(nextBoundary, 'month', tz, 1, 'months');
     const nextAfterNextMonth = getStartOf(nextMonth, 'month', tz, 1, 'months');


### PR DESCRIPTION
Inquiries didn't take unitType into account when fetching timeSlots for day & night bookings.
This caused current day to be available for the booking start time (which then jammed the end-time picker)

Note: current day is not selectable atm.