### PR TITLE
Fix listing type path param usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,12 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [fix] Fix listing type path param usage
+  [#599](https://github.com/sharetribe/web-template/pull/599)
+  
 - [fix] Avatar: use correct pending-approval variant link when user is pending approval.
   [#601](https://github.com/sharetribe/web-template/pull/601)
+  
 - [add] Add currently available translations for DE, ES, FR.
   [#597](https://github.com/sharetribe/web-template/pull/597)
 

--- a/src/containers/SearchPage/SearchPage.duck.js
+++ b/src/containers/SearchPage/SearchPage.duck.js
@@ -115,9 +115,7 @@ export const searchListings = (searchParams, config) => (dispatch, getState, sdk
   // Read More:
   // https://www.sharetribe.com/docs/how-to/manage-search-schemas-with-flex-cli/#adding-listing-search-schemas
   const searchValidListingTypes = (listingTypes, listingTypePathParam, isListingTypeVariant) => {
-    const isValidListingTypeParam =
-      listingTypePathParam && listingTypes.find(lt => lt.listingType === listingTypePathParam);
-    return isListingTypeVariant && isValidListingTypeParam
+    return isListingTypeVariant
       ? {
           pub_listingType: listingTypePathParam,
         }

--- a/src/containers/SearchPage/SearchPage.shared.js
+++ b/src/containers/SearchPage/SearchPage.shared.js
@@ -547,20 +547,25 @@ export const getDatesAndSeatsMaybe = (currentParams, newParams) => {
  * @returns an object with the attributes routeName and pathParams, which can then be passed
  * as the corresponding parameters to createResourceLocatorString
  */
-export const getResourceLocatorStringParams = (routes, location) => {
+export const getSearchPageResourceLocatorStringParams = (routes, location) => {
   const matchedRoutes = matchPathname(location.pathname, routes);
+  const searchPageRoute = 'SearchPage';
+  const searchPageListingTypeRoute = 'SearchPageWithListingType';
 
   if (matchedRoutes.length > 0) {
     const matched = matchedRoutes[0];
     const { params: pathParams, route } = matched;
+    const routeName =
+      route.name === searchPageListingTypeRoute ? searchPageListingTypeRoute : searchPageRoute;
+
     return {
-      routeName: route.name,
+      routeName,
       pathParams,
     };
   } else {
     console.error(`Route not found for pathname ${location.pathname}, redirecting to SearchPage`);
     return {
-      routeName: 'SearchPage',
+      routeName: searchPageRoute,
       pathParams: {},
     };
   }

--- a/src/containers/SearchPage/SearchPage.shared.js
+++ b/src/containers/SearchPage/SearchPage.shared.js
@@ -568,10 +568,8 @@ export const getResourceLocatorStringParams = (routes, location) => {
 
 export const getActiveListingTypes = (config, listingTypePathParam) => {
   const availableListingTypes = config?.listing?.listingTypes.map(config => config.listingType);
-  const isListingTypeVariant =
-    listingTypePathParam && availableListingTypes.includes(listingTypePathParam);
-  const activeListingTypes = isListingTypeVariant
+  const activeListingTypes = listingTypePathParam
     ? availableListingTypes.filter(lt => lt === listingTypePathParam)
     : availableListingTypes;
-  return { isListingTypeVariant, activeListingTypes };
+  return { activeListingTypes };
 };

--- a/src/containers/SearchPage/SearchPageWithGrid.js
+++ b/src/containers/SearchPage/SearchPageWithGrid.js
@@ -233,12 +233,9 @@ export class SearchPageComponent extends Component {
     const { listingFields } = config?.listing || {};
     const { defaultFilters: defaultFiltersRaw, sortConfig } = config?.search || {};
 
-    const { isListingTypeVariant, activeListingTypes } = getActiveListingTypes(
-      config,
-      listingTypePathParam
-    );
+    const { activeListingTypes } = getActiveListingTypes(config, listingTypePathParam);
 
-    const defaultFiltersConfig = isListingTypeVariant
+    const defaultFiltersConfig = listingTypePathParam
       ? defaultFiltersRaw.filter(f => f.key !== 'listingType')
       : defaultFiltersRaw;
     const marketplaceCurrency = config.currency;

--- a/src/containers/SearchPage/SearchPageWithGrid.js
+++ b/src/containers/SearchPage/SearchPageWithGrid.js
@@ -46,7 +46,7 @@ import {
   pickListingFieldFilters,
   omitLimitedListingFieldParams,
   getDatesAndSeatsMaybe,
-  getResourceLocatorStringParams,
+  getSearchPageResourceLocatorStringParams,
   getActiveListingTypes,
 } from './SearchPage.shared';
 
@@ -112,7 +112,10 @@ export class SearchPageComponent extends Component {
     // Reset routing params
     const queryParams = omit(urlQueryParams, filterQueryParamNames);
 
-    const { routeName, pathParams } = getResourceLocatorStringParams(routeConfiguration, location);
+    const { routeName, pathParams } = getSearchPageResourceLocatorStringParams(
+      routeConfiguration,
+      location
+    );
 
     history.push(
       createResourceLocatorString(routeName, routeConfiguration, pathParams, queryParams)
@@ -167,7 +170,7 @@ export class SearchPageComponent extends Component {
           const searchParams = this.state.currentQueryParams;
           const search = cleanSearchFromConflictingParams(searchParams, filterConfigs, sortConfig);
 
-          const { routeName, pathParams } = getResourceLocatorStringParams(
+          const { routeName, pathParams } = getSearchPageResourceLocatorStringParams(
             routeConfiguration,
             location
           );
@@ -190,7 +193,10 @@ export class SearchPageComponent extends Component {
       ? { ...urlQueryParams, [urlParam]: values }
       : omit(urlQueryParams, urlParam);
 
-    const { routeName, pathParams } = getResourceLocatorStringParams(routeConfiguration, location);
+    const { routeName, pathParams } = getSearchPageResourceLocatorStringParams(
+      routeConfiguration,
+      location
+    );
 
     history.push(
       createResourceLocatorString(routeName, routeConfiguration, pathParams, queryParams)

--- a/src/containers/SearchPage/SearchPageWithMap.js
+++ b/src/containers/SearchPage/SearchPageWithMap.js
@@ -47,7 +47,7 @@ import {
   pickListingFieldFilters,
   omitLimitedListingFieldParams,
   getDatesAndSeatsMaybe,
-  getResourceLocatorStringParams,
+  getSearchPageResourceLocatorStringParams,
   getActiveListingTypes,
 } from './SearchPage.shared';
 
@@ -145,7 +145,7 @@ export class SearchPageComponent extends Component {
         ...validFilterParams(rest, filterConfigs, dropNonFilterParams),
       };
 
-      const { routeName, pathParams } = getResourceLocatorStringParams(routes, location);
+      const { routeName, pathParams } = getSearchPageResourceLocatorStringParams(routes, location);
 
       history.push(createResourceLocatorString(routeName, routes, pathParams, searchParams));
     }
@@ -183,7 +183,10 @@ export class SearchPageComponent extends Component {
     const searchParams = { ...urlQueryParams, ...this.state.currentQueryParams };
     const search = cleanSearchFromConflictingParams(searchParams, filterConfigs, sortConfig);
 
-    const { routeName, pathParams } = getResourceLocatorStringParams(routeConfiguration, location);
+    const { routeName, pathParams } = getSearchPageResourceLocatorStringParams(
+      routeConfiguration,
+      location
+    );
 
     history.push(createResourceLocatorString(routeName, routeConfiguration, pathParams, search));
   }
@@ -208,7 +211,10 @@ export class SearchPageComponent extends Component {
     // Reset routing params
     const queryParams = omit(urlQueryParams, filterQueryParamNames);
 
-    const { routeName, pathParams } = getResourceLocatorStringParams(routeConfiguration, location);
+    const { routeName, pathParams } = getSearchPageResourceLocatorStringParams(
+      routeConfiguration,
+      location
+    );
 
     history.push(
       createResourceLocatorString(routeName, routeConfiguration, pathParams, queryParams)
@@ -265,7 +271,7 @@ export class SearchPageComponent extends Component {
           const searchParams = this.state.currentQueryParams;
           const search = cleanSearchFromConflictingParams(searchParams, filterConfigs, sortConfig);
 
-          const { routeName, pathParams } = getResourceLocatorStringParams(
+          const { routeName, pathParams } = getSearchPageResourceLocatorStringParams(
             routeConfiguration,
             location
           );
@@ -288,7 +294,10 @@ export class SearchPageComponent extends Component {
       ? { ...urlQueryParams, [urlParam]: values }
       : omit(urlQueryParams, urlParam);
 
-    const { routeName, pathParams } = getResourceLocatorStringParams(routeConfiguration, location);
+    const { routeName, pathParams } = getSearchPageResourceLocatorStringParams(
+      routeConfiguration,
+      location
+    );
 
     history.push(
       createResourceLocatorString(routeName, routeConfiguration, pathParams, queryParams)

--- a/src/containers/SearchPage/SearchPageWithMap.js
+++ b/src/containers/SearchPage/SearchPageWithMap.js
@@ -323,12 +323,8 @@ export class SearchPageComponent extends Component {
     const { listingFields } = config?.listing || {};
     const { defaultFilters: defaultFiltersRaw, sortConfig } = config?.search || {};
 
-    const { isListingTypeVariant, activeListingTypes } = getActiveListingTypes(
-      config,
-      listingTypePathParam
-    );
-
-    const defaultFiltersConfig = isListingTypeVariant
+    const { activeListingTypes } = getActiveListingTypes(config, listingTypePathParam);
+    const defaultFiltersConfig = listingTypePathParam
       ? defaultFiltersRaw.filter(f => f.key !== 'listingType')
       : defaultFiltersRaw;
 

--- a/src/containers/TopbarContainer/Topbar/Topbar.js
+++ b/src/containers/TopbarContainer/Topbar/Topbar.js
@@ -17,6 +17,7 @@ import {
   Modal,
   ModalMissingInformation,
 } from '../../../components';
+import { getSearchPageResourceLocatorStringParams } from '../../SearchPage/SearchPage.shared';
 
 import MenuIcon from './MenuIcon';
 import SearchIcon from './SearchIcon';
@@ -154,7 +155,7 @@ const TopbarComponent = props => {
   } = props;
 
   const handleSubmit = values => {
-    const { currentSearchParams, history, config, routeConfiguration } = props;
+    const { currentSearchParams, history, location, config, routeConfiguration } = props;
 
     const topbarSearchParams = () => {
       if (isMainSearchTypeKeywords(config)) {
@@ -175,7 +176,15 @@ const TopbarComponent = props => {
       ...currentSearchParams,
       ...topbarSearchParams(),
     };
-    history.push(createResourceLocatorString('SearchPage', routeConfiguration, {}, searchParams));
+
+    const { routeName, pathParams } = getSearchPageResourceLocatorStringParams(
+      routeConfiguration,
+      location
+    );
+
+    history.push(
+      createResourceLocatorString(routeName, routeConfiguration, pathParams, searchParams)
+    );
   };
 
   const handleLogout = () => {


### PR DESCRIPTION
Earlier, listingTypePathParam was used as a filter only if it matched an existing listing type id. This change simplifies the usage so that listingTypePathParam is always used for filtering if given, and a non-valid param results in empty search result set.

This change also modifies the top bar search form to maintain the listing type path param, if the top bar search is used from a listing type specific search page.