### PR TITLE
Fix multiple search page routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [fix] Handle multiple search page routes outside search page and clarify path param usage
+  [#605](https://github.com/sharetribe/web-template/pull/605)
+
 ## [v8.3.1] 2025-05-06
 
 - [fix] Fix listing type path param usage

--- a/src/components/LimitedAccessBanner/LimitedAccessBanner.js
+++ b/src/components/LimitedAccessBanner/LimitedAccessBanner.js
@@ -9,7 +9,7 @@ import { Button } from '../../components';
 import css from './LimitedAccessBanner.module.css';
 
 // Due to the layout structure, do not render the banner on the following pages
-const disabledPages = ['SearchPage'];
+const disabledPages = ['SearchPage', 'SearchPageWithListingType'];
 
 /**
  * This component returns a limited-access banner.

--- a/src/containers/SearchPage/SearchFiltersMobile/SearchFiltersMobile.js
+++ b/src/containers/SearchPage/SearchFiltersMobile/SearchFiltersMobile.js
@@ -5,6 +5,7 @@ import { useHistory } from 'react-router-dom';
 import { useRouteConfiguration } from '../../../context/routeConfigurationContext';
 import { FormattedMessage, useIntl } from '../../../util/reactIntl';
 import { createResourceLocatorString } from '../../../util/routes';
+import { getSearchPageResourceLocatorStringParams } from '../SearchPage.shared';
 
 import { ModalInMobile, Button } from '../../../components';
 
@@ -31,13 +32,18 @@ class SearchFiltersMobileComponent extends Component {
 
   // Close the filters by clicking cancel, revert to the initial params
   cancelFilters() {
-    const { history, onCloseModal, routeConfiguration } = this.props;
+    const { history, onCloseModal, location, routeConfiguration } = this.props;
+
+    const { routeName, pathParams } = getSearchPageResourceLocatorStringParams(
+      routeConfiguration,
+      location
+    );
 
     history.push(
       createResourceLocatorString(
-        'SearchPage',
+        routeName,
         routeConfiguration,
-        {},
+        pathParams,
         this.state.initialQueryParams
       )
     );

--- a/src/containers/SearchPage/SearchPageWithGrid.js
+++ b/src/containers/SearchPage/SearchPageWithGrid.js
@@ -47,7 +47,6 @@ import {
   omitLimitedListingFieldParams,
   getDatesAndSeatsMaybe,
   getSearchPageResourceLocatorStringParams,
-  getActiveListingTypes,
 } from './SearchPage.shared';
 
 import FilterComponent from './FilterComponent';
@@ -123,18 +122,23 @@ export class SearchPageComponent extends Component {
   }
 
   getHandleChangedValueFn(useHistoryPush) {
-    const { history, routeConfiguration, config, location, params = {} } = this.props;
+    const {
+      history,
+      routeConfiguration,
+      config,
+      location,
+      params: currentPathParams = {},
+    } = this.props;
     const { listingFields: listingFieldsConfig } = config?.listing || {};
     const { defaultFilters: defaultFiltersConfig, sortConfig } = config?.search || {};
-    const { listingType: listingTypePathParam } = params;
-    const { activeListingTypes } = getActiveListingTypes(config, listingTypePathParam);
+    const activeListingTypes = config?.listing?.listingTypes.map(config => config.listingType);
     const listingCategories = config.categoryConfiguration.categories;
     const filterConfigs = {
       listingFieldsConfig,
       defaultFiltersConfig,
       listingCategories,
       activeListingTypes,
-      listingTypePathParam,
+      currentPathParams,
     };
 
     const urlQueryParams = validUrlQueryParamsFromProps(this.props);
@@ -226,7 +230,7 @@ export class SearchPageComponent extends Component {
       searchParams = {},
       routeConfiguration,
       config,
-      params = {},
+      params: currentPathParams = {},
     } = this.props;
 
     // If the search page variant is of type /s/:listingType, this defines the :listingType
@@ -234,16 +238,16 @@ export class SearchPageComponent extends Component {
     //
     // On a default search page (/s), this constant does not have a value, even when a
     // query parameter ?pub_listingType=[queryParamListingType] is used.
-    const { listingType: listingTypePathParam } = params;
+    const { listingType: listingTypePathParam } = currentPathParams;
 
     const { listingFields } = config?.listing || {};
     const { defaultFilters: defaultFiltersRaw, sortConfig } = config?.search || {};
 
-    const { activeListingTypes } = getActiveListingTypes(config, listingTypePathParam);
-
+    const activeListingTypes = config?.listing?.listingTypes.map(config => config.listingType);
     const defaultFiltersConfig = listingTypePathParam
       ? defaultFiltersRaw.filter(f => f.key !== 'listingType')
       : defaultFiltersRaw;
+
     const marketplaceCurrency = config.currency;
     const categoryConfiguration = config.categoryConfiguration;
     const listingCategories = categoryConfiguration.categories;
@@ -252,13 +256,14 @@ export class SearchPageComponent extends Component {
       locationSearch: location.search,
       categoryConfiguration,
       activeListingTypes,
-      listingTypeParam: listingTypePathParam,
+      currentPathParams,
     });
     const filterConfigs = {
       listingFieldsConfig,
       defaultFiltersConfig,
       listingCategories,
       activeListingTypes,
+      currentPathParams,
     };
 
     // Page transition might initially use values from previous search

--- a/src/containers/SearchPage/SearchPageWithMap.js
+++ b/src/containers/SearchPage/SearchPageWithMap.js
@@ -513,6 +513,7 @@ export class SearchPageComponent extends Component {
               resetAll={this.resetAll}
               selectedFiltersCount={selectedFiltersCountForMobile}
               noResultsInfo={noResultsInfo}
+              location={location}
               isMapVariant
             >
               {availableFilters.map(filterConfig => {

--- a/src/containers/TopbarContainer/Topbar/Topbar.js
+++ b/src/containers/TopbarContainer/Topbar/Topbar.js
@@ -263,7 +263,8 @@ const TopbarComponent = props => {
   // the current page.
   const showSearchOnAllPages = searchFormDisplay === SEARCH_DISPLAY_ALWAYS;
   const showSearchOnSearchPage =
-    searchFormDisplay === SEARCH_DISPLAY_ONLY_SEARCH_PAGE && resolvedCurrentPage === 'SearchPage';
+    searchFormDisplay === SEARCH_DISPLAY_ONLY_SEARCH_PAGE &&
+    ['SearchPage', 'SearchPageWithListingType'].includes(resolvedCurrentPage);
   const showSearchNotOnLandingPage =
     searchFormDisplay === SEARCH_DISPLAY_NOT_LANDING_PAGE && resolvedCurrentPage !== 'LandingPage';
 


### PR DESCRIPTION
This update addresses a few bugs related to the listing page filtering feature:
- In mobile search filter view, clicking "cancel" now maintains listing type path parameter
- When showing LimitedAccessBanner, exclude both search page versions
- With the configuration "only show top bar search input on search page", include both search page versions
- If a listing field is restricted to multiple valid listing types, show that field on listing type specific search pages corresponding to any of those listing types

In addition, this update changes the way the listing type path parameter is passed to helper functions, making it possible to pass other path parameters more easily in the future.