### PR TITLE
Menu: fix mobile Safari issue with focused element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] Menu: fix a bug with focus handling on iOS Safari.
+  [#747](https://github.com/sharetribe/web-template/pull/747)
 - [add] EditListingDetailsPanel: add support for preselected listing type through URLSearchParam:
   listingType. [#748](https://github.com/sharetribe/web-template/pull/748)
 - [fix] Fix incorrect translation keys in default-negotiation transaction process

--- a/src/components/Menu/Menu.js
+++ b/src/components/Menu/Menu.js
@@ -153,7 +153,7 @@ class Menu extends Component {
       if (e.target === this.menu?.firstChild) {
         e.preventDefault();
         e.stopPropagation();
-        this.toggleOpen({ enforcedState: true });
+        this.toggleOpen({ enforcedState: true, moveFocusFn: moveFocusToFirstFocusableElement });
       } else if (this.menuContent?.contains(e.target)) {
         e.preventDefault();
         e.stopPropagation();
@@ -173,7 +173,7 @@ class Menu extends Component {
       if (e.target === this.menu?.firstChild) {
         e.preventDefault();
         e.stopPropagation();
-        this.toggleOpen({ enforcedState: true });
+        this.toggleOpen({ enforcedState: true, moveFocusFn: moveFocusToFirstFocusableElement });
       } else if (this.menuContent?.contains(e.target)) {
         e.preventDefault();
         e.stopPropagation();
@@ -193,10 +193,9 @@ class Menu extends Component {
   }
 
   toggleOpen(options = {}) {
-    const { enforcedState, moveFocusFn } = options || {};
-    const moveFocusTo = moveFocusFn || moveFocusToFirstFocusableElement;
+    const { enforcedState, moveFocusFn: moveFocusTo } = options || {};
     const delayedMoveFocus = isMenuOpen => {
-      if (isMenuOpen) {
+      if (isMenuOpen && moveFocusTo) {
         setTimeout(() => {
           moveFocusTo(this.menuContent);
         }, 100);


### PR DESCRIPTION
Issue: menu options were not clickable on iOS Safari!

When focused element was set separately from button element with click event, iOS Safari was not able to handle the on click event.

Accessibility improvement PR (723) added feature to move focus always to the first item on the menu. This backs down a bit: only keyboard events that open the menu move the focus. Click on the menu toggle does not.