### PR TITLE
DatePicker: fix calendar slide flickering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [fix] DatePicker: fix a bug with the calendar transition.
+  [#553](https://github.com/sharetribe/web-template/pull/553)
 - [add] Add fixed bookings and price variant name support to booking process email templates.
   [#552](https://github.com/sharetribe/web-template/pull/552)
 - [fix] LocationAutocompleteInput: fix a bug with Google Maps API loading order with Webpack Dev

--- a/src/components/DatePicker/DatePickers/DatePicker.js
+++ b/src/components/DatePicker/DatePickers/DatePicker.js
@@ -495,14 +495,11 @@ const DatePicker = props => {
       return;
     }
     calendarsPanel.classList.add(css.slide);
-    const posInitial = -1 * SLIDE_WIDTH + OUTLINE_WIDTH;
 
     if (allowSlide) {
       if (direction == 1) {
-        calendarsPanel.style.transform = `translateX(${posInitial - SLIDE_WIDTH}px)`;
         setCalendarIndex(prevIndex => ++prevIndex);
       } else if (direction == -1) {
-        calendarsPanel.style.transform = `translateX(${posInitial + SLIDE_WIDTH}px)`;
         setCalendarIndex(prevIndex => --prevIndex);
       }
     }
@@ -520,8 +517,6 @@ const DatePicker = props => {
       return;
     }
     calendarsPanel.classList.remove(css.slide);
-
-    calendarsPanel.style.transform = `translateX(${-(1 * SLIDE_WIDTH - OUTLINE_WIDTH)}px)`;
 
     if (calendarIndex == -1) {
       updateCurrentDate(getPreviousMonth(currentDate));
@@ -554,6 +549,18 @@ const DatePicker = props => {
     intl,
   };
 
+  const translateX = index => {
+    const initialPosition = -1 * (1 * SLIDE_WIDTH - OUTLINE_WIDTH);
+    return index === -1
+      ? initialPosition + SLIDE_WIDTH
+      : index === 1
+      ? initialPosition - SLIDE_WIDTH
+      : initialPosition;
+  };
+  const style = {
+    transform: `translateX(${translateX(calendarIndex)}px)`,
+  };
+
   return (
     <div
       aria-disabled={String(disabled)}
@@ -580,7 +587,12 @@ const DatePicker = props => {
 
         <div className={css.body} style={{ height }}>
           <div className={css.calendarViewport}>
-            <div id="calendars" className={css.calendars} onTransitionEnd={handleTransitionEnd}>
+            <div
+              id="calendars"
+              className={css.calendars}
+              onTransitionEnd={handleTransitionEnd}
+              style={style}
+            >
               <CalendarMonth
                 currentMonth={getPreviousMonth(currentDate)}
                 visible={!allowSlide}


### PR DESCRIPTION
DatePicker: move translateX inside the rendering cycle.

If translateX is inside the `transitionEnd` callback function, DOM changes before the next rendering pass.
This causes previous month to flicker after animation, because 'old' month container is repositioned first and only the next update will update the months.
