### PR TITLE
New patch release v8.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+## [v8.3.2] 2025-05-12
+
 - [fix] SearchPageWithMap: secondary filter count was not taking into use filters that were limited
   to category or listing type [#606](https://github.com/sharetribe/web-template/pull/606)
 - [fix] Handle multiple search page routes outside search page and clarify path param usage
   [#605](https://github.com/sharetribe/web-template/pull/605)
+
+  [v8.3.2]: https://github.com/sharetribe/web-template/compare/v8.3.1...v8.3.2
 
 ## [v8.3.1] 2025-05-06
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "8.3.1",
+  "version": "8.3.2",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This update addresses a few bugs related to the listing page filtering feature:
- In mobile search filter view, clicking "cancel" now maintains listing type path parameter
- When showing LimitedAccessBanner, exclude both search page versions
- With the configuration "only show top bar search input on search page", include both search page versions
- If a listing field is restricted to multiple valid listing types, show that field on listing type specific search pages corresponding to any of those listing types

In addition, this update changes the way the listing type path parameter is passed to helper functions, making it possible to pass other path parameters more easily in the future.
## [Changes] v8.3.2

- [fix] SearchPageWithMap: secondary filter count was not taking into use filters that were limited
  to category or listing type [#606](https://github.com/sharetribe/web-template/pull/606)
- [fix] Handle multiple search page routes outside search page and clarify path param usage
  [#605](https://github.com/sharetribe/web-template/pull/605)

  [Changes]: https://github.com/sharetribe/web-template/compare/v8.3.1...v8.3.2