### PR TITLE
Price for schema maybe allow 0 price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [change] priceForSchemaMaybe: render offer price when price is 0. This helps customizations, but
+  it's not enough for no-code features to support 0 price for inquiries.
+  [#544](https://github.com/sharetribe/web-template/pull/544)
 - [fix] TabNavHorizontal: Dark skin tab focus styles overriding hover font color.
   [#543](https://github.com/sharetribe/web-template/pull/543)
 - [fix] Private marketplace: allow search crawlers to access the `/sitemap` route.

--- a/src/containers/ListingPage/ListingPage.shared.js
+++ b/src/containers/ListingPage/ListingPage.shared.js
@@ -51,12 +51,10 @@ export const priceData = (price, marketplaceCurrency, intl) => {
 export const priceForSchemaMaybe = price => {
   try {
     const schemaPrice = convertMoneyToNumber(price);
-    return schemaPrice
-      ? {
-          price: schemaPrice.toFixed(2),
-          priceCurrency: price.currency,
-        }
-      : {};
+    return {
+      price: schemaPrice.toFixed(2),
+      priceCurrency: price.currency,
+    };
   } catch (e) {
     return {};
   }


### PR DESCRIPTION
ListingPage / priceForSchemaMaybe: render offer price when price is 0.
This helps customizations, but it's not enough for no-code features to support 0 price for inquiries - since listing minimum price is not allowed to be 0 on the Marketplace Console.