### PR TITLE
replace zoomControlOptions with cameraControlOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ way to update this template, but currently, we follow a pattern:
 ---
 
 ## Upcoming version 2025-XX-XX
+
+- [fix] Fix the positioning of the camera control otpions on Google Maps
+  [#565](https://github.com/sharetribe/web-template/pull/565)
 - [fix] Fix currently available translations for FR.
   [#559](https://github.com/sharetribe/web-template/pull/559)
 

--- a/src/components/Map/DynamicGoogleMap.js
+++ b/src/components/Map/DynamicGoogleMap.js
@@ -54,8 +54,8 @@ class DynamicGoogleMap extends Component {
         fullscreenControl: false,
         // Street View control
         streetViewControl: false,
-        // Zoom control position
-        zoomControlOptions: {
+        // Camera control position
+        cameraControlOptions: {
           position: controlPosition,
         },
       };

--- a/src/containers/SearchPage/SearchMap/SearchMapWithGoogleMaps.js
+++ b/src/containers/SearchPage/SearchMap/SearchMapWithGoogleMaps.js
@@ -486,7 +486,7 @@ class SearchMapWithGoogleMaps extends Component {
         clickableIcons: false,
         streetViewControl: false,
 
-        zoomControlOptions: {
+        cameraControlOptions: {
           position: controlPosition,
         },
 


### PR DESCRIPTION
By default, zoom is hidden, and instead we overlay Map camera controls, i.e. `cameraControlOptions`:

<img width="507" alt="image" src="https://github.com/user-attachments/assets/37db9467-c2dd-4dc8-8ab6-239bdc3ed79c" />

Therefore, `zoomControlOptions` has no effect on positioning, as zoom controls are hidden by default. 

`cameraControlOptions` is the correct attribute to use to position the cameraControlOptions.

An alternative here would be to continue using 

```
 zoomControlOptions: {
      position: controlPosition,
    },
```

and add

`zoom: true`

to the mapConfig object


