### PR TITLE
New release: v10.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2025-XX-XX
 
+## [v10.4.0] 2025-12-02
+
 - [add] Add Proxy around SDK instance on server that caches the responses for the page-asset
   requests. [#713](https://github.com/sharetribe/web-template/pull/713)
 - [fix] Styleguide examples for booking forms were missing a mandatory prop.
@@ -30,6 +32,8 @@ way to update this template, but currently, we follow a pattern:
   [#711](https://github.com/sharetribe/web-template/pull/711)
 - [add] Add currently available translations for DE, ES, FR.
   [#710](https://github.com/sharetribe/web-template/pull/710)
+
+  [v10.4.0]: https://github.com/sharetribe/web-template/compare/v10.3.0...v10.4.0
 
 ## [v10.3.0] 2025-11-20
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This release adds a cache implementation around SDK instance that will cache Page assets (e.g. content/landing-page.json) on server. 

**Note**: by default it's reserving ~10Mb memory for those assets.

Read more from the PR:
https://github.com/sharetribe/web-template/pull/713

In addition, there are several smaller fixes and improvements.
- SDK is updated to newer version
- Accessibility: 
  - modals leverage "inert" prop to create focus trap and 
  - on closing pass the focus back to the related toggle button.
- AuthenticationPage: "Sign up" & "Log in" tabs were overflowing if the words were too long.

## [Changes] v10.4.0

- [add] Add Proxy around SDK instance on server that caches the responses for the page-asset
  requests. [#713](https://github.com/sharetribe/web-template/pull/713)
- [fix] Styleguide examples for booking forms were missing a mandatory prop.
  [#719](https://github.com/sharetribe/web-template/pull/719)
- [fix] PREVENT_DATA_LOADING_IN_SSR environment variable has not been working.
  [#717](https://github.com/sharetribe/web-template/pull/717)
- [add] Add accessibility improvements (Modals, filters, etc.).
  [#716](https://github.com/sharetribe/web-template/pull/716)
- [change] Upgrade Sharetribe SDK to 1.22.0.
  [#715](https://github.com/sharetribe/web-template/pull/715)
- [fix] ListingPageCoverPhoto: fix payoutDetailsWarning message.
  [#714](https://github.com/sharetribe/web-template/pull/714)
- [fix] AuthenticationPage: fix a bug with long words in the title on mobile layout.
  [#711](https://github.com/sharetribe/web-template/pull/711)
- [add] Add currently available translations for DE, ES, FR.
  [#710](https://github.com/sharetribe/web-template/pull/710)

  [Changes]: https://github.com/sharetribe/web-template/compare/v10.3.0...v10.4.0
