### PR TITLE
Patch release v10.8.1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+## [v10.8.1] 2026-01-21
+
+- [fix] EditListingDetailsPanel: fix a bug with preselected listing type not being set correctly.
+  [#750](https://github.com/sharetribe/web-template/pull/750)
+
+  [v10.8.1]: https://github.com/sharetribe/web-template/compare/v10.8.0...v10.8.1
+
 ## [v10.8.0] 2026-01-20
 
 - [fix] Menu: fix a bug with focus handling on iOS Safari.
@@ -28,6 +35,8 @@ way to update this template, but currently, we follow a pattern:
   [#745](https://github.com/sharetribe/web-template/pull/745)
 - [change] Update React Redux from v8.1.2 to v9.2.0 and Redux Toolkit from v2.9.0 to v2.11.2.
   [#742](https://github.com/sharetribe/web-template/pull/742)
+
+  [v10.8.0]: https://github.com/sharetribe/web-template/compare/v10.7.0...v10.8.0
 
 ## [v10.7.0] 2026-01-15
 

--- a/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsPanel.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingDetailsPanel/EditListingDetailsPanel.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import classNames from 'classnames';
 
 // Import util modules
@@ -331,6 +331,15 @@ const EditListingDetailsPanel = props => {
     pathParams?.type === LISTING_PAGE_PARAM_TYPE_NEW && !!locationSearch?.listingType
       ? listingTypes.find(conf => conf.listingType === locationSearch.listingType)
       : null;
+
+  // Call onListingTypeChange with validPreselectedListingType id-string on initialization.
+  // The call selects the correct wizard tabs for the preselected listing type.
+  // Note: it's only called if listing type is not already saved to publicData.
+  useEffect(() => {
+    if (!hasExistingListingType && validPreselectedListingType && onListingTypeChange) {
+      onListingTypeChange(validPreselectedListingType);
+    }
+  }, []);
 
   const initialValues = getInitialValues(
     props,


### PR DESCRIPTION
Fix EditListingWizard tab selection when preselected listing type is given.
The code needed to update wizard's tab selection was missing from version 10.8.0