### PR TITLE
Fix dark skin tab focus styles overriding hover font color

### DIFF
--- a/src/components/TabNavHorizontal/TabNavHorizontal.module.css
+++ b/src/components/TabNavHorizontal/TabNavHorizontal.module.css
@@ -78,7 +78,8 @@
 .tabContentDarkSkin {
   color: var(--colorGrey300);
 
-  &:hover {
+  &:hover,
+  &:focus {
     color: var(--colorWhite);
   }
 }


### PR DESCRIPTION
This commit resolves an issue where the tabContentDarkSkin class in TabNavHorizontal.module.css did not include :focus styles, causing it to inherit the :focus styles from the tabContent class. Since the tabContent class uses black font color and the dark skin uses white font color, this created a visibility issue when the component was in its dark skin mode and focused.