### PR TITLE
fix nightly mode check with search as cta component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [fix] Fix an issue with the date filter in the Search CTA component, which was not observing
+  nightly search configuration correctly.[#625](https://github.com/sharetribe/web-template/pull/625)
+
 ## [v8.4.2] 2025-06-02
 
 - [fix] Set the font size for the input fields in the Search as CTA component to 16px to prevent

--- a/src/containers/PageBuilder/Primitives/SearchCTA/FilterDateRange/FilterDateRange.js
+++ b/src/containers/PageBuilder/Primitives/SearchCTA/FilterDateRange/FilterDateRange.js
@@ -54,7 +54,8 @@ const FilterDateRange = props => {
     }
   };
 
-  const { dateRangeMode } = config;
+  const datesFilter = config.search.defaultFilters.find(f => f.key === 'dates');
+  const { dateRangeMode } = datesFilter || {};
   const isNightlyMode = dateRangeMode === 'night';
 
   // Compute the CSS class for the label with an "active" modifier if there is a selection or if the picker is open.


### PR DESCRIPTION
The Search as CTA component failed to observer the date range mode set in Console, resulting in users being able to search for individual days using the Search as CTA component when the nightly mode was enabled.

<img width="342" alt="image" src="https://github.com/user-attachments/assets/08f247c4-fd8c-4699-9435-f618270f7b36" />
