### PR TITLE
SearchMapWithMapbox: fix clicking listing cards on top of the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] SearchMapWithMapbox: fix a bug with info card marker container not being removed correctly.
+  [#763](https://github.com/sharetribe/web-template/pull/763)
+
 ## [v10.10.0] 2026-02-03
 
 - [change] Improve map library loading strategy.

--- a/src/containers/SearchPage/SearchMap/SearchMapWithMapbox.js
+++ b/src/containers/SearchPage/SearchMap/SearchMapWithMapbox.js
@@ -303,7 +303,7 @@ class SearchMapWithMapbox extends Component {
   }
 
   componentWillUnmount() {
-    this.currentInfoCard.markerContainer.removeEventListener(
+    this.currentInfoCard?.markerContainer?.removeEventListener(
       'dblclick',
       this.handleDoubleClickOnInfoCard
     );
@@ -409,7 +409,7 @@ class SearchMapWithMapbox extends Component {
 
       // If map has moved or info card opened, unnecessary markers need to be removed
       const removableMarkers = this.currentMarkers.filter(
-        marker => !labels.some(label => label.markerId === marker.markerId)
+        marker => !labels.some(label => label?.markerId === marker?.markerId)
       );
       removableMarkers.forEach(rm => rm.marker.remove());
 


### PR DESCRIPTION
aka add null protection to SearchMapWithMapbox labels filter
(previous lodash/differenceBy handled nulls on labels array.)