### PR TITLE
Add cache-control (1 year) for some generated js and css files

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -156,7 +156,23 @@ if (TRUST_PROXY === 'true') {
 }
 
 app.use(compression());
-app.use('/static', express.static(path.join(buildPath, 'static')));
+app.use(
+  '/static',
+  express.static(path.join(buildPath, 'static'), {
+    setHeaders: (res, path) => {
+      const isMain = path.match(
+        /^\/.*static\/(js|css)\/main\.[a-z0-9]+\.(css|js|css\.map|js\.map)$/g
+      );
+      const isChunk = path.match(
+        /^\/.*static\/(js|css)\/.*\.[a-z0-9]+\.chunk\.(css|js|css\.map|js\.map)$/g
+      );
+      if (isMain || isChunk) {
+        // cache for one year
+        res.setHeader('Cache-Control', 'public, max-age=31557600');
+      }
+    },
+  })
+);
 app.use(cookieParser());
 
 // We don't serve favicon.ico from root. PNG images are used instead for icons through link elements.


### PR DESCRIPTION
This applies to
- `main.<hash>.js` & `main.<hash>.css` 
- Other code-splitted files: `*.<hash>.chunk.(js/css)`
  - https://regexper.com/#%2F%5E%5C%2F.*static%5C%2F%28js%7Ccss%29%5C%2F.*%5C.%5Ba-z0-9%5D%2B%5C.chunk%5C.%28css%7Cjs%7Ccss%5C.map%7Cjs%5C.map%29%24%2Fg

(and also related source map files are cached too.)

The idea here is that when the code is changed, build process generates new names (hash strings) for those files. Therefore it's OK to cache them permanently (aka 1 year).