### PR TITLE
Add conditional visibility features based on user type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [add] Add conditional visibility for the following elements depending on Console configuration:
+    - Visibility for create listings links for unauthenticated users configured in Top bar
+    - Visibility for elements configured in User types:
+      - Create listings and Manage listings links
+      - Payment method and payout detail tab links
+      - Inbox links for orders and sales
+      - Profile page review tabs
+  
+  [#614](https://github.com/sharetribe/web-template/pull/614)
 - [fix] Fix an issue with the date filter in the Search CTA component, which was not observing
   nightly search configuration correctly.[#625](https://github.com/sharetribe/web-template/pull/625)
 

--- a/src/components/LayoutComposer/LayoutSideNavigation/LayoutSideNavigation.js
+++ b/src/components/LayoutComposer/LayoutSideNavigation/LayoutSideNavigation.js
@@ -36,7 +36,7 @@ const LayoutSideNavigation = props => {
     footer: footerContent,
     sideNav: sideNavContent,
     useAccountSettingsNav,
-    currentPage,
+    accountSettingsNavProps,
     ...rest
   } = props;
 
@@ -63,7 +63,9 @@ const LayoutSideNavigation = props => {
             <Main as="div" className={containerClasses}>
               <aside className={classNames(css.sideNav, sideNavClassName)}>
                 {useAccountSettingsNav ? (
-                  <LayoutWrapperAccountSettingsSideNav currentPage={currentPage} />
+                  <LayoutWrapperAccountSettingsSideNav
+                    accountSettingsNavProps={accountSettingsNavProps}
+                  />
                 ) : null}
                 {sideNavContent}
               </aside>

--- a/src/components/LayoutComposer/LayoutSideNavigation/LayoutWrapperAccountSettingsSideNav.js
+++ b/src/components/LayoutComposer/LayoutSideNavigation/LayoutWrapperAccountSettingsSideNav.js
@@ -60,12 +60,16 @@ const scrollToTab = (currentPage, scrollLeft, setScrollLeft) => {
  *
  * @component
  * @param {Object} props
- * @param {string?} props.currentPage
+ * @param {Object} props.accountSettingsNavProps
+ * @param {string?} props.accountSettingsNavProps.currentPage
+ * @param {boolean?} props.accountSettingsNavProps.showPaymentMethods
+ * @param {boolean?} props.accountSettingsNavProps.showPayoutDetails
  * @returns {JSX.Element} Side nav with navigation to different account settings
  */
 const LayoutWrapperAccountSettingsSideNav = props => {
   const [mounted, setMounted] = useState(false);
   const [scrollLeft, setScrollLeft] = useGlobalState('scrollLeft');
+  const { accountSettingsNavProps } = props;
 
   useEffect(() => {
     setMounted(true);
@@ -73,7 +77,7 @@ const LayoutWrapperAccountSettingsSideNav = props => {
 
   useEffect(() => {
     if (mounted) {
-      const { currentPage } = props;
+      const { currentPage } = accountSettingsNavProps;
       const hasMatchMedia = typeof window !== 'undefined' && window?.matchMedia;
       const hasHorizontalTabLayout = hasMatchMedia
         ? window.matchMedia(`(max-width: ${MAX_HORIZONTAL_NAV_SCREEN_WIDTH}px)`)?.matches
@@ -86,7 +90,34 @@ const LayoutWrapperAccountSettingsSideNav = props => {
     }
   }, [mounted]);
 
-  const { currentPage } = props;
+  const { currentPage, showPaymentMethods, showPayoutDetails } = accountSettingsNavProps;
+  const payoutDetailsMaybe = showPayoutDetails
+    ? [
+        {
+          text: <FormattedMessage id="LayoutWrapperAccountSettingsSideNav.paymentsTabTitle" />,
+          selected: currentPage === 'StripePayoutPage',
+          id: 'StripePayoutPageTab',
+          linkProps: {
+            name: 'StripePayoutPage',
+          },
+        },
+      ]
+    : [];
+
+  const paymentMethodsMaybe = showPaymentMethods
+    ? [
+        {
+          text: (
+            <FormattedMessage id="LayoutWrapperAccountSettingsSideNav.paymentMethodsTabTitle" />
+          ),
+          selected: currentPage === 'PaymentMethodsPage',
+          id: 'PaymentMethodsPageTab',
+          linkProps: {
+            name: 'PaymentMethodsPage',
+          },
+        },
+      ]
+    : [];
 
   const tabs = [
     {
@@ -105,22 +136,8 @@ const LayoutWrapperAccountSettingsSideNav = props => {
         name: 'PasswordChangePage',
       },
     },
-    {
-      text: <FormattedMessage id="LayoutWrapperAccountSettingsSideNav.paymentsTabTitle" />,
-      selected: currentPage === 'StripePayoutPage',
-      id: 'StripePayoutPageTab',
-      linkProps: {
-        name: 'StripePayoutPage',
-      },
-    },
-    {
-      text: <FormattedMessage id="LayoutWrapperAccountSettingsSideNav.paymentMethodsTabTitle" />,
-      selected: currentPage === 'PaymentMethodsPage',
-      id: 'PaymentMethodsPageTab',
-      linkProps: {
-        name: 'PaymentMethodsPage',
-      },
-    },
+    ...payoutDetailsMaybe,
+    ...paymentMethodsMaybe,
   ];
 
   return <TabNav rootClassName={css.tabs} tabRootClassName={css.tab} tabs={tabs} />;

--- a/src/components/MenuContent/MenuContent.js
+++ b/src/components/MenuContent/MenuContent.js
@@ -50,10 +50,10 @@ const MenuContent = props => {
   ) : null;
 
   React.Children.forEach(children, child => {
-    if (child.type !== MenuItem) {
+    if (child && child.type !== MenuItem) {
       throw new Error('All children of MenuContent must be MenuItems.');
     }
-    if (child.key == null) {
+    if (child && child.key == null) {
       throw new Error('All children of MenuContent must have a "key" prop.');
     }
   });

--- a/src/components/UserNav/UserNav.js
+++ b/src/components/UserNav/UserNav.js
@@ -17,17 +17,23 @@ import css from './UserNav.module.css';
  * @returns {JSX.Element} User navigation component
  */
 const UserNav = props => {
-  const { className, rootClassName, currentPage } = props;
+  const { className, rootClassName, currentPage, showManageListingsLink } = props;
   const classes = classNames(rootClassName || css.root, className);
 
+  const manageListingsTabMaybe = showManageListingsLink
+    ? [
+        {
+          text: <FormattedMessage id="UserNav.yourListings" />,
+          selected: currentPage === 'ManageListingsPage',
+          linkProps: {
+            name: 'ManageListingsPage',
+          },
+        },
+      ]
+    : [];
+
   const tabs = [
-    {
-      text: <FormattedMessage id="UserNav.yourListings" />,
-      selected: currentPage === 'ManageListingsPage',
-      linkProps: {
-        name: 'ManageListingsPage',
-      },
-    },
+    ...manageListingsTabMaybe,
     {
       text: <FormattedMessage id="UserNav.profileSettings" />,
       selected: currentPage === 'ProfileSettingsPage',

--- a/src/containers/ContactDetailsPage/ContactDetailsPage.js
+++ b/src/containers/ContactDetailsPage/ContactDetailsPage.js
@@ -7,6 +7,7 @@ import { useConfiguration } from '../../context/configurationContext';
 import { FormattedMessage, useIntl } from '../../util/reactIntl';
 import { propTypes } from '../../util/types';
 import { ensureCurrentUser } from '../../util/data';
+import { showCreateListingLinkForUser } from '../../util/userHelpers';
 
 import { sendVerificationEmail } from '../../ducks/user.duck';
 import { isScrollingDisabled } from '../../ducks/ui.duck';
@@ -104,6 +105,8 @@ export const ContactDetailsPageComponent = props => {
 
   const title = intl.formatMessage({ id: 'ContactDetailsPage.title' });
 
+  const showManageListingsLink = showCreateListingLinkForUser(config, currentUser);
+
   return (
     <Page title={title} scrollingDisabled={scrollingDisabled}>
       <LayoutSideNavigation
@@ -113,7 +116,10 @@ export const ContactDetailsPageComponent = props => {
               desktopClassName={css.desktopTopbar}
               mobileClassName={css.mobileTopbar}
             />
-            <UserNav currentPage="ContactDetailsPage" />
+            <UserNav
+              currentPage="ContactDetailsPage"
+              showManageListingsLink={showManageListingsLink}
+            />
           </>
         }
         sideNav={null}

--- a/src/containers/ContactDetailsPage/ContactDetailsPage.js
+++ b/src/containers/ContactDetailsPage/ContactDetailsPage.js
@@ -7,7 +7,7 @@ import { useConfiguration } from '../../context/configurationContext';
 import { FormattedMessage, useIntl } from '../../util/reactIntl';
 import { propTypes } from '../../util/types';
 import { ensureCurrentUser } from '../../util/data';
-import { showCreateListingLinkForUser } from '../../util/userHelpers';
+import { showCreateListingLinkForUser, showPaymentDetailsForUser } from '../../util/userHelpers';
 
 import { sendVerificationEmail } from '../../ducks/user.duck';
 import { isScrollingDisabled } from '../../ducks/ui.duck';
@@ -106,6 +106,12 @@ export const ContactDetailsPageComponent = props => {
   const title = intl.formatMessage({ id: 'ContactDetailsPage.title' });
 
   const showManageListingsLink = showCreateListingLinkForUser(config, currentUser);
+  const { showPayoutDetails, showPaymentMethods } = showPaymentDetailsForUser(config, currentUser);
+  const accountSettingsNavProps = {
+    currentPage: 'ContactDetailsPage',
+    showPaymentMethods,
+    showPayoutDetails,
+  };
 
   return (
     <Page title={title} scrollingDisabled={scrollingDisabled}>
@@ -124,7 +130,7 @@ export const ContactDetailsPageComponent = props => {
         }
         sideNav={null}
         useAccountSettingsNav
-        currentPage="ContactDetailsPage"
+        accountSettingsNavProps={accountSettingsNavProps}
         footer={<FooterContainer />}
       >
         <div className={css.content}>

--- a/src/containers/InboxPage/InboxPage.js
+++ b/src/containers/InboxPage/InboxPage.js
@@ -48,6 +48,7 @@ import NotFoundPage from '../../containers/NotFoundPage/NotFoundPage';
 
 import { stateDataShape, getStateData } from './InboxPage.stateData';
 import css from './InboxPage.module.css';
+import { getCurrentUserTypeRoles } from '../../util/userHelpers';
 
 // Check if the transaction line-items use booking-related units
 const getUnitLineItem = lineItems => {
@@ -232,6 +233,11 @@ export const InboxPageComponent = props => {
     return <NotFoundPage staticContext={props.staticContext} />;
   }
 
+  const { customer: isCustomerUserType, provider: isProviderUserType } = getCurrentUserTypeRoles(
+    config,
+    currentUser
+  );
+
   const isOrders = tab === 'orders';
   const hasNoResults = !fetchInProgress && transactions.length === 0 && !fetchOrdersOrSalesError;
   const ordersTitle = intl.formatMessage({ id: 'InboxPage.ordersTitle' });
@@ -285,35 +291,44 @@ export const InboxPageComponent = props => {
   const hasTransactions =
     !fetchInProgress && hasOrderOrSaleTransactions(transactions, isOrders, currentUser);
 
-  const tabs = [
-    {
-      text: (
-        <span>
-          <FormattedMessage id="InboxPage.ordersTabTitle" />
-        </span>
-      ),
-      selected: isOrders,
-      linkProps: {
-        name: 'InboxPage',
-        params: { tab: 'orders' },
-      },
-    },
-    {
-      text: (
-        <span>
-          <FormattedMessage id="InboxPage.salesTabTitle" />
-          {providerNotificationCount > 0 ? (
-            <NotificationBadge count={providerNotificationCount} />
-          ) : null}
-        </span>
-      ),
-      selected: !isOrders,
-      linkProps: {
-        name: 'InboxPage',
-        params: { tab: 'sales' },
-      },
-    },
-  ];
+  const ordersTabMaybe = isCustomerUserType
+    ? [
+        {
+          text: (
+            <span>
+              <FormattedMessage id="InboxPage.ordersTabTitle" />
+            </span>
+          ),
+          selected: isOrders,
+          linkProps: {
+            name: 'InboxPage',
+            params: { tab: 'orders' },
+          },
+        },
+      ]
+    : [];
+
+  const salesTabMaybe = isProviderUserType
+    ? [
+        {
+          text: (
+            <span>
+              <FormattedMessage id="InboxPage.salesTabTitle" />
+              {providerNotificationCount > 0 ? (
+                <NotificationBadge count={providerNotificationCount} />
+              ) : null}
+            </span>
+          ),
+          selected: !isOrders,
+          linkProps: {
+            name: 'InboxPage',
+            params: { tab: 'sales' },
+          },
+        },
+      ]
+    : [];
+
+  const tabs = [...ordersTabMaybe, ...salesTabMaybe];
 
   return (
     <Page title={title} scrollingDisabled={scrollingDisabled}>

--- a/src/containers/ManageListingsPage/ManageListingsPage.js
+++ b/src/containers/ManageListingsPage/ManageListingsPage.js
@@ -4,9 +4,10 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 
 import { useRouteConfiguration } from '../../context/routeConfigurationContext';
+import { useConfiguration } from '../../context/configurationContext';
 import { FormattedMessage, useIntl } from '../../util/reactIntl';
 import { pathByRouteName } from '../../util/routes';
-import { hasPermissionToPostListings } from '../../util/userHelpers';
+import { hasPermissionToPostListings, showCreateListingLinkForUser } from '../../util/userHelpers';
 import { NO_ACCESS_PAGE_POST_LISTINGS } from '../../util/urlHelpers';
 import { propTypes } from '../../util/types';
 import { isErrorNoPermissionToPostListings } from '../../util/errors';
@@ -107,6 +108,7 @@ export const ManageListingsPageComponent = props => {
   const [discardDraftModalId, setDiscardDraftModalId] = useState(null);
   const history = useHistory();
   const routeConfiguration = useRouteConfiguration();
+  const config = useConfiguration();
   const intl = useIntl();
 
   const {
@@ -197,6 +199,8 @@ export const ManageListingsPageComponent = props => {
     `${panelWidth / 3}vw`,
   ].join(', ');
 
+  const showManageListingsLink = showCreateListingLinkForUser(config, currentUser);
+
   return (
     <Page
       title={intl.formatMessage({ id: 'ManageListingsPage.title' })}
@@ -206,7 +210,10 @@ export const ManageListingsPageComponent = props => {
         topbar={
           <>
             <TopbarContainer />
-            <UserNav currentPage="ManageListingsPage" />
+            <UserNav
+              currentPage="ManageListingsPage"
+              showManageListingsLink={showManageListingsLink}
+            />
           </>
         }
         footer={<FooterContainer />}

--- a/src/containers/PasswordChangePage/PasswordChangePage.js
+++ b/src/containers/PasswordChangePage/PasswordChangePage.js
@@ -2,9 +2,11 @@ import React from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
+import { useConfiguration } from '../../context/configurationContext';
 import { FormattedMessage, useIntl } from '../../util/reactIntl';
 import { propTypes } from '../../util/types';
 import { isScrollingDisabled } from '../../ducks/ui.duck';
+import { showCreateListingLinkForUser } from '../../util/userHelpers';
 
 import { Page, UserNav, H3, LayoutSideNavigation } from '../../components';
 
@@ -33,6 +35,7 @@ import css from './PasswordChangePage.module.css';
  */
 export const PasswordChangePageComponent = props => {
   const intl = useIntl();
+  const config = useConfiguration();
   const {
     changePasswordError,
     changePasswordInProgress,
@@ -64,6 +67,8 @@ export const PasswordChangePageComponent = props => {
 
   const title = intl.formatMessage({ id: 'PasswordChangePage.title' });
 
+  const showManageListingsLink = showCreateListingLinkForUser(config, currentUser);
+
   return (
     <Page title={title} scrollingDisabled={scrollingDisabled}>
       <LayoutSideNavigation
@@ -73,7 +78,10 @@ export const PasswordChangePageComponent = props => {
               desktopClassName={css.desktopTopbar}
               mobileClassName={css.mobileTopbar}
             />
-            <UserNav currentPage="PasswordChangePage" />
+            <UserNav
+              currentPage="PasswordChangePage"
+              showManageListingsLink={showManageListingsLink}
+            />
           </>
         }
         sideNav={null}

--- a/src/containers/PasswordChangePage/PasswordChangePage.js
+++ b/src/containers/PasswordChangePage/PasswordChangePage.js
@@ -6,7 +6,7 @@ import { useConfiguration } from '../../context/configurationContext';
 import { FormattedMessage, useIntl } from '../../util/reactIntl';
 import { propTypes } from '../../util/types';
 import { isScrollingDisabled } from '../../ducks/ui.duck';
-import { showCreateListingLinkForUser } from '../../util/userHelpers';
+import { showCreateListingLinkForUser, showPaymentDetailsForUser } from '../../util/userHelpers';
 
 import { Page, UserNav, H3, LayoutSideNavigation } from '../../components';
 
@@ -68,6 +68,12 @@ export const PasswordChangePageComponent = props => {
   const title = intl.formatMessage({ id: 'PasswordChangePage.title' });
 
   const showManageListingsLink = showCreateListingLinkForUser(config, currentUser);
+  const { showPayoutDetails, showPaymentMethods } = showPaymentDetailsForUser(config, currentUser);
+  const accountSettingsNavProps = {
+    currentPage: 'PasswordChangePage',
+    showPaymentMethods,
+    showPayoutDetails,
+  };
 
   return (
     <Page title={title} scrollingDisabled={scrollingDisabled}>
@@ -86,7 +92,7 @@ export const PasswordChangePageComponent = props => {
         }
         sideNav={null}
         useAccountSettingsNav
-        currentPage="PasswordChangePage"
+        accountSettingsNavProps={accountSettingsNavProps}
         footer={<FooterContainer />}
       >
         <div className={css.content}>

--- a/src/containers/PaymentMethodsPage/PaymentMethodsPage.js
+++ b/src/containers/PaymentMethodsPage/PaymentMethodsPage.js
@@ -6,6 +6,7 @@ import { useConfiguration } from '../../context/configurationContext.js';
 import { FormattedMessage, useIntl } from '../../util/reactIntl';
 import { ensureCurrentUser, ensureStripeCustomer, ensurePaymentMethodCard } from '../../util/data';
 import { propTypes } from '../../util/types';
+import { showCreateListingLinkForUser, showPaymentDetailsForUser } from '../../util/userHelpers.js';
 import { savePaymentMethod, deletePaymentMethod } from '../../ducks/paymentMethods.duck';
 import { handleCardSetup } from '../../ducks/stripe.duck';
 import { manageDisableScrolling, isScrollingDisabled } from '../../ducks/ui.duck';
@@ -162,6 +163,13 @@ const PaymentMethodsPageComponent = props => {
   const showCardDetails = !!hasDefaultPaymentMethod;
 
   const showManageListingsLink = showCreateListingLinkForUser(config, currentUser);
+  const { showPayoutDetails, showPaymentMethods } = showPaymentDetailsForUser(config, currentUser);
+  const accountSettingsNavProps = {
+    currentPage: 'PaymentMethodsPage',
+    showPaymentMethods,
+    showPayoutDetails,
+  };
+
   return (
     <Page title={title} scrollingDisabled={scrollingDisabled}>
       <LayoutSideNavigation
@@ -179,7 +187,7 @@ const PaymentMethodsPageComponent = props => {
         }
         sideNav={null}
         useAccountSettingsNav
-        currentPage="PaymentMethodsPage"
+        accountSettingsNavProps={accountSettingsNavProps}
         footer={<FooterContainer />}
       >
         <div className={css.content}>

--- a/src/containers/PaymentMethodsPage/PaymentMethodsPage.js
+++ b/src/containers/PaymentMethodsPage/PaymentMethodsPage.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
+import { useConfiguration } from '../../context/configurationContext.js';
 import { FormattedMessage, useIntl } from '../../util/reactIntl';
 import { ensureCurrentUser, ensureStripeCustomer, ensurePaymentMethodCard } from '../../util/data';
 import { propTypes } from '../../util/types';
@@ -43,6 +44,7 @@ const PaymentMethodsPageComponent = props => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [cardState, setCardState] = useState(null);
   const intl = useIntl();
+  const config = useConfiguration();
 
   const {
     currentUser,
@@ -158,6 +160,8 @@ const PaymentMethodsPageComponent = props => {
 
   const showForm = cardState === 'replaceCard' || !hasDefaultPaymentMethod;
   const showCardDetails = !!hasDefaultPaymentMethod;
+
+  const showManageListingsLink = showCreateListingLinkForUser(config, currentUser);
   return (
     <Page title={title} scrollingDisabled={scrollingDisabled}>
       <LayoutSideNavigation
@@ -167,7 +171,10 @@ const PaymentMethodsPageComponent = props => {
               desktopClassName={css.desktopTopbar}
               mobileClassName={css.mobileTopbar}
             />
-            <UserNav currentPage="PaymentMethodsPage" />
+            <UserNav
+              currentPage="PaymentMethodsPage"
+              showManageListingsLink={showManageListingsLink}
+            />
           </>
         }
         sideNav={null}

--- a/src/containers/ProfilePage/ProfilePage.js
+++ b/src/containers/ProfilePage/ProfilePage.js
@@ -25,7 +25,11 @@ import {
   isNotFoundError,
 } from '../../util/errors';
 import { pickCustomFieldProps } from '../../util/fieldHelpers';
-import { hasPermissionToViewData, isUserAuthorized } from '../../util/userHelpers';
+import {
+  getCurrentUserTypeRoles,
+  hasPermissionToViewData,
+  isUserAuthorized,
+} from '../../util/userHelpers';
 import { richText } from '../../util/richText';
 
 import { isScrollingDisabled } from '../../ducks/ui.duck';
@@ -117,38 +121,52 @@ export const MobileReviews = props => {
 };
 
 export const DesktopReviews = props => {
-  const [showReviewsType, setShowReviewsType] = useState(REVIEW_TYPE_OF_PROVIDER);
-  const { reviews, queryReviewsError } = props;
+  const { reviews, queryReviewsError, userTypeRoles } = props;
+  const { customer: isCustomerUserType, provider: isProviderUserType } = userTypeRoles;
+
+  const initialReviewState = !isProviderUserType
+    ? REVIEW_TYPE_OF_CUSTOMER
+    : REVIEW_TYPE_OF_PROVIDER;
+  const [showReviewsType, setShowReviewsType] = useState(initialReviewState);
+
   const reviewsOfProvider = reviews.filter(r => r.attributes.type === REVIEW_TYPE_OF_PROVIDER);
   const reviewsOfCustomer = reviews.filter(r => r.attributes.type === REVIEW_TYPE_OF_CUSTOMER);
   const isReviewTypeProviderSelected = showReviewsType === REVIEW_TYPE_OF_PROVIDER;
   const isReviewTypeCustomerSelected = showReviewsType === REVIEW_TYPE_OF_CUSTOMER;
-  const desktopReviewTabs = [
-    {
-      text: (
-        <Heading as="h3" rootClassName={css.desktopReviewsTitle}>
-          <FormattedMessage
-            id="ProfilePage.reviewsFromMyCustomersTitle"
-            values={{ count: reviewsOfProvider.length }}
-          />
-        </Heading>
-      ),
-      selected: isReviewTypeProviderSelected,
-      onClick: () => setShowReviewsType(REVIEW_TYPE_OF_PROVIDER),
-    },
-    {
-      text: (
-        <Heading as="h3" rootClassName={css.desktopReviewsTitle}>
-          <FormattedMessage
-            id="ProfilePage.reviewsAsACustomerTitle"
-            values={{ count: reviewsOfCustomer.length }}
-          />
-        </Heading>
-      ),
-      selected: isReviewTypeCustomerSelected,
-      onClick: () => setShowReviewsType(REVIEW_TYPE_OF_CUSTOMER),
-    },
-  ];
+  const providerReviewsMaybe = isProviderUserType
+    ? [
+        {
+          text: (
+            <Heading as="h3" rootClassName={css.desktopReviewsTitle}>
+              <FormattedMessage
+                id="ProfilePage.reviewsFromMyCustomersTitle"
+                values={{ count: reviewsOfProvider.length }}
+              />
+            </Heading>
+          ),
+          selected: isReviewTypeProviderSelected,
+          onClick: () => setShowReviewsType(REVIEW_TYPE_OF_PROVIDER),
+        },
+      ]
+    : [];
+
+  const customerReviewsMaybe = isCustomerUserType
+    ? [
+        {
+          text: (
+            <Heading as="h3" rootClassName={css.desktopReviewsTitle}>
+              <FormattedMessage
+                id="ProfilePage.reviewsAsACustomerTitle"
+                values={{ count: reviewsOfCustomer.length }}
+              />
+            </Heading>
+          ),
+          selected: isReviewTypeCustomerSelected,
+          onClick: () => setShowReviewsType(REVIEW_TYPE_OF_CUSTOMER),
+        },
+      ]
+    : [];
+  const desktopReviewTabs = [...providerReviewsMaybe, ...customerReviewsMaybe];
 
   return (
     <div className={css.desktopReviews}>
@@ -211,6 +229,7 @@ export const MainContent = props => {
     userFieldConfig,
     intl,
     hideReviews,
+    userTypeRoles,
   } = props;
 
   const hasListings = listings.length > 0;
@@ -269,9 +288,17 @@ export const MainContent = props => {
         </div>
       ) : null}
       {hideReviews ? null : isMobileLayout ? (
-        <MobileReviews reviews={reviews} queryReviewsError={queryReviewsError} />
+        <MobileReviews
+          reviews={reviews}
+          queryReviewsError={queryReviewsError}
+          userTypeRoles={userTypeRoles}
+        />
       ) : (
-        <DesktopReviews reviews={reviews} queryReviewsError={queryReviewsError} />
+        <DesktopReviews
+          reviews={reviews}
+          queryReviewsError={queryReviewsError}
+          userTypeRoles={userTypeRoles}
+        />
       )}
     </div>
   );
@@ -336,6 +363,8 @@ export const ProfilePageComponent = props => {
   const hasUserPendingApprovalError = isErrorUserPendingApproval(userShowError);
   const hasNoViewingRightsUser = currentUser && !hasPermissionToViewData(currentUser);
   const hasNoViewingRightsOnPrivateMarketplace = isPrivateMarketplace && hasNoViewingRightsUser;
+
+  const userTypeRoles = getCurrentUserTypeRoles(config, profileUser);
 
   const isDataLoaded = isPreview
     ? currentUser != null || userShowError != null
@@ -419,6 +448,7 @@ export const ProfilePageComponent = props => {
           userFieldConfig={userFields}
           hideReviews={hasNoViewingRightsOnPrivateMarketplace}
           intl={intl}
+          userTypeRoles={userTypeRoles}
           {...rest}
         />
       </LayoutSideNavigation>

--- a/src/containers/ProfileSettingsPage/ProfileSettingsPage.js
+++ b/src/containers/ProfileSettingsPage/ProfileSettingsPage.js
@@ -11,6 +11,7 @@ import {
   initialValuesForUserFields,
   isUserAuthorized,
   pickUserFieldsData,
+  showCreateListingLinkForUser,
 } from '../../util/userHelpers';
 import { isScrollingDisabled } from '../../ducks/ui.duck';
 
@@ -171,13 +172,18 @@ export const ProfileSettingsPageComponent = props => {
 
   const title = intl.formatMessage({ id: 'ProfileSettingsPage.title' });
 
+  const showManageListingsLink = showCreateListingLinkForUser(config, currentUser);
+
   return (
     <Page className={css.root} title={title} scrollingDisabled={scrollingDisabled}>
       <LayoutSingleColumn
         topbar={
           <>
             <TopbarContainer />
-            <UserNav currentPage="ProfileSettingsPage" />
+            <UserNav
+              currentPage="ProfileSettingsPage"
+              showManageListingsLink={showManageListingsLink}
+            />
           </>
         }
         footer={<FooterContainer />}

--- a/src/containers/SearchPage/NoSearchResultsMaybe/NoSearchResultsMaybe.js
+++ b/src/containers/SearchPage/NoSearchResultsMaybe/NoSearchResultsMaybe.js
@@ -5,9 +5,16 @@ import { NamedLink } from '../../../components';
 import css from './NoSearchResultsMaybe.module.css';
 
 const NoSearchResultsMaybe = props => {
-  const { listingsAreLoaded, totalItems, location, resetAll } = props;
+  const { listingsAreLoaded, totalItems, location, resetAll, showCreateListingsLink } = props;
   const hasNoResult = listingsAreLoaded && totalItems === 0;
   const hasSearchParams = location.search?.length > 0;
+
+  const createListingLinkMaybe = showCreateListingsLink ? (
+    <NamedLink className={css.createListingLink} name="NewListingPage">
+      <FormattedMessage id="SearchPage.createListing" />
+    </NamedLink>
+  ) : null;
+
   return hasNoResult ? (
     <div className={css.noSearchResults}>
       <FormattedMessage id="SearchPage.noResults" />
@@ -17,11 +24,7 @@ const NoSearchResultsMaybe = props => {
           <FormattedMessage id={'SearchPage.resetAllFilters'} />
         </button>
       ) : null}
-      <p>
-        <NamedLink className={css.createListingLink} name="NewListingPage">
-          <FormattedMessage id="SearchPage.createListing" />
-        </NamedLink>
-      </p>
+      <p>{createListingLinkMaybe}</p>
     </div>
   ) : null;
 };

--- a/src/containers/SearchPage/SearchPageWithGrid.js
+++ b/src/containers/SearchPage/SearchPageWithGrid.js
@@ -27,7 +27,11 @@ import {
   isErrorUserPendingApproval,
   isForbiddenError,
 } from '../../util/errors';
-import { hasPermissionToViewData, isUserAuthorized } from '../../util/userHelpers';
+import {
+  hasPermissionToViewData,
+  isUserAuthorized,
+  showCreateListingLinkForUser,
+} from '../../util/userHelpers';
 import { getListingsById } from '../../ducks/marketplaceData.duck';
 import { manageDisableScrolling, isScrollingDisabled } from '../../ducks/ui.duck';
 
@@ -231,6 +235,7 @@ export class SearchPageComponent extends Component {
       routeConfiguration,
       config,
       params: currentPathParams = {},
+      currentUser,
     } = this.props;
 
     // If the search page variant is of type /s/:listingType, this defines the :listingType
@@ -325,6 +330,8 @@ export class SearchPageComponent extends Component {
       validQueryParams,
       filterConfigs
     );
+
+    const showCreateListingsLink = showCreateListingLinkForUser(config, currentUser);
     const sortBy = mode => {
       return sortConfig.active ? (
         <SortBy
@@ -345,6 +352,7 @@ export class SearchPageComponent extends Component {
         totalItems={totalItems}
         location={location}
         resetAll={this.resetAll}
+        showCreateListingsLink={showCreateListingsLink}
       />
     );
 
@@ -550,6 +558,7 @@ const EnhancedSearchPage = props => {
       intl={intl}
       history={history}
       location={location}
+      currentUser={currentUser}
       {...restOfProps}
     />
   );

--- a/src/containers/SearchPage/SearchPageWithMap.js
+++ b/src/containers/SearchPage/SearchPageWithMap.js
@@ -28,7 +28,11 @@ import {
   isErrorUserPendingApproval,
   isForbiddenError,
 } from '../../util/errors';
-import { hasPermissionToViewData, isUserAuthorized } from '../../util/userHelpers';
+import {
+  hasPermissionToViewData,
+  isUserAuthorized,
+  showCreateListingLinkForUser,
+} from '../../util/userHelpers';
 import { getListingsById } from '../../ducks/marketplaceData.duck';
 import { manageDisableScrolling, isScrollingDisabled } from '../../ducks/ui.duck';
 
@@ -345,6 +349,7 @@ export class SearchPageComponent extends Component {
       routeConfiguration,
       config,
       params: currentPathParams = {},
+      currentUser,
     } = this.props;
 
     // If the search page variant is of type /s/:listingType, this defines the :listingType
@@ -469,6 +474,8 @@ export class SearchPageComponent extends Component {
       validQueryParams,
       filterConfigs
     );
+
+    const showCreateListingsLink = showCreateListingLinkForUser(config, currentUser);
     const sortBy = mode => {
       return sortConfig.active ? (
         <SortBy
@@ -489,6 +496,7 @@ export class SearchPageComponent extends Component {
         totalItems={totalItems}
         location={location}
         resetAll={this.resetAll}
+        showCreateListingsLink={showCreateListingsLink}
       />
     );
 
@@ -749,6 +757,7 @@ const EnhancedSearchPage = props => {
       intl={intl}
       history={history}
       location={location}
+      currentUser={currentUser}
       {...restOfProps}
     />
   );

--- a/src/containers/StripePayoutPage/StripePayoutPage.js
+++ b/src/containers/StripePayoutPage/StripePayoutPage.js
@@ -8,6 +8,7 @@ import { createResourceLocatorString } from '../../util/routes';
 import { FormattedMessage, useIntl } from '../../util/reactIntl';
 import { ensureCurrentUser } from '../../util/data';
 import { propTypes } from '../../util/types';
+import { showCreateListingLinkForUser } from '../../util/userHelpers';
 import { isScrollingDisabled } from '../../ducks/ui.duck';
 import {
   stripeAccountClearError,
@@ -167,6 +168,8 @@ export const StripePayoutPageComponent = props => {
     handleGetStripeConnectAccountLink('custom_account_verification')();
   }
 
+  const showManageListingsLink = showCreateListingLinkForUser(config, currentUser);
+
   return (
     <Page title={title} scrollingDisabled={scrollingDisabled}>
       <LayoutSideNavigation
@@ -176,7 +179,10 @@ export const StripePayoutPageComponent = props => {
               desktopClassName={css.desktopTopbar}
               mobileClassName={css.mobileTopbar}
             />
-            <UserNav currentPage="StripePayoutPage" />
+            <UserNav
+              currentPage="StripePayoutPage"
+              showManageListingsLink={showManageListingsLink}
+            />
           </>
         }
         sideNav={null}

--- a/src/containers/StripePayoutPage/StripePayoutPage.js
+++ b/src/containers/StripePayoutPage/StripePayoutPage.js
@@ -8,7 +8,7 @@ import { createResourceLocatorString } from '../../util/routes';
 import { FormattedMessage, useIntl } from '../../util/reactIntl';
 import { ensureCurrentUser } from '../../util/data';
 import { propTypes } from '../../util/types';
-import { showCreateListingLinkForUser } from '../../util/userHelpers';
+import { showCreateListingLinkForUser, showPaymentDetailsForUser } from '../../util/userHelpers';
 import { isScrollingDisabled } from '../../ducks/ui.duck';
 import {
   stripeAccountClearError,
@@ -169,6 +169,12 @@ export const StripePayoutPageComponent = props => {
   }
 
   const showManageListingsLink = showCreateListingLinkForUser(config, currentUser);
+  const { showPayoutDetails, showPaymentMethods } = showPaymentDetailsForUser(config, currentUser);
+  const accountSettingsNavProps = {
+    currentPage: 'StripePayoutPage',
+    showPaymentMethods,
+    showPayoutDetails,
+  };
 
   return (
     <Page title={title} scrollingDisabled={scrollingDisabled}>
@@ -187,7 +193,7 @@ export const StripePayoutPageComponent = props => {
         }
         sideNav={null}
         useAccountSettingsNav
-        currentPage="StripePayoutPage"
+        accountSettingsNavProps={accountSettingsNavProps}
         footer={<FooterContainer />}
       >
         <div className={css.content}>

--- a/src/containers/TopbarContainer/Topbar/Topbar.js
+++ b/src/containers/TopbarContainer/Topbar/Topbar.js
@@ -26,6 +26,7 @@ import TopbarMobileMenu from './TopbarMobileMenu/TopbarMobileMenu';
 import TopbarDesktop from './TopbarDesktop/TopbarDesktop';
 
 import css from './Topbar.module.css';
+import { showCreateListingLinkForUser } from '../../../util/userHelpers';
 
 const MAX_MOBILE_SCREEN_WIDTH = 1024;
 
@@ -204,6 +205,8 @@ const TopbarComponent = props => {
     });
   };
 
+  const showCreateListingsLink = showCreateListingLinkForUser(config, currentUser);
+
   const { mobilemenu, mobilesearch, keywords, address, origin, bounds } = parse(location.search, {
     latlng: ['origin'],
     latlngBounds: ['bounds'],
@@ -232,6 +235,7 @@ const TopbarComponent = props => {
       notificationCount={notificationCount}
       currentPage={resolvedCurrentPage}
       customLinks={customLinks}
+      showCreateListingsLink={showCreateListingsLink}
     />
   );
 
@@ -324,6 +328,7 @@ const TopbarComponent = props => {
           config={config}
           customLinks={customLinks}
           showSearchForm={showSearchForm}
+          showCreateListingsLink={showCreateListingsLink}
         />
       </div>
       <Modal

--- a/src/containers/TopbarContainer/Topbar/Topbar.js
+++ b/src/containers/TopbarContainer/Topbar/Topbar.js
@@ -26,7 +26,7 @@ import TopbarMobileMenu from './TopbarMobileMenu/TopbarMobileMenu';
 import TopbarDesktop from './TopbarDesktop/TopbarDesktop';
 
 import css from './Topbar.module.css';
-import { showCreateListingLinkForUser } from '../../../util/userHelpers';
+import { getCurrentUserTypeRoles, showCreateListingLinkForUser } from '../../../util/userHelpers';
 
 const MAX_MOBILE_SCREEN_WIDTH = 1024;
 
@@ -206,6 +206,24 @@ const TopbarComponent = props => {
   };
 
   const showCreateListingsLink = showCreateListingLinkForUser(config, currentUser);
+  const { customer: isCustomer, provider: isProvider } = getCurrentUserTypeRoles(
+    config,
+    currentUser
+  );
+
+  /**
+   * Determine which tab to use in the inbox link:
+   * - if only provider role – sales
+   * - if only customer role – orders
+   * - if both roles – determine by currentUserHasListings value
+   */
+  const topbarInboxTab = !isCustomer
+    ? 'sales'
+    : !isProvider
+    ? 'orders'
+    : currentUserHasListings
+    ? 'sales'
+    : 'orders';
 
   const { mobilemenu, mobilesearch, keywords, address, origin, bounds } = parse(location.search, {
     latlng: ['origin'],
@@ -229,13 +247,13 @@ const TopbarComponent = props => {
   const mobileMenu = (
     <TopbarMobileMenu
       isAuthenticated={isAuthenticated}
-      currentUserHasListings={currentUserHasListings}
       currentUser={currentUser}
       onLogout={handleLogout}
       notificationCount={notificationCount}
       currentPage={resolvedCurrentPage}
       customLinks={customLinks}
       showCreateListingsLink={showCreateListingsLink}
+      inboxTab={topbarInboxTab}
     />
   );
 
@@ -329,6 +347,7 @@ const TopbarComponent = props => {
           customLinks={customLinks}
           showSearchForm={showSearchForm}
           showCreateListingsLink={showCreateListingsLink}
+          inboxTab={topbarInboxTab}
         />
       </div>
       <Modal

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
@@ -6,16 +6,21 @@ import LinksMenu from './LinksMenu';
 import css from './CustomLinksMenu.module.css';
 
 const draftId = '00000000-0000-0000-0000-000000000000';
-const createListingLinkConfig = intl => ({
-  group: 'primary',
-  text: intl.formatMessage({ id: 'TopbarDesktop.createListing' }),
-  type: 'internal',
-  route: {
-    name: 'EditListingPage',
-    params: { slug: 'draft', id: draftId, type: 'new', tab: 'details' },
-  },
-  highlight: true,
-});
+const createListingLinkConfigMaybe = (intl, showLink) =>
+  showLink
+    ? [
+        {
+          group: 'primary',
+          text: intl.formatMessage({ id: 'TopbarDesktop.createListing' }),
+          type: 'internal',
+          route: {
+            name: 'EditListingPage',
+            params: { slug: 'draft', id: draftId, type: 'new', tab: 'details' },
+          },
+          highlight: true,
+        },
+      ]
+    : [];
 
 /**
  * Group links to 2 groups:
@@ -100,12 +105,22 @@ const calculateContainerWidth = (containerRefTarget, parentWidth) => {
  * @param {*} props contains currentPage, customLinks, intl, and hasClientSideContentReady
  * @returns component to be placed inside TopbarDesktop
  */
-const CustomLinksMenu = ({ currentPage, customLinks = [], hasClientSideContentReady, intl }) => {
+const CustomLinksMenu = ({
+  currentPage,
+  customLinks = [],
+  hasClientSideContentReady,
+  intl,
+  showCreateListingsLink,
+}) => {
   const containerRef = useRef(null);
   const observer = useRef(null);
   const [mounted, setMounted] = useState(false);
   const [moreLabelWidth, setMoreLabelWidth] = useState(0);
-  const [links, setLinks] = useState([createListingLinkConfig(intl), ...customLinks]);
+  const [links, setLinks] = useState([
+    ...createListingLinkConfigMaybe(intl, showCreateListingsLink),
+    ...customLinks,
+  ]);
+
   const [layoutData, setLayoutData] = useState({
     priorityLinks: links,
     menuLinks: links,
@@ -178,7 +193,7 @@ const CustomLinksMenu = ({ currentPage, customLinks = [], hasClientSideContentRe
   const { priorityLinks, menuLinks, containerWidth } = layoutData;
 
   // If there are no custom links, just render createListing link.
-  if (customLinks?.length === 0) {
+  if (customLinks?.length === 0 && showCreateListingsLink) {
     return <CreateListingMenuLink customLinksMenuClass={css.createListingLinkOnly} />;
   }
 

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -55,7 +55,7 @@ const InboxLink = ({ notificationCount, currentUserHasListings }) => {
   );
 };
 
-const ProfileMenu = ({ currentPage, currentUser, onLogout }) => {
+const ProfileMenu = ({ currentPage, currentUser, onLogout, showManageListingsLink }) => {
   const currentPageClass = page => {
     const isAccountSettingsPage =
       page === 'AccountSettingsPage' && ACCOUNT_SETTINGS_PAGES.includes(currentPage);
@@ -68,15 +68,17 @@ const ProfileMenu = ({ currentPage, currentUser, onLogout }) => {
         <Avatar className={css.avatar} user={currentUser} disableProfileLink />
       </MenuLabel>
       <MenuContent className={css.profileMenuContent}>
-        <MenuItem key="ManageListingsPage">
-          <NamedLink
-            className={classNames(css.menuLink, currentPageClass('ManageListingsPage'))}
-            name="ManageListingsPage"
-          >
-            <span className={css.menuItemBorder} />
-            <FormattedMessage id="TopbarDesktop.yourListingsLink" />
-          </NamedLink>
-        </MenuItem>
+        {showManageListingsLink ? (
+          <MenuItem key="ManageListingsPage">
+            <NamedLink
+              className={classNames(css.menuLink, currentPageClass('ManageListingsPage'))}
+              name="ManageListingsPage"
+            >
+              <span className={css.menuItemBorder} />
+              <FormattedMessage id="TopbarDesktop.yourListingsLink" />
+            </NamedLink>
+          </MenuItem>
+        ) : null}
         <MenuItem key="ProfileSettingsPage">
           <NamedLink
             className={classNames(css.menuLink, currentPageClass('ProfileSettingsPage'))}
@@ -165,7 +167,12 @@ const TopbarDesktop = props => {
   ) : null;
 
   const profileMenuMaybe = authenticatedOnClientSide ? (
-    <ProfileMenu currentPage={currentPage} currentUser={currentUser} onLogout={onLogout} />
+    <ProfileMenu
+      currentPage={currentPage}
+      currentUser={currentUser}
+      onLogout={onLogout}
+      showManageListingsLink={showCreateListingsLink}
+    />
   ) : null;
 
   const signupLinkMaybe = isAuthenticatedOrJustHydrated ? null : <SignupLink />;

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -142,6 +142,7 @@ const TopbarDesktop = props => {
     onSearchSubmit,
     initialSearchFormValues = {},
     showSearchForm,
+    showCreateListingsLink,
   } = props;
   const [mounted, setMounted] = useState(false);
 
@@ -201,6 +202,7 @@ const TopbarDesktop = props => {
         customLinks={customLinks}
         intl={intl}
         hasClientSideContentReady={authenticatedOnClientSide || !isAuthenticatedOrJustHydrated}
+        showCreateListingsLink={showCreateListingsLink}
       />
 
       {inboxLinkMaybe}

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/TopbarDesktop.js
@@ -39,14 +39,10 @@ const LoginLink = () => {
   );
 };
 
-const InboxLink = ({ notificationCount, currentUserHasListings }) => {
+const InboxLink = ({ notificationCount, inboxTab }) => {
   const notificationDot = notificationCount > 0 ? <div className={css.notificationDot} /> : null;
   return (
-    <NamedLink
-      className={css.topbarLink}
-      name="InboxPage"
-      params={{ tab: currentUserHasListings ? 'sales' : 'orders' }}
-    >
+    <NamedLink className={css.topbarLink} name="InboxPage" params={{ tab: inboxTab }}>
       <span className={css.topbarLinkLabel}>
         <FormattedMessage id="TopbarDesktop.inbox" />
         {notificationDot}
@@ -115,7 +111,6 @@ const ProfileMenu = ({ currentPage, currentUser, onLogout, showManageListingsLin
  * @param {Object} props
  * @param {string?} props.className add more style rules in addition to components own css.root
  * @param {string?} props.rootClassName overwrite components own css.root
- * @param {boolean} props.currentUserHasListings
  * @param {CurrentUser} props.currentUser API entity
  * @param {string?} props.currentPage
  * @param {boolean} props.isAuthenticated
@@ -126,6 +121,8 @@ const ProfileMenu = ({ currentPage, currentUser, onLogout, showManageListingsLin
  * @param {Object} props.intl
  * @param {Object} props.config
  * @param {boolean} props.showSearchForm
+ * @param {boolean} props.showCreateListingsLink
+ * @param {string} props.inboxTab
  * @returns {JSX.Element} search icon
  */
 const TopbarDesktop = props => {
@@ -136,7 +133,6 @@ const TopbarDesktop = props => {
     currentUser,
     currentPage,
     rootClassName,
-    currentUserHasListings,
     notificationCount = 0,
     intl,
     isAuthenticated,
@@ -145,6 +141,7 @@ const TopbarDesktop = props => {
     initialSearchFormValues = {},
     showSearchForm,
     showCreateListingsLink,
+    inboxTab,
   } = props;
   const [mounted, setMounted] = useState(false);
 
@@ -160,10 +157,7 @@ const TopbarDesktop = props => {
   const classes = classNames(rootClassName || css.root, className);
 
   const inboxLinkMaybe = authenticatedOnClientSide ? (
-    <InboxLink
-      notificationCount={notificationCount}
-      currentUserHasListings={currentUserHasListings}
-    />
+    <InboxLink notificationCount={notificationCount} inboxTab={inboxTab} />
   ) : null;
 
   const profileMenuMaybe = authenticatedOnClientSide ? (

--- a/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
@@ -71,7 +71,7 @@ const TopbarMobileMenu = props => {
   const {
     isAuthenticated,
     currentPage,
-    currentUserHasListings,
+    inboxTab,
     currentUser,
     notificationCount = 0,
     customLinks,
@@ -146,7 +146,15 @@ const TopbarMobileMenu = props => {
     const isInboxPage = currentPage?.indexOf('InboxPage') === 0 && page?.indexOf('InboxPage') === 0;
     return currentPage === page || isAccountSettingsPage || isInboxPage ? css.currentPage : null;
   };
-  const inboxTab = currentUserHasListings ? 'sales' : 'orders';
+
+  const manageListingsLinkMaybe = showCreateListingsLink ? (
+    <NamedLink
+      className={classNames(css.navigationLink, currentPageClass('ManageListingsPage'))}
+      name="ManageListingsPage"
+    >
+      <FormattedMessage id="TopbarMobileMenu.yourListingsLink" />
+    </NamedLink>
+  ) : null;
 
   return (
     <div className={css.root}>
@@ -168,12 +176,7 @@ const TopbarMobileMenu = props => {
             <FormattedMessage id="TopbarMobileMenu.inboxLink" />
             {notificationCountBadge}
           </NamedLink>
-          <NamedLink
-            className={classNames(css.navigationLink, currentPageClass('ManageListingsPage'))}
-            name="ManageListingsPage"
-          >
-            <FormattedMessage id="TopbarMobileMenu.yourListingsLink" />
-          </NamedLink>
+          {manageListingsLinkMaybe}
           <NamedLink
             className={classNames(css.navigationLink, currentPageClass('ProfileSettingsPage'))}
             name="ProfileSettingsPage"

--- a/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarMobileMenu/TopbarMobileMenu.js
@@ -76,6 +76,7 @@ const TopbarMobileMenu = props => {
     notificationCount = 0,
     customLinks,
     onLogout,
+    showCreateListingsLink,
   } = props;
 
   const user = ensureCurrentUser(currentUser);
@@ -89,6 +90,12 @@ const TopbarMobileMenu = props => {
       />
     );
   });
+
+  const createListingsLinkMaybe = showCreateListingsLink ? (
+    <NamedLink className={css.createNewListingLink} name="NewListingPage">
+      <FormattedMessage id="TopbarMobileMenu.newListingLink" />
+    </NamedLink>
+  ) : null;
 
   if (!isAuthenticated) {
     const signup = (
@@ -122,11 +129,7 @@ const TopbarMobileMenu = props => {
 
           <div className={css.spacer} />
         </div>
-        <div className={css.footer}>
-          <NamedLink className={css.createNewListingLink} name="NewListingPage">
-            <FormattedMessage id="TopbarMobileMenu.newListingLink" />
-          </NamedLink>
-        </div>
+        <div className={css.footer}>{createListingsLinkMaybe}</div>
       </div>
     );
   }
@@ -187,11 +190,7 @@ const TopbarMobileMenu = props => {
         <div className={css.customLinksWrapper}>{extraLinks}</div>
         <div className={css.spacer} />
       </div>
-      <div className={css.footer}>
-        <NamedLink className={css.createNewListingLink} name="NewListingPage">
-          <FormattedMessage id="TopbarMobileMenu.newListingLink" />
-        </NamedLink>
-      </div>
+      <div className={css.footer}>{createListingsLinkMaybe}</div>
     </div>
   );
 };

--- a/src/containers/TransactionPage/TransactionPage.js
+++ b/src/containers/TransactionPage/TransactionPage.js
@@ -54,7 +54,7 @@ import {
   fetchTransactionLineItems,
 } from './TransactionPage.duck';
 import css from './TransactionPage.module.css';
-import { hasPermissionToViewData } from '../../util/userHelpers.js';
+import { getCurrentUserTypeRoles, hasPermissionToViewData } from '../../util/userHelpers.js';
 
 // Submit dispute and close the review modal
 const onDisputeOrder = (
@@ -345,14 +345,25 @@ export const TransactionPageComponent = props => {
   const isOwnOrder =
     isDataAvailable && isCustomerRole && currentUser.id.uuid === customer?.id?.uuid;
 
+  const {
+    customer: isCustomerUserTypeRole,
+    provider: isProviderUserTypeRole,
+  } = getCurrentUserTypeRoles(config, currentUser);
+
   if (isDataAvailable && isProviderRole && !isOwnSale) {
+    // If the user's user type does not have a provider role set, redirect
+    // to 'orders' inbox tab. Otherwise, redirect to 'sales' tab.
+    const tab = !isProviderUserTypeRole ? 'orders' : 'sales';
     // eslint-disable-next-line no-console
     console.error('Tried to access a sale that was not owned by the current user');
-    return <NamedRedirect name="InboxPage" params={{ tab: 'sales' }} />;
+    return <NamedRedirect name="InboxPage" params={{ tab }} />;
   } else if (isDataAvailable && isCustomerRole && !isOwnOrder) {
+    // If the user's user type does not have a customer role set, redirect
+    // to 'sales' inbox tab. Otherwise, redirect to 'orders' tab.
+    const tab = !isCustomerUserTypeRole ? 'sales' : 'orders';
     // eslint-disable-next-line no-console
     console.error('Tried to access an order that was not owned by the current user');
-    return <NamedRedirect name="InboxPage" params={{ tab: 'orders' }} />;
+    return <NamedRedirect name="InboxPage" params={{ tab }} />;
   }
 
   const detailsClassName = classNames(css.tabContent, css.tabContentVisible);

--- a/src/util/userHelpers.js
+++ b/src/util/userHelpers.js
@@ -197,3 +197,28 @@ export const hasPermissionToViewData = currentUser => {
  * @returns {Boolean} true if currentUser has been approved (state is 'active').
  */
 export const isUserAuthorized = currentUser => currentUser?.attributes?.state === 'active';
+
+/**
+ * Check if the links for creating a new listing should be shown to the
+ * user currently browsing the marketplace.
+ * @param {Object} config Marketplace configuration
+ * @param {Object} currentUser API entity
+ * @returns {Boolean} true if the currentUser's user type, or the anonymous user configuration, is set to see the link
+ */
+export const showCreateListingLinkForUser = (config, currentUser) => {
+  const { topbar, user } = config;
+  const { userTypes } = user;
+  const currentUserTypeConfig = userTypes.find(
+    ut => ut.userType === currentUser?.attributes?.profile?.publicData?.userType
+  );
+
+  const { accountLinksVisibility } = currentUserTypeConfig || {};
+
+  return currentUser && accountLinksVisibility
+    ? accountLinksVisibility.postListings
+    : currentUser
+    ? true
+    : topbar?.postListingsLink
+    ? topbar.postListingsLink.showToUnauthenticatedUsers
+    : true;
+};

--- a/src/util/userHelpers.js
+++ b/src/util/userHelpers.js
@@ -198,6 +198,13 @@ export const hasPermissionToViewData = currentUser => {
  */
 export const isUserAuthorized = currentUser => currentUser?.attributes?.state === 'active';
 
+const getCurrentUserTypeConfig = (config, currentUser) => {
+  const { userTypes } = config.user;
+  return userTypes.find(
+    ut => ut.userType === currentUser?.attributes?.profile?.publicData?.userType
+  );
+};
+
 /**
  * Check if the links for creating a new listing should be shown to the
  * user currently browsing the marketplace.
@@ -206,11 +213,8 @@ export const isUserAuthorized = currentUser => currentUser?.attributes?.state ==
  * @returns {Boolean} true if the currentUser's user type, or the anonymous user configuration, is set to see the link
  */
 export const showCreateListingLinkForUser = (config, currentUser) => {
-  const { topbar, user } = config;
-  const { userTypes } = user;
-  const currentUserTypeConfig = userTypes.find(
-    ut => ut.userType === currentUser?.attributes?.profile?.publicData?.userType
-  );
+  const { topbar } = config;
+  const currentUserTypeConfig = getCurrentUserTypeConfig(config, currentUser);
 
   const { accountLinksVisibility } = currentUserTypeConfig || {};
 

--- a/src/util/userHelpers.js
+++ b/src/util/userHelpers.js
@@ -198,6 +198,12 @@ export const hasPermissionToViewData = currentUser => {
  */
 export const isUserAuthorized = currentUser => currentUser?.attributes?.state === 'active';
 
+/**
+ * Get the user type configuration for the current user's user type
+ * @param {*} config marketplace configuration
+ * @param {*} currentUser API entity
+ * @returns a single user type configuration, if found
+ */
 const getCurrentUserTypeConfig = (config, currentUser) => {
   const { userTypes } = config.user;
   return userTypes.find(
@@ -225,4 +231,23 @@ export const showCreateListingLinkForUser = (config, currentUser) => {
     : topbar?.postListingsLink
     ? topbar.postListingsLink.showToUnauthenticatedUsers
     : true;
+};
+
+/**
+ * Check if payout details tab and payout methods tab should be shown for the user
+ * @param {Object} config Marketplace configuration
+ * @param {*} currentUser API entity
+ * @returns {Object} { showPayoutDetails: Boolean, showPaymentMethods: boolean }
+ */
+export const showPaymentDetailsForUser = (config, currentUser) => {
+  const currentUserTypeConfig = getCurrentUserTypeConfig(config, currentUser);
+  const { paymentMethods = true, payoutDetails = true } =
+    currentUserTypeConfig?.accountLinksVisibility || {};
+
+  return (
+    currentUser && {
+      showPayoutDetails: payoutDetails,
+      showPaymentMethods: paymentMethods,
+    }
+  );
 };

--- a/src/util/userHelpers.js
+++ b/src/util/userHelpers.js
@@ -251,3 +251,19 @@ export const showPaymentDetailsForUser = (config, currentUser) => {
     }
   );
 };
+
+/**
+ * Check the roles defined for the current user
+ * @param {*} config Marketplace configuration
+ * @param {*} currentUser API entity
+ * @returns Object with attributes 'customer' and 'provider' and boolean values for each
+ */
+export const getCurrentUserTypeRoles = (config, currentUser) => {
+  const currentUserTypeConfig = getCurrentUserTypeConfig(config, currentUser);
+  return (
+    currentUserTypeConfig?.roles || {
+      customer: true,
+      provider: true,
+    }
+  );
+};


### PR DESCRIPTION
This change introduces conditional visibility on key elements depending on upcoming Console configurations for user types and top bar. This configuration is not yet released in Console!

Authenticated users with no user type, or with a user type that does not have any restrictions specified, will continue to see all of the following elements without changes.

## Visibility for "Create listings" and "Manage listings" links

Operators can hide the link for creating new listings
- from unauthenticated users
- and from specific user types

When the link configured as hidden, the following places will not show a link to create a listing
- the desktop top bar
- the mobile menu top bar
- any empty search results page

<img width="645" alt="topbar_no_listinglink" src="https://github.com/user-attachments/assets/48d07a71-c0ae-4c80-9b1e-cd896bbcf7b0" />

In addition, an authenticated user will not see the Manage listings links in the profile menu or the navigation bar for profile and account settings.

<img width="246" alt="profile_menu" src="https://github.com/user-attachments/assets/b7b23557-a7d4-45a0-8cbf-5209c649a648" />

<img width="753" alt="usernav" src="https://github.com/user-attachments/assets/531ea5e8-afe2-4d29-882e-e16f917641dc" />

## Payment details links in Account settings

Operators can select whether users with a specific user type can see tabs for adding payment methods, payout details, or both. The account settings side navigation shows the links configured for the user. Both payment method and payout detail pages will still be available for all authenticated users with a direct URL (`/payment-methods` or `/payments`).

<img width="726" alt="account_sidenav" src="https://github.com/user-attachments/assets/ba5e2df9-6e40-42a3-8f02-b8e0498a4c5d" />

## Inbox links

Operators can configure user types to customer, provider, or both.

If a user's user type is defined as 'customer' only, the links across the template will direct that user to the `/orders` tab when visiting the inbox, and the side navigation will only show the customer tab option. The user can navigate to the `/sales` tab with a direct URL. 

Conversely, if a user's user type is defined as 'provider' only, the user will be linked to the `/sales` tab when visiting the inbox. They can navigate to the `/orders` tab with a direct URL. A user with both user type roles will continue to see both tabs.

<img width="267" alt="provider_inbox" src="https://github.com/user-attachments/assets/62e86170-1ddf-47d0-aaff-4ab45ee1d8ca" />

## Profile page review tabs

If a user's user type is defined as 'customer' only, their profile page will show a tab with their reviews as a customer in transactions. For a user type defined as 'provider' only, their profile page will show a tab with their reviews from customers. A user with both definitions, or with no definition, will have both kinds of reviews visible in their profile.

<img width="776" alt="reviews_as_customer" src="https://github.com/user-attachments/assets/4458b423-9c8b-45eb-b8b4-cda280b6453a" />
