### PR TITLE
LocationAutocompleteInput: localhost:3000 gave errors…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [fix] LocationAutocompleteInput: fix a bug with Google Maps API loading order with Webpack Dev
+  Server. [#548](https://github.com/sharetribe/web-template/pull/548)
+
 ## [v7.2.0] 2025-01-30
 
 - [add] Add support for the new Google Places API

--- a/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
+++ b/src/components/LocationAutocompleteInput/LocationAutocompleteInputImpl.js
@@ -178,13 +178,15 @@ class LocationAutocompleteInputImplementation extends Component {
     // Google Places API is available and being utilized. If the useNewGooglePlacesAPI
     // property is undefined, it means we haven't determined the API version yet.
     const googleMapsStatus = typeof window?.useNewGooglePlacesAPI !== 'undefined';
+    // Development against localhost:3000 aka Webpack Dev Server has a bit random loading order.
+    const hasGoogle = window?.google;
 
     // If the map provider configured in the application is Google Maps and we
     // haven't yet determined the API version, we make a test API call
     // to Google Maps Places Autocomplete to check its behavior.
     // The fetchAutocompleteSuggestions function is only supported by
     // the newer version of Google Places API.
-    if (this.props.config.maps.mapProvider === 'googleMaps' && !googleMapsStatus) {
+    if (this.props.config.maps.mapProvider === 'googleMaps' && hasGoogle && !googleMapsStatus) {
       window?.google.maps.places.AutocompleteSuggestion.fetchAutocompleteSuggestions({
         input: 'test',
       })


### PR DESCRIPTION
…when WebpackDevServer loaded libs in a different order.