### PR TITLE
New release v8.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+## [v8.6.0] 2025-07-17
+
 - [fix] EditListingDeliveryPanel: additional shipping fee was not asked and the related shipping fee
   was missing, when selecting multiple items.
+  [#636](https://github.com/sharetribe/web-template/pull/636)
 - [add] Add support for listing types that do not require images.
   [#624](https://github.com/sharetribe/web-template/pull/624)
 - [fix] Remove mentions to legacy templates from README.md
@@ -29,7 +32,9 @@ way to update this template, but currently, we follow a pattern:
   - [fix] Removed additional padding on primary integer filters
   - [fix] Added word-break to Message and OwnMessage in ActivityFeed.js
 
-[#631](https://github.com/sharetribe/web-template/pull/631)
+  [#631](https://github.com/sharetribe/web-template/pull/631)
+
+  [v8.6.0]: https://github.com/sharetribe/web-template/compare/v8.5.0...v8.6.0
 
 ## [v8.5.0] 2025-06-10
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "8.5.0",
+  "version": "8.6.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
The main feature in this release is that it prepares _sharetribe/web-template_ to handle listings without images.

The feature is build so that it works together with listings that have images: basically, operator will get ability to toggle images on/off per listing type on Console (this is not available at the time of Template's release). If images are not used, provider sees Style tab in EditListingWizard. There they get the possibility to choose between a selection of background colors - as the listing card on search page (and elsewhere) will still render a card with similar dimensions as defined in branding asset (_Console > Build > Design > Branding_). 
In other words, listings without images have thumbnails with the same dimensions than what listings with images use on search page. On listing page, image is not shown as expected (no carousel nor cover photo).
[#624](https://github.com/sharetribe/web-template/pull/624)

<img width="933" height="772" alt="Screenshot 2025-07-17 at 15 41 33" src="https://github.com/user-attachments/assets/b31c1d63-66d4-4809-b737-450b840b225f" />

In addition, there are several bug fixes and improvements. The biggest highlight is that listings, using infinite items together with shipping option, didn't ask about shipping fee for additional items.

## Translation changes
### New translations
```json
  "EditListingStyleForm.helpText": "Decide how your listing will look like in search results.",
  "EditListingStyleForm.title": "Choose a style",
  "EditListingStyleForm.preview": "Preview",
  "EditListingStylePanel.createListingTitle": "Style",
  "EditListingStylePanel.title": "Edit the style of {listingTitle}",
  "EditListingWizard.default-booking.new.saveStyle": "Publish listing",
  "EditListingWizard.default-inquiry.new.saveStyle": "Publish listing",
  "EditListingWizard.default-purchase.new.saveStyle": "Publish listing",
  "EditListingWizard.edit.saveStyle": "Save changes",
  "EditListingWizard.tabLabelStyle": "Style",
  "StripeConnectAccountForm.buttonTitleLimitedAccess": "You can't manage payout details on behalf of user.",
  "StripeConnectAccountStatusBox.getVerifiedButtonTitleLimitedAccess": "You can't manage payout details on behalf of user.",
```

### Changed translations
```diff
-  "LimitedAccessBanner.message": "You're logged in as {firstName} {lastName}. You have limited access rights. You can't initiate transactions, move them forward, or send messages on the user's behalf.",
+  "LimitedAccessBanner.message": "You're logged in as {firstName} {lastName}. You have limited access rights. You can't add payout details, initiate transactions, move them forward, or send messages on the user's behalf.",
```

## [Changes] v8.6.0

- [fix] EditListingDeliveryPanel: additional shipping fee was not asked and the related shipping fee
  was missing, when selecting multiple items.
  [#636](https://github.com/sharetribe/web-template/pull/636)
- [add] Add support for listing types that do not require images.
  [#624](https://github.com/sharetribe/web-template/pull/624)
- [fix] Remove mentions to legacy templates from README.md
  [#630](https://github.com/sharetribe/web-template/pull/630)
- [fix] Small fixes

  - [fix] Renamed onRecoverableError param
  - [add] Improved schema for ProfilePage
  - [add] Added role, aria-label, and titles to social media icons
  - [change] Limited editing and added communication for operators using the 'log-in as' feature
  - [fix] Removed additional padding on primary integer filters
  - [fix] Added word-break to Message and OwnMessage in ActivityFeed.js

  [#631](https://github.com/sharetribe/web-template/pull/631)

  [Changes]: https://github.com/sharetribe/web-template/compare/v8.5.0...v8.6.0