### PR TITLE
New patch release v10.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+## [v10.1.2] 2025-11-10
+
 - [fix] ListingPage.duck.js: fix a bug with time slots fetching. This affects bookable listings with
   hour or fixed durations. [#697](https://github.com/sharetribe/web-template/pull/697)
 - [add] Add currently available translations for DE, ES, FR.
   [#695](https://github.com/sharetribe/web-template/pull/695)
+
+  [v10.1.2]: https://github.com/sharetribe/web-template/compare/v10.1.1...v10.1.2
 
 ## [v10.1.1] 2025-11-06
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "10.1.1",
+  "version": "10.1.2",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This fixes an issue where price variants on bookable listings (with hour or fixed unit type) didn't update availability calendar correctly when changing from 1 variant to another.

## [Changes] v10.1.2

- [fix] ListingPage.duck.js: fix a bug with time slots fetching. This affects bookable listings with
  hour or fixed durations. [#697](https://github.com/sharetribe/web-template/pull/697)
- [add] Add currently available translations for DE, ES, FR.
  [#695](https://github.com/sharetribe/web-template/pull/695)

  [Changes]: https://github.com/sharetribe/web-template/compare/v10.1.1...v10.1.2