### PR TITLE
Missing nested dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "unified": "^9.2.2"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "7.18.6",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,7 +928,7 @@
     "@babel/helper-create-class-features-plugin" "^7.18.6"
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-proposal-private-property-in-object@^7.18.6":
+"@babel/plugin-proposal-private-property-in-object@7.18.6", "@babel/plugin-proposal-private-property-in-object@^7.18.6":
   version "7.18.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.18.6.tgz#a64137b232f0aca3733a67eb1a144c192389c503"
   integrity sha512-9Rysx7FOctvT5ouj5JODjAFAkgGoudQuLPamZb0v1TGLpapdNaftzifU8NTWQm0IRjqoYypdrSmyWgkocDQ8Dw==


### PR DESCRIPTION
The create-react-app (CRA) fork (aka sharetribe-scripts dependency) is missing one deeply nested dependency

**create-react-app** > **babel-preset-react-app** >
**@babel/plugin-proposal-private-property-in-object**

https://github.com/facebook/create-react-app/issues?q=is%3Aissue%20state%3Aopen%20plugin-proposal-private-property-in-object

This adds the plugin as devDependency to mitigate the issue. 

Note: This issue is fixed on the "Eject" PR - so, the permanent solution is to take that into use. (But we are not yet ready to merge that.)

<img width="1113" height="293" alt="Screenshot 2026-03-24 at 18 06 25" src="https://github.com/user-attachments/assets/78c10bf6-68d3-4bb2-9845-d1b8da7f3448" />