### PR TITLE
Routes.js: fix a bug with hash selector.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] Routes.js: fix a bug with hash selector. (CSS.escape was not used correctly.)
+  [#774](https://github.com/sharetribe/web-template/pull/774)
 - [fix] SearchPage.shared.js: fix a bug with keywords search type. (SortBy doesn't pick relevance
   option when keywords search is active.)
   [#772](https://github.com/sharetribe/web-template/pull/772)

--- a/src/routing/Routes.js
+++ b/src/routing/Routes.js
@@ -56,7 +56,9 @@ const setPageScrollPosition = (location, delayed) => {
       left: 0,
     });
   } else {
-    const el = document.querySelector(CSS.escape(location.hash));
+    const idString = location.hash.substring(1); // Remove the # from the hash
+    const escapedHashId = `#${CSS.escape(idString)}`; // Escape the id string to avoid invalid CSS id
+    const el = document.querySelector(escapedHashId);
     if (el) {
       // Found element from the current page with the given fragment identifier,
       // scrolling to that element.
@@ -76,7 +78,7 @@ const setPageScrollPosition = (location, delayed) => {
       // Note: 300 milliseconds might not be enough, but adding too much delay
       // might affect user initiated scrolling.
       delayed = window.setTimeout(() => {
-        const reTry = document.querySelector(CSS.escape(location.hash));
+        const reTry = document.querySelector(escapedHashId);
         reTry?.scrollIntoView({
           block: 'start',
           behavior: 'smooth',


### PR DESCRIPTION
CSS.escape was not used correctly. (It escaped the "#" too)
I.e. the previous PR caused another issue.
https://github.com/sharetribe/web-template/pull/773 