### PR TITLE
fix an issue with anchor links on modals on the signup/login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [fix] Corrected anchor link scrolling behavior on Privacy Policy and Terms of Service pages, when
+  opened as modals (in signup/login). [#612](https://github.com/sharetribe/web-template/pull/612)
+
 ## [v8.4.0] 2025-05-20
 
 - [add] Added a "Search as CTA" component for embedding a search bar on any dynamic content page

--- a/src/containers/PrivacyPolicyPage/PrivacyPolicyPage.js
+++ b/src/containers/PrivacyPolicyPage/PrivacyPolicyPage.js
@@ -26,16 +26,17 @@ const SectionBuilder = loadable(
 const PrivacyPolicyContent = props => {
   const { inProgress, error, data } = props;
 
-  if (inProgress) {
-    return null;
-  }
-
   // We don't want to add h1 heading twice to the HTML (SEO issue).
   // Modal's header is mapped as h2
   const hasContent = data => typeof data?.content === 'string';
   const exposeContentAsChildren = data => {
     return hasContent(data) ? { children: data.content } : {};
   };
+
+  if (!hasContent && inProgress) {
+    return null;
+  }
+
   const CustomHeading1 = props => <H1 as="h2" {...props} />;
 
   const hasData = error === null && data;

--- a/src/containers/TermsOfServicePage/TermsOfServicePage.js
+++ b/src/containers/TermsOfServicePage/TermsOfServicePage.js
@@ -27,16 +27,17 @@ import { ASSET_NAME } from './TermsOfServicePage.duck';
 const TermsOfServiceContent = props => {
   const { inProgress, error, data } = props;
 
-  if (inProgress) {
-    return null;
-  }
-
   // We don't want to add h1 heading twice to the HTML (SEO issue).
   // Modal's header is mapped as h2
   const hasContent = data => typeof data?.content === 'string';
   const exposeContentAsChildren = data => {
     return hasContent(data) ? { children: data.content } : {};
   };
+
+  if (!hasContent && inProgress) {
+    return null;
+  }
+
   const CustomHeading1 = props => <H1 as="h2" {...props} />;
 
   const hasData = error === null && data;


### PR DESCRIPTION
This PR fixes an issue observed at least in Safari v18.4 where anchor links on the Privacy Policy and Terms of Service pages did not scroll to the correct section when those pages were opened in modals (e.g., via links in the sign-up or log-in forms).  The update ensures that anchor links now reliably scroll to the intended section.