### PR TITLE
change input font size to 16px

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [fix] Set the font size for the input fields in the Search as CTA component to 16px to prevent
+  unintentional zooming on mobile.[#622](https://github.com/sharetribe/web-template/pull/622)
 - [fix] BookingFixedDurationForm: start time generation didn't count consecutive time-slots
   correctly when multiple seats were allowed.
   [#620](https://github.com/sharetribe/web-template/pull/620)
-- [add] Improve one copy text.
-  [#621](https://github.com/sharetribe/web-template/pull/621)
+- [add] Improve one copy text. [#621](https://github.com/sharetribe/web-template/pull/621)
 - [add] Add currently available translations for DE, ES, FR.
   [#619](https://github.com/sharetribe/web-template/pull/619)
 

--- a/src/containers/PageBuilder/Primitives/SearchCTA/FilterKeyword/FilterKeyword.module.css
+++ b/src/containers/PageBuilder/Primitives/SearchCTA/FilterKeyword/FilterKeyword.module.css
@@ -29,7 +29,6 @@
   cursor: pointer;
   text-overflow: ellipsis;
   height: 40px;
-  font-size: 14px;
   &:hover,
   &:focus {
     border: none;

--- a/src/containers/PageBuilder/Primitives/SearchCTA/FilterLocation/FilterLocation.module.css
+++ b/src/containers/PageBuilder/Primitives/SearchCTA/FilterLocation/FilterLocation.module.css
@@ -5,7 +5,6 @@
   padding-left: 8px;
   text-overflow: ellipsis;
   cursor: pointer;
-  font-size: 14px;
   &:hover,
   &:focus {
     border: none;

--- a/src/containers/PageBuilder/Primitives/SearchCTA/SearchCTA.module.css
+++ b/src/containers/PageBuilder/Primitives/SearchCTA/SearchCTA.module.css
@@ -8,6 +8,7 @@
   min-height: 40px;
   padding-bottom: 8px;
   padding-top: 8px;
+  font-size: 16px;
   @media (--viewportLarge) {
     padding-bottom: 0;
     padding: 0;


### PR DESCRIPTION
Sets the font size for all input fields in the Search as CTA component to 16px to prevent mobile browsers from zooming into the input fields.