### PR TITLE
Fix robots.txt for private marketplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [fix] Private marketplace: allow search crawlers to access the `/sitemap` route.
+  [#541](https://github.com/sharetribe/web-template/pull/541)
+
 ## [v7.1.0] 2025-01-23
 
-- [add] Add support for hiding the Topbar search based on configuration. 
+- [add] Add support for hiding the Topbar search based on configuration.
   [#531](https://github.com/sharetribe/web-template/pull/531)
-- [fix] ListingPage: fetchMonthlyTimeSlots didn't work correctly with day unitType.
+- [fix] TransactionPage: fetchMonthlyTimeSlots didn't work correctly with day unitType.
   [#536](https://github.com/sharetribe/web-template/pull/536)
 - [change] Google's search schema requires a price that uses dot as decimal separator.
   [#535](https://github.com/sharetribe/web-template/pull/535)

--- a/server/resources/README.md
+++ b/server/resources/README.md
@@ -34,6 +34,12 @@ http://localhost:3500/robots.txt) for debugging purposes.
 There's a more restrictive version of the robots.txt (robotsPrivateMarketplace.txt), which is used
 if access-control.json asset has private mode set active.
 
+**Note**: For private marketplace, the `/s` route is disallowed, and the `/sitemap` route is
+explicitly allowed. If you add new routes that start with `/s` at the root (e.g.
+`your.marketplace.com/support`), you need to add them to the robotsPrivateMarketplace.txt file. By
+default, [Pages content](https://www.sharetribe.com/docs/template/page-builder/) is served from
+`/p/*`, which is unaffected.
+
 ## Sitemap
 
 A [sitemap](https://developers.google.com/search/docs/crawling-indexing/sitemaps/overview) is a file

--- a/server/resources/robotsPrivateMarketplace.txt
+++ b/server/resources/robotsPrivateMarketplace.txt
@@ -3,9 +3,10 @@
 #
 
 User-agent: *
+Allow: /sitemap
 Disallow: /s
-Disallow: /u
-Disallow: /l
+Disallow: /u/
+Disallow: /l/
 Disallow: /profile-settings
 Disallow: /inbox
 Disallow: /order

--- a/src/routing/routeConfiguration.js
+++ b/src/routing/routeConfiguration.js
@@ -85,6 +85,8 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
       component: CMSPage,
       loadData: pageDataLoadingAPI.CMSPage.loadData,
     },
+    // NOTE: when the private marketplace feature is enabled, the '/s' route is disallowed by the robots.txt resource.
+    // If you add new routes that start with '/s*' (e.g. /support), you should add them to the robotsPrivateMarketplace.txt file.
     {
       path: '/s',
       name: 'SearchPage',


### PR DESCRIPTION
With the private marketplace feature, the `/s` route is disallowed and the `/sitemap` route is
explicitly allowed.

If you add new routes that start with `/s` on the root (e.g. `your.marketplace.com/support`), you need to add them to the robotsPrivateMarketplace.txt file. 

Note: By default, [Pages content](https://www.sharetribe.com/docs/template/page-builder/) is served from `/p/*`, which remains unaffected.
