### PR TITLE
Fix issue in emptying image array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ way to update this template, but currently, we follow a pattern:
 ---
 
 ## Upcoming version 2025-XX-XX
+- [fix] EditListingPhotosForm: removing all images from a listing caused the screen to go blank
+  [#608](https://github.com/sharetribe/web-template/pull/608)
 
 ## [v8.3.2] 2025-05-12
 

--- a/src/containers/EditListingPage/EditListingWizard/EditListingPhotosPanel/EditListingPhotosForm.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingPhotosPanel/EditListingPhotosForm.js
@@ -178,7 +178,7 @@ export const EditListingPhotosForm = props => {
           listingImageConfig,
         } = formRenderProps;
 
-        const images = values.images;
+        const images = values.images || [];
         const { aspectWidth = 1, aspectHeight = 1, variantPrefix } = listingImageConfig;
 
         const { publishListingError, showListingsError, updateListingError, uploadImageError } =
@@ -186,7 +186,7 @@ export const EditListingPhotosForm = props => {
         const uploadOverLimit = isUploadImageOverLimitError(uploadImageError);
 
         // imgs can contain added images (with temp ids) and submitted images with uniq ids.
-        const arrayOfImgIds = imgs => imgs.map(i => (typeof i.id === 'string' ? i.imageId : i.id));
+        const arrayOfImgIds = imgs => imgs?.map(i => (typeof i.id === 'string' ? i.imageId : i.id));
         const imageIdsFromProps = arrayOfImgIds(images);
         const imageIdsFromPreviousSubmit = arrayOfImgIds(submittedImages);
         const imageArrayHasSameImages = isEqual(imageIdsFromProps, imageIdsFromPreviousSubmit);


### PR DESCRIPTION
EditListingPhotosForm: removing all images from a listing caused the screen to go blank