### PR TITLE
New release v10.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+## [v10.13.0] 2026-02-26
+
 - [change] Hides listing description input/display when option is toggled off in Console > Listing
   types > Default listing fields
   [#767](https://github.com/sharetribe/web-template/pull/767)
@@ -23,6 +25,8 @@ way to update this template, but currently, we follow a pattern:
   [#786](https://github.com/sharetribe/web-template/pull/786)
 - [add] Add currently available translations for DE, ES, FR.
   [#790](https://github.com/sharetribe/web-template/pull/790)
+
+  [v10.13.0]: https://github.com/sharetribe/web-template/compare/v10.12.1...v10.13.0
 
 ## [v10.12.1] 2026-02-24
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "10.12.1",
+  "version": "10.13.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This release prepares the template for an upcoming feature: disabling listing descriptions as a default listing field in the listing type configuration. It also refactors [ListingCard](https://github.com/sharetribe/web-template/blob/main/src/components/ListingCard/ListingCard.js) for better readability and includes accessibility improvements.

## Translations changes

### New translation keys:
 ```json
    "ListingCard.screenreader.label": "{listingTitle}, {formattedPrice}",
  ```

## [Changes] 2023-02-26
- [change] Hides listing description input/display when option is toggled off in Console > Listing
  types > Default listing fields [#767](https://github.com/sharetribe/web-template/pull/767)
- [change] ListingCard: refactor and add aria-label attribute to the component.
  [#787](https://github.com/sharetribe/web-template/pull/787)
- [fix] FieldSelectIntegerRange: fix aria-attributes.
  [#786](https://github.com/sharetribe/web-template/pull/786)
- [add] Add currently available translations for DE, ES, FR.
  [#790](https://github.com/sharetribe/web-template/pull/790)

  [Changes]: https://github.com/sharetribe/web-template/compare/v10.12.1...v10.13.0