### PR TITLE
wip (private marketplace: sitemap crawling issue)

### DIFF
--- a/server/apiServer.js
+++ b/server/apiServer.js
@@ -45,7 +45,12 @@ app.use(compression());
 app.get('/robots.txt', robotsTxtRoute);
 
 // Handle different sitemap-* resources. E.g. /sitemap-index.xml
-app.get('/sitemap-:resource', sitemapResourceRoute);
+// Note: we don't use /sitemap-* because private marketplace concept would have a robots.txt issue:
+// disallowing route /s would also disallow /sitemap-*
+app.get('/sitemap-*', (req, res) => {
+  res.redirect('/robots' + req.originalUrl, '301');
+});
+app.get('/robots/sitemap-:resource', sitemapResourceRoute);
 
 app.listen(PORT, () => {
   console.log(`API server listening on ${PORT}`);

--- a/server/index.js
+++ b/server/index.js
@@ -150,7 +150,12 @@ app.get('/favicon.ico', (req, res) => {
 app.get('/robots.txt', robotsTxtRoute);
 
 // Handle different sitemap-* resources. E.g. /sitemap-index.xml
-app.get('/sitemap-:resource', sitemapResourceRoute);
+// Note: we don't use /sitemap-* because private marketplace concept would have a robots.txt issue:
+// disallowing route /s would also disallow /sitemap-*
+app.get('/sitemap-*', (req, res) => {
+  res.redirect('/robots' + req.originalUrl, '301');
+});
+app.get('/robots/sitemap-:resource', sitemapResourceRoute);
 
 // Generate web app manifest
 // When developing with "yarn run dev",

--- a/server/resources/README.md
+++ b/server/resources/README.md
@@ -23,8 +23,8 @@ access to the website.
 Robots.txt also contains a link to the sitemap, which is the reason why we generate this on the fly.
 Essentially, the _server/resources/robots.txt_ contains a URL
 _"https://my.marketplace.com/sitemap-index.xml"_, which is transformed to use the correct hostname
-from `REACT_APP_MARKETPLACE_ROOT_URL`. This transformation is done by the actual resource-script:
-**robotsTxt.js**.
+from `REACT_APP_MARKETPLACE_ROOT_URL` and subpath `/robots/sitemap-index.xml`. This transformation
+is done by the actual resource-script: **robotsTxt.js**.
 
 **Note**: on localhost, this file is served from the Dev port on apiServer.js (3500 aka
 http://localhost:3500/robots.txt) for debugging purposes.
@@ -57,7 +57,8 @@ is not.
 
 ### Sitemap Index
 
-We serve /sitemap-index.xml from the root. The _robotsTxt.js_ adds a link to the sitemap-index.xml
+We serve sitemap-index.xml from the robots folder. The _robotsTxt.js_ adds a link to the
+/robots/sitemap-index.xml
 
 The sitemap-index.xml contains links to 3 different sub sitemaps:
 

--- a/server/resources/robotsPrivateMarketplace.txt
+++ b/server/resources/robotsPrivateMarketplace.txt
@@ -4,8 +4,8 @@
 
 User-agent: *
 Disallow: /s
-Disallow: /u
-Disallow: /l
+Disallow: /u/
+Disallow: /l/
 Disallow: /profile-settings
 Disallow: /inbox
 Disallow: /order

--- a/server/resources/robotsTxt.js
+++ b/server/resources/robotsTxt.js
@@ -88,7 +88,7 @@ Crawl-Delay: 5
  * @param {String} robotsTxtPath
  */
 const sendRobotsTxt = (req, res, robotsTxtPath) => {
-  const sitemapIndexUrl = `${getRootURL({ useDevApiServerPort: true })}/sitemap-index.xml`;
+  const sitemapIndexUrl = `${getRootURL({ useDevApiServerPort: true })}/robots/sitemap-index.xml`;
 
   try {
     const modifiedStream = new Transform({

--- a/server/resources/sitemap.js
+++ b/server/resources/sitemap.js
@@ -114,8 +114,12 @@ const sitemapIndex = (req, res, rootUrl, isPrivateMarketplace) => {
 
     // Sitemap-index will contain the following sitemaps:
     const sitemaps = isPrivateMarketplace
-      ? ['/sitemap-default.xml', '/sitemap-recent-pages.xml']
-      : ['/sitemap-default.xml', '/sitemap-recent-listings.xml', '/sitemap-recent-pages.xml'];
+      ? ['/robots/sitemap-default.xml', '/robots/sitemap-recent-pages.xml']
+      : [
+          '/robots/sitemap-default.xml',
+          '/robots/sitemap-recent-listings.xml',
+          '/robots/sitemap-recent-pages.xml',
+        ];
 
     // Add sitemaps to the index
     sitemaps.forEach(sitemapPath => {


### PR DESCRIPTION
Suggestion to redirect /sitemap-... routes to /robots/sitemap-...

Before private marketplace feature, we had 2 resources: /s and /sitemap. 
Disallowing /s on robots.txt is the same as disallowing the path with a wildcard /s* (which basically disallows bots from following links to /sitemap-index.xml too)