### PR TITLE
urlHelpers.js: fix coordinate parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
-  [#675](https://github.com/sharetribe/web-template/pull/675)
-- [fix] Fix some Marketplace texts.
+- [fix] Fix a bug with coordinate values in the URL.
+  [#676](https://github.com/sharetribe/web-template/pull/676)
+- [fix] Fix some Marketplace texts. [#675](https://github.com/sharetribe/web-template/pull/675)
 
 ## [v9.0.0] 2025-10-14
 

--- a/src/util/urlHelpers.js
+++ b/src/util/urlHelpers.js
@@ -91,8 +91,22 @@ export const parseFloatNum = str => {
   }
   const num = parseFloat(trimmed);
   const isNumber = !isNaN(num);
-  const isFullyParsedNum = isNumber && num.toString() === trimmed;
-  return isFullyParsedNum ? num : null;
+  const parts = trimmed.split('.');
+
+  if (isNumber && parts.length === 2) {
+    const [integerPart, decimalPart] = parts;
+    const isFullyParsedNum = parseInt(integerPart, 10).toString() === integerPart;
+    const isDigitsOnlyDecimal = /^\d+$/.test(decimalPart);
+    if (isFullyParsedNum && isDigitsOnlyDecimal) {
+      return num;
+    }
+  } else if (isNumber && parts.length === 1) {
+    const isFullyParsedNum = parseInt(parts[0], 10).toString() === parts[0];
+    if (isFullyParsedNum) {
+      return num;
+    }
+  }
+  return null;
 };
 
 /**

--- a/src/util/urlHelpers.test.js
+++ b/src/util/urlHelpers.test.js
@@ -59,6 +59,10 @@ describe('urlHelpers', () => {
       expect(parseFloatNum('123.01')).toBeCloseTo(123.01, 2);
     });
 
+    it('handles float value with trailing zeros', () => {
+      expect(parseFloatNum('42.1000')).toBeCloseTo(42.1, 2);
+    });
+
     it('handles trailing chars', () => {
       expect(parseFloatNum('123abc')).toBeNull();
     });


### PR DESCRIPTION
It seems trailing zeros are rare - as this is the first time I heard this issue. O_o