### PR TITLE
Update a typo on variable name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [fix] CheckoutPageWithPayment & PaymentMethodsPage had a typo in a variable name.
+  [#554](https://github.com/sharetribe/web-template/pull/554)
 - [fix] DatePicker: fix a bug with the calendar transition.
   [#553](https://github.com/sharetribe/web-template/pull/553)
 - [add] Add fixed bookings and price variant name support to booking process email templates.

--- a/src/containers/CheckoutPage/CheckoutPageWithPayment.js
+++ b/src/containers/CheckoutPage/CheckoutPageWithPayment.js
@@ -463,7 +463,7 @@ export const CheckoutPageWithPayment = props => {
   // If your marketplace works mostly in one country you can use initial values to select country automatically
   // e.g. {country: 'FI'}
 
-  const initalValuesForStripePayment = { name: userName, recipientName: userName };
+  const initialValuesForStripePayment = { name: userName, recipientName: userName };
   const askShippingDetails =
     orderData?.deliveryMethod === 'shipping' &&
     !hasTransactionPassedPendingPayment(existingTransaction, process);
@@ -535,7 +535,7 @@ export const CheckoutPageWithPayment = props => {
                 formId="CheckoutPagePaymentForm"
                 authorDisplayName={listing?.author?.attributes?.profile?.displayName}
                 showInitialMessageInput={showInitialMessageInput}
-                initialValues={initalValuesForStripePayment}
+                initialValues={initialValuesForStripePayment}
                 initiateOrderError={initiateOrderError}
                 confirmCardPaymentError={confirmCardPaymentError}
                 confirmPaymentError={confirmPaymentError}

--- a/src/containers/PaymentMethodsPage/PaymentMethodsPage.js
+++ b/src/containers/PaymentMethodsPage/PaymentMethodsPage.js
@@ -150,7 +150,7 @@ const PaymentMethodsPageComponent = props => {
     ? `${ensuredCurrentUser.attributes.profile.firstName} ${ensuredCurrentUser.attributes.profile.lastName}`
     : null;
 
-  const initalValuesForStripePayment = { name: userName };
+  const initialValuesForStripePayment = { name: userName };
 
   const card = hasDefaultPaymentMethod
     ? ensurePaymentMethodCard(currentUser.stripeCustomer.defaultPaymentMethod).attributes.card
@@ -194,7 +194,7 @@ const PaymentMethodsPageComponent = props => {
                 <PaymentMethodsForm
                   className={css.paymentForm}
                   formId="PaymentMethodsForm"
-                  initialValues={initalValuesForStripePayment}
+                  initialValues={initialValuesForStripePayment}
                   onSubmit={handleSubmit}
                   handleRemovePaymentMethod={handleRemovePaymentMethod}
                   hasDefaultPaymentMethod={hasDefaultPaymentMethod}


### PR DESCRIPTION
CheckoutPageWithPayment & PaymentMethodsPage had a typo in a variable name.