### PR TITLE
Fix dark skin tab focus styles overriding hover font color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [fix] TabNavHorizontal: Dark skin tab focus styles overriding hover font color.
+  [#543](https://github.com/sharetribe/web-template/pull/543)
 - [fix] Private marketplace: allow search crawlers to access the `/sitemap` route.
   [#541](https://github.com/sharetribe/web-template/pull/541)
 

--- a/src/components/TabNavHorizontal/TabNavHorizontal.module.css
+++ b/src/components/TabNavHorizontal/TabNavHorizontal.module.css
@@ -78,7 +78,8 @@
 .tabContentDarkSkin {
   color: var(--colorGrey300);
 
-  &:hover {
+  &:hover,
+  &:focus {
     color: var(--colorWhite);
   }
 }


### PR DESCRIPTION
TabNavHorizontal: Dark skin tab focus styles overriding hover font color.
This is the same as #542, but I added changelog + rebased on top of main branch