### PR TITLE
SearchPage.shared.js: category ids are strings, so we need to convert query params to strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+- [fix] SearchPage.shared.js: category ids are always strings, so we need to convert query params to
+  strings. [#653](https://github.com/sharetribe/web-template/pull/653)
 - [fix] SearchPage: fix a bug with integer range values. The range end value was not exclusive.
   [#652](https://github.com/sharetribe/web-template/pull/652)
 - [fix] IntegerRangeFilter: fix a bug with small text on grid layout.

--- a/src/containers/SearchPage/SearchPage.shared.js
+++ b/src/containers/SearchPage/SearchPage.shared.js
@@ -19,8 +19,10 @@ import { isFieldForCategory, isFieldForListingType } from '../../util/fieldHelpe
 
 const validURLParamForCategoryData = (prefix, categories, level, params) => {
   const levelKey = constructQueryParamName(`${prefix}${level}`, 'public');
-  const levelValue = params?.[levelKey];
-  const foundCategory = categories.find(cat => cat.id === params?.[levelKey]);
+  const levelValue =
+    typeof params?.[levelKey] !== 'undefined' ? `${params?.[levelKey]}` : undefined;
+
+  const foundCategory = categories.find(cat => cat.id === levelValue);
   const subcategories = foundCategory?.subcategories || [];
   return foundCategory && subcategories.length > 0
     ? {


### PR DESCRIPTION
SearchPage.shared.js / validURLParamForCategoryData: values should be turned to strings since the _listing categories_ asset only deals with strings.
(background: URL search parameters are automatically turned to numbers if they are numbers)