### PR TITLE
add support for new google places api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ way to update this template, but currently, we follow a pattern:
 
 ## [v7.0.0] 2025-01-15
 
-This major release takes the React v17.0.2 into use.
+This major release takes the React v18.3.1 into use.
 
 - [fix] EditListingWizard: fix a bug with YouTube field.
   [#533](https://github.com/sharetribe/web-template/pull/533)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [add] Add support for the new Google Places API
+  [#539](https://github.com/sharetribe/web-template/pull/539)
 - [fix] SearchPageWithMap: duplicate class caused positioning issue on localhost:3000.
   [#546](https://github.com/sharetribe/web-template/pull/546)
 - [fix] TopbarDesktop: fix a typo (non-existent element attribute), when the search form was not

--- a/server/csp.js
+++ b/server/csp.js
@@ -42,6 +42,7 @@ const defaultDirectives = {
     assetCdnBaseUrl,
     '*.st-api.com',
     'maps.googleapis.com',
+    'places.googleapis.com',
     '*.tiles.mapbox.com',
     'api.mapbox.com',
     'events.mapbox.com',

--- a/src/components/LocationAutocompleteInput/GeocoderGoogleMapsNew.js
+++ b/src/components/LocationAutocompleteInput/GeocoderGoogleMapsNew.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import classNames from 'classnames';
+import * as googleMapsUtil from '../../util/googleMaps';
+import { userLocation } from '../../util/maps';
+
+import css from './LocationAutocompleteInput.module.css';
+
+export const CURRENT_LOCATION_ID = 'current-location';
+
+// When displaying data from the Google Maps Places API, and
+// attribution is required next to the results.
+// See: https://developers.google.com/places/web-service/policies#powered
+export const GeocoderAttribution = props => {
+  const { rootClassName, className } = props;
+  const classes = classNames(rootClassName || css.poweredByGoogle, className);
+  return <div className={classes} />;
+};
+
+/**
+ * A forward geocoding (place name -> coordinates) implementation
+ * using the Google Maps Places API.
+ */
+class GeocoderGoogleMaps {
+  constructor() {
+    this.sessionToken = null;
+  }
+  getSessionToken() {
+    this.sessionToken =
+      this.sessionToken || new window.google.maps.places.AutocompleteSessionToken();
+    return this.sessionToken;
+  }
+
+  // Public API
+  //
+
+  /**
+   * Search places with the given name.
+   *
+   * @param {String} search query for place names
+   *
+   * @return {Promise<{ search: String, predictions: Array<Object>}>}
+   * results of the geocoding, should have the original search query
+   * and an array of predictions. The format of the predictions is
+   * only relevant for the `getPlaceDetails` function below.
+   */
+  getPlacePredictions(search, countryLimit) {
+    const limitCountriesMaybe = countryLimit
+      ? {
+          componentRestrictions: {
+            country: countryLimit,
+          },
+        }
+      : {};
+
+    return googleMapsUtil
+      .getPlacePredictionsNew(search, this.getSessionToken(), limitCountriesMaybe)
+      .then(results => {
+        return {
+          search,
+          predictions: results.predictions,
+        };
+      });
+  }
+
+  getPredictionId(prediction) {
+    if (prediction.predictionPlace) {
+      // default prediction defined above
+      return prediction.id;
+    }
+    return prediction.placePrediction.placeId;
+  }
+
+  /**
+   * Get the address text of the given prediction.
+   */
+  getPredictionAddress(prediction) {
+    if (prediction.predictionPlace) {
+      // default prediction defined above
+      return prediction.predictionPlace.address;
+    }
+    // prediction from Google Maps Places API
+
+    return prediction.placePrediction.text.text;
+  }
+
+  /**
+   * Fetch or read place details from the selected prediction.
+   *
+   * @param {Object} prediction selected prediction object
+   *
+   * @return {Promise<util.propTypes.place>} a place object
+   */
+
+  getPlaceDetails(prediction, currentLocationBoundsDistance) {
+    if (this.getPredictionId(prediction) === CURRENT_LOCATION_ID) {
+      return userLocation().then(latlng => {
+        return {
+          address: '',
+          origin: latlng,
+          bounds: googleMapsUtil.locationBounds(latlng, currentLocationBoundsDistance),
+        };
+      });
+    }
+
+    if (prediction.predictionPlace) {
+      return Promise.resolve(prediction.predictionPlace);
+    }
+
+    return googleMapsUtil.getPlaceDetailsNew(this.getPredictionId(prediction)).then(place => {
+      this.sessionToken = null;
+      return place;
+    });
+  }
+}
+
+export default GeocoderGoogleMaps;

--- a/src/components/LocationAutocompleteInput/GeocoderGoogleMapsNew.js
+++ b/src/components/LocationAutocompleteInput/GeocoderGoogleMapsNew.js
@@ -46,9 +46,7 @@ class GeocoderGoogleMaps {
   getPlacePredictions(search, countryLimit) {
     const limitCountriesMaybe = countryLimit
       ? {
-          componentRestrictions: {
-            country: countryLimit,
-          },
+          includedRegionCodes: countryLimit,
         }
       : {};
 
@@ -62,6 +60,9 @@ class GeocoderGoogleMaps {
       });
   }
 
+  /**
+   * Get the ID of the given prediction.
+   */
   getPredictionId(prediction) {
     if (prediction.predictionPlace) {
       // default prediction defined above
@@ -90,7 +91,6 @@ class GeocoderGoogleMaps {
    *
    * @return {Promise<util.propTypes.place>} a place object
    */
-
   getPlaceDetails(prediction, currentLocationBoundsDistance) {
     if (this.getPredictionId(prediction) === CURRENT_LOCATION_ID) {
       return userLocation().then(latlng => {

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
@@ -11,6 +11,8 @@ import IconHourGlass from './IconHourGlass';
 import IconCurrentLocation from './IconCurrentLocation';
 import * as geocoderMapbox from './GeocoderMapbox';
 import * as geocoderGoogleMaps from './GeocoderGoogleMaps';
+// import * as geocoderGoogleMaps from './GeocoderGoogleMapsNew';
+import * as geocoderGoogleMapsNew from './GeocoderGoogleMapsNew';
 
 import css from './LocationAutocompleteInput.module.css';
 

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
@@ -251,11 +251,11 @@ class LocationAutocompleteInputImplementation extends Component {
         e.preventDefault();
         e.stopPropagation();
         this.selectItemIfNoneSelected();
-        this.input.blur();
+        this.input?.blur();
       }
     } else if (e.keyCode === KEY_CODE_TAB) {
       this.selectItemIfNoneSelected();
-      this.input.blur();
+      this.input?.blur();
     } else if (e.keyCode === KEY_CODE_ESC && this.input) {
       this.input.blur();
     }

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
@@ -11,7 +11,6 @@ import IconHourGlass from './IconHourGlass';
 import IconCurrentLocation from './IconCurrentLocation';
 import * as geocoderMapbox from './GeocoderMapbox';
 import * as geocoderGoogleMaps from './GeocoderGoogleMaps';
-// import * as geocoderGoogleMaps from './GeocoderGoogleMapsNew';
 import * as geocoderGoogleMapsNew from './GeocoderGoogleMapsNew';
 
 import css from './LocationAutocompleteInput.module.css';
@@ -36,7 +35,17 @@ const getTouchCoordinates = nativeEvent => {
 // Get correct geocoding variant: geocoderGoogleMaps or geocoderMapbox
 const getGeocoderVariant = mapProvider => {
   const isGoogleMapsInUse = mapProvider === 'googleMaps';
-  return isGoogleMapsInUse ? geocoderGoogleMaps : geocoderMapbox;
+
+  // Determine if the new version of the Google Places API is enabled
+  const useNewGooglePlacesAPI =
+    typeof window !== 'undefined' &&
+    typeof window?.useNewGooglePlacesAPI !== 'undefined' &&
+    window?.useNewGooglePlacesAPI;
+  return isGoogleMapsInUse && useNewGooglePlacesAPI
+    ? geocoderGoogleMapsNew
+    : isGoogleMapsInUse
+    ? geocoderGoogleMaps
+    : geocoderMapbox;
 };
 
 // Renders the autocompletion prediction results in a list
@@ -163,6 +172,32 @@ class LocationAutocompleteInputImplementation extends Component {
 
   componentDidMount() {
     this._isMounted = true;
+
+    // Check whether the new version of the Google Places API is in use.
+    // The useNewGooglePlacesAPI property indicates whether the updated
+    // Google Places API is available and being utilized. If the useNewGooglePlacesAPI
+    // property is undefined, it means we haven't determined the API version yet.
+    if (typeof window !== 'undefined') {
+      const googleMapsStatus = typeof window?.useNewGooglePlacesAPI !== 'undefined';
+
+      // If the map provider configured in the application is Google Maps and we
+      // haven't yet determined the API version, we make a test API call
+      // to Google Maps Places Autocomplete to check its behavior.
+      // The fetchAutocompleteSuggestions function is only supported by
+      // the newer version of Google Places API.
+      if (this.props.config.maps.mapProvider === 'googleMaps' && !googleMapsStatus) {
+        window?.google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions({
+          input: 'test',
+        })
+          .then(response => {
+            // A response means that the new Places API is enabled
+            window.useNewGooglePlacesAPI = true;
+          })
+          .catch(e => {
+            window.useNewGooglePlacesAPI = false;
+          });
+      }
+    }
   }
 
   componentWillUnmount() {

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
@@ -177,26 +177,24 @@ class LocationAutocompleteInputImplementation extends Component {
     // The useNewGooglePlacesAPI property indicates whether the updated
     // Google Places API is available and being utilized. If the useNewGooglePlacesAPI
     // property is undefined, it means we haven't determined the API version yet.
-    if (typeof window !== 'undefined') {
-      const googleMapsStatus = typeof window?.useNewGooglePlacesAPI !== 'undefined';
+    const googleMapsStatus = typeof window?.useNewGooglePlacesAPI !== 'undefined';
 
-      // If the map provider configured in the application is Google Maps and we
-      // haven't yet determined the API version, we make a test API call
-      // to Google Maps Places Autocomplete to check its behavior.
-      // The fetchAutocompleteSuggestions function is only supported by
-      // the newer version of Google Places API.
-      if (this.props.config.maps.mapProvider === 'googleMaps' && !googleMapsStatus) {
-        window?.google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions({
-          input: 'test',
+    // If the map provider configured in the application is Google Maps and we
+    // haven't yet determined the API version, we make a test API call
+    // to Google Maps Places Autocomplete to check its behavior.
+    // The fetchAutocompleteSuggestions function is only supported by
+    // the newer version of Google Places API.
+    if (this.props.config.maps.mapProvider === 'googleMaps' && !googleMapsStatus) {
+      window?.google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions({
+        input: 'test',
+      })
+        .then(response => {
+          // A response means that the new Places API is enabled
+          window.useNewGooglePlacesAPI = true;
         })
-          .then(response => {
-            // A response means that the new Places API is enabled
-            window.useNewGooglePlacesAPI = true;
-          })
-          .catch(e => {
-            window.useNewGooglePlacesAPI = false;
-          });
-      }
+        .catch(e => {
+          window.useNewGooglePlacesAPI = false;
+        });
     }
   }
 

--- a/src/config/configMaps.js
+++ b/src/config/configMaps.js
@@ -45,9 +45,9 @@ export const search = {
   sortSearchByDistance: false,
 
   // Limit location autocomplete to a one or more countries
-  // using CLDR two-character region codes, separated by commas.
+  // using ISO 3166 alpha 2 country codes separated by commas.
   // If you want to limit the autocomplete, uncomment this value:
-  // countryLimit: ['us'],
+  // countryLimit: ['AU'],
 };
 
 // When fuzzy locations are enabled, coordinates on maps are

--- a/src/config/configMaps.js
+++ b/src/config/configMaps.js
@@ -45,9 +45,9 @@ export const search = {
   sortSearchByDistance: false,
 
   // Limit location autocomplete to a one or more countries
-  // using ISO 3166 alpha 2 country codes separated by commas.
+  // using CLDR two-character region codes, separated by commas.
   // If you want to limit the autocomplete, uncomment this value:
-  // countryLimit: ['AU'],
+  // countryLimit: ['us'],
 };
 
 // When fuzzy locations are enabled, coordinates on maps are

--- a/src/util/googleMaps.js
+++ b/src/util/googleMaps.js
@@ -9,6 +9,15 @@ const placeOrigin = place => {
   return null;
 };
 
+/**
+ * Extracts the geographic location (origin) from a Google Maps Place object
+ * using the new Google Places API structure, and converts it into an SDKLatLng object.
+ *
+ * @param {google.maps.places.Place} place - An instance of the Google Maps Place class.
+ * @returns {SDKLatLng|null} An SDKLatLng object representing the latitude and longitude
+ *                           of the place's location.
+ *                           Returns null if the place or its location is invalid.
+ */
 const placeOriginNew = place => {
   if (place && place.location) {
     return new SDKLatLng(place.location.lat(), place.location.lng());
@@ -28,6 +37,15 @@ const placeBounds = place => {
   return null;
 };
 
+/**
+ * Extracts the viewport bounds from a Google Maps Place object using the new Places API,
+ * and converts them into an SDKLatLngBounds object.
+ *
+ * @param {google.maps.places.Place} place - An instance of the Google Maps Place class.
+ * @returns {SDKLatLngBounds|null} An SDKLatLngBounds object representing the northeast and
+ *                                 southwest corners of the place's viewport.
+ *                                 Returns null if the place or its viewport is invalid.
+ */
 const placeBoundsNew = place => {
   if (place && place.viewport) {
     const ne = place.viewport.getNorthEast();
@@ -74,18 +92,31 @@ export const getPlaceDetails = (placeId, sessionToken) =>
     });
   });
 
-// ToDo apply error handling
+/**
+ * Fetches detailed information about a specific place using the new Google Maps Places API.
+ *
+ * @param {string} placeId - ID for a place received from the
+ * autocomplete service
+ * @returns {Promise<Object|undefined>} A promise that resolves to an object containing:
+ *   - `adress` (string): The formatted address of the place.
+ *   - `origin` (object): The geographic origin of the place (calculated using `placeOriginNew`).
+ *   - `bounds` (object): The viewport bounds of the place (calculated using `placeBoundsNew`).
+ */
 export const getPlaceDetailsNew = async placeId => {
-  const place = await new window.google.maps.places.Place({ id: placeId });
-  const fields = ['addressComponents', 'formattedAddress', 'viewport', 'id', 'location'];
+  try {
+    const place = await new window.google.maps.places.Place({ id: placeId });
+    const fields = ['addressComponents', 'formattedAddress', 'viewport', 'id', 'location'];
 
-  await place.fetchFields({ fields: fields });
+    await place.fetchFields({ fields: fields });
 
-  return {
-    adress: place.formattedAddress,
-    origin: placeOriginNew(place),
-    bounds: placeBoundsNew(place),
-  };
+    return {
+      adress: place.formattedAddress,
+      origin: placeOriginNew(place),
+      bounds: placeBoundsNew(place),
+    };
+  } catch (error) {
+    console.error(`Could not get details for place id "${placeId}": `, error);
+  }
 };
 
 const predictionSuccessful = status => {
@@ -127,21 +158,39 @@ export const getPlacePredictions = (search, sessionToken, searchConfigurations) 
     );
   });
 
+/**
+ * Fetches autocomplete predictions using the new Google Places API.
+ *
+ * @param {string} search - Place name or address to search
+ * @param {object} sessionToken - Token to tie different autocomplete character searches together
+ * with getPlaceDetails call
+ * @param {object} searchConfigurations - Defines the search configurations that can be used with
+ * the autocomplete service. Used to restrict search to specific region (or regions).
+ *
+ * @returns {Promise<object>} - An object containing the original search query and predictions array:
+ *   - `search` (string): The search query.
+ *   - `predictions` (array): An array of prediction objects returned from the Google Places API.
+ */
 export const getPlacePredictionsNew = async (search, sessionToken, searchConfigurations) => {
-  const sessionTokenMaybe = sessionToken ? { sessionToken } : {};
-  const request = {
-    input: search,
-    ...sessionTokenMaybe,
-  };
+  try {
+    const sessionTokenMaybe = sessionToken ? { sessionToken } : {};
+    const request = {
+      input: search,
+      ...searchConfigurations,
+      ...sessionTokenMaybe,
+    };
 
-  const {
-    suggestions,
-  } = await google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions(request);
+    const {
+      suggestions,
+    } = await google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions(request);
 
-  return {
-    search,
-    predictions: suggestions,
-  };
+    return {
+      search,
+      predictions: suggestions,
+    };
+  } catch (error) {
+    console.error(`Could not get autocomplete suggestions using search query "${search}": `, error);
+  }
 };
 
 /**

--- a/src/util/googleMaps.js
+++ b/src/util/googleMaps.js
@@ -2,6 +2,8 @@ import { types as sdkTypes } from '../util/sdkLoader';
 
 const { LatLng: SDKLatLng, LatLngBounds: SDKLatLngBounds } = sdkTypes;
 
+const isDev = process.env.NODE_ENV === 'development';
+
 const placeOrigin = place => {
   if (place && place.geometry && place.geometry.location) {
     return new SDKLatLng(place.geometry.location.lat(), place.geometry.location.lng());
@@ -115,7 +117,10 @@ export const getPlaceDetailsNew = async placeId => {
       bounds: placeBoundsNew(place),
     };
   } catch (error) {
-    console.error(`Could not get details for place id "${placeId}": `, error);
+    if (isDev) {
+      console.error(`Could not get details for place id "${placeId}": `, error);
+    }
+    return error;
   }
 };
 
@@ -189,7 +194,13 @@ export const getPlacePredictionsNew = async (search, sessionToken, searchConfigu
       predictions: suggestions,
     };
   } catch (error) {
-    console.error(`Could not get autocomplete suggestions using search query "${search}": `, error);
+    if (isDev) {
+      console.error(
+        `Could not get autocomplete suggestions using search query "${search}": `,
+        error
+      );
+    }
+    return error;
   }
 };
 

--- a/src/util/googleMaps.js
+++ b/src/util/googleMaps.js
@@ -112,7 +112,7 @@ export const getPlaceDetailsNew = async placeId => {
     await place.fetchFields({ fields: fields });
 
     return {
-      adress: place.formattedAddress,
+      address: place.formattedAddress,
       origin: placeOriginNew(place),
       bounds: placeBoundsNew(place),
     };
@@ -191,7 +191,7 @@ export const getPlacePredictionsNew = async (search, sessionToken, searchConfigu
 
     return {
       search,
-      predictions: suggestions,
+      predictions: suggestions || [],
     };
   } catch (error) {
     if (isDev) {


### PR DESCRIPTION
This PR introduces support for the New Google Places API. While the Legacy Places API will continue to work, users will not be able to enable the Legacy Places API after **March 1st, 2025**. Read more in [Google's documentation](https://developers.google.com/maps/documentation/javascript/places-migration-overview).

We make a call to Google's API and based on the response we identify if the New API or Legacy API is in use. 

After March 1st, we'll remove support for the Legacy API in the codebase.

To use the New Places API, you'll need to enable it in Google's API settings.