### PR TITLE
Fix return value in CheckoutPage pay-and-save-card flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] Fix return value in CheckoutPage pay-and-save-card flow
+  [#816](https://github.com/sharetribe/web-template/pull/816)
+
 ## [v10.15.0] 2026-03-25
 
 - [fix] Fix too-big font-size in mobile h4 heading and some too large margins.

--- a/src/containers/CheckoutPage/CheckoutPageTransactionHelpers.js
+++ b/src/containers/CheckoutPage/CheckoutPageTransactionHelpers.js
@@ -312,13 +312,13 @@ export const processCheckoutWithPayment = (orderParams, extraPaymentParams) => {
       return onSavePaymentMethod(ensuredStripeCustomer, pi.payment_method)
         .then(response => {
           if (response.errors) {
-            return { ...fnParams, paymentMethodSaved: false };
+            return { orderId, paymentMethodSaved: false };
           }
-          return { ...fnParams, paymentMethodSaved: true };
+          return { orderId, paymentMethodSaved: true };
         })
         .catch(e => {
           // Real error cases are catched already in paymentMethods page.
-          return { ...fnParams, paymentMethodSaved: false };
+          return { orderId, paymentMethodSaved: false };
         });
     } else {
       return Promise.resolve({ orderId, paymentMethodSaved: true });


### PR DESCRIPTION
The Checkout page flow for saving a payment method after purchase was throwing an error instead of redirecting. Fix the value in the return statement to correctly return the order id.