### PR TITLE
Convert non-string category URL param to string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [fix] Convert non-string category URL param to string
+  [#590](https://github.com/sharetribe/web-template/pull/590)
+
 - [add] Add currently available translations for DE, ES, FR.
   [#587](https://github.com/sharetribe/web-template/pull/587)
 

--- a/src/containers/SearchPage/SearchPage.duck.js
+++ b/src/containers/SearchPage/SearchPage.duck.js
@@ -132,7 +132,8 @@ export const searchListings = (searchParams, config) => (dispatch, getState, sdk
 
     const validURLParamForCategoryData = (prefix, categories, level, params) => {
       const levelKey = `${categoryParamPrefix}${level}`;
-      const levelValue = params?.[levelKey];
+      const levelValue =
+        typeof params?.[levelKey] !== 'undefined' ? `${params?.[levelKey]}` : undefined;
       const foundCategory = categories.find(cat => cat.id === levelValue);
       const subcategories = foundCategory?.subcategories || [];
       return foundCategory && subcategories.length > 0

--- a/src/containers/SearchPage/SearchPage.shared.js
+++ b/src/containers/SearchPage/SearchPage.shared.js
@@ -123,8 +123,9 @@ export const validURLParamForExtendedData = (
 
 const validURLParamForCategoryData = (prefix, categories, level, params) => {
   const levelKey = constructQueryParamName(`${prefix}${level}`, 'public');
-  const levelValue = params?.[levelKey];
-  const foundCategory = categories.find(cat => cat.id === params?.[levelKey]);
+  const levelValue =
+    typeof params?.[levelKey] !== 'undefined' ? `${params?.[levelKey]}` : undefined;
+  const foundCategory = categories.find(cat => cat.id === levelValue);
   const subcategories = foundCategory?.subcategories || [];
   return foundCategory && subcategories.length > 0
     ? {


### PR DESCRIPTION
This change fixes an issue where a category with a numeric key doesn't get highlighted in the grid search page filter. The URL param is interpreted as a numeric value, so it doesn't match the category key string. Enforcing the non-string value to a string ensures that numeric (and boolean) category keys are highlighted correctly.