### PR TITLE
Add missing location prop to grid search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ way to update this template, but currently, we follow a pattern:
 ---
 
 ## Upcoming version 2025-XX-XX
-
+- [fix] Add missing location prop to grid search page
+  [#615](https://github.com/sharetribe/web-template/pull/615)
 - [fix] Corrected anchor link scrolling behavior on Privacy Policy and Terms of Service pages, when
   opened as modals (in signup/login). [#612](https://github.com/sharetribe/web-template/pull/612)
 

--- a/src/containers/SearchPage/SearchPageWithGrid.js
+++ b/src/containers/SearchPage/SearchPageWithGrid.js
@@ -421,6 +421,7 @@ export class SearchPageComponent extends Component {
                 selectedFiltersCount={selectedFiltersCountForMobile}
                 isMapVariant={false}
                 noResultsInfo={noResultsInfo}
+                location={location}
               >
                 {availableFilters.map(filterConfig => {
                   const key = `SearchFiltersMobile.${filterConfig.scope || 'built-in'}.${


### PR DESCRIPTION
SearchPageWithGrid component wasn't passing location as a prop to SearchFiltersMobile, so the "Cancel" button was not working.