### PR TITLE
Update Stripe Connect account requirements for Netherlands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
-- [fix] DatePicker: fix the background color of selected dates to match the primary button color.
+- [change] Update Stripe Connect account requirements for Netherlands.
+  [#824](https://github.com/sharetribe/web-template/pull/824)
+- [fix] email verification badge: it was using the old success color.
   [#825](https://github.com/sharetribe/web-template/pull/825)
 - [add] Add support for a new user, listing, and transaction field schema type: shortText
   [#812](https://github.com/sharetribe/web-template/pull/812)

--- a/src/containers/EditListingPage/EditListingWizard/EditListingWizard.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingWizard.js
@@ -34,6 +34,7 @@ import {
   pickCategoryFields,
 } from '../../../util/fieldHelpers';
 import { ensureCurrentUser, ensureListing } from '../../../util/data';
+import { getDisplayAccountType } from '../../../util/stripeConnect';
 import { INQUIRY_PROCESS_NAME, resolveLatestProcessName } from '../../../transactions/transaction';
 
 // Import shared components
@@ -620,8 +621,7 @@ class EditListingWizard extends Component {
         hasRequirements(stripeAccountData, 'currently_due'));
 
     const savedCountry = stripeAccountData ? stripeAccountData.country : null;
-    const savedAccountType = stripeAccountData ? stripeAccountData.business_type : null;
-
+    const savedAccountType = stripeAccountData ? getDisplayAccountType(stripeAccountData) : null;
     const { marketplaceName } = config;
     const payoutModalInfo = stripeAccountData ? (
       <FormattedMessage id="EditListingWizard.payoutModalInfo" values={{ marketplaceName }} />

--- a/src/containers/StripePayoutPage/StripePayoutPage.js
+++ b/src/containers/StripePayoutPage/StripePayoutPage.js
@@ -9,6 +9,7 @@ import { FormattedMessage, useIntl } from '../../util/reactIntl';
 import { ensureCurrentUser } from '../../util/data';
 import { propTypes } from '../../util/types';
 import { showCreateListingLinkForUser, showPaymentDetailsForUser } from '../../util/userHelpers';
+import { getDisplayAccountType } from '../../util/stripeConnect';
 import { isScrollingDisabled } from '../../ducks/ui.duck';
 import {
   stripeAccountClearError,
@@ -143,7 +144,7 @@ export const StripePayoutPageComponent = props => {
       hasRequirements(stripeAccountData, 'currently_due'));
 
   const savedCountry = stripeAccountData ? stripeAccountData.country : null;
-  const savedAccountType = stripeAccountData ? stripeAccountData.business_type : null;
+  const savedAccountType = stripeAccountData ? getDisplayAccountType(stripeAccountData) : null;
 
   const handleGetStripeConnectAccountLink = handleGetStripeConnectAccountLinkFn(
     onGetStripeConnectAccountLink,

--- a/src/ducks/stripeConnectAccount.duck.js
+++ b/src/ducks/stripeConnectAccount.duck.js
@@ -3,6 +3,7 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import * as log from '../util/log';
 import { storableError } from '../util/errors';
+import { getStripeAccountTokenInfo } from '../util/stripeConnect';
 
 // ================ Async thunks ================ //
 
@@ -30,7 +31,7 @@ const createStripeAccountPayloadCreator = (params, { extra: sdk, rejectWithValue
   const requestedCapabilities = ['card_payments', 'transfers'];
 
   const accountInfo = {
-    business_type: accountType,
+    ...getStripeAccountTokenInfo({ country, accountType }),
     tos_shown_and_accepted: true,
   };
 

--- a/src/util/stripeConnect.js
+++ b/src/util/stripeConnect.js
@@ -1,0 +1,63 @@
+const countriesRequiringSoleProprietorshipForIndividuals = new Set([
+  'AT',
+  'BE',
+  'BG',
+  'CH',
+  'CY',
+  'CZ',
+  'DE',
+  'DK',
+  'EE',
+  'ES',
+  'FI',
+  'FR',
+  'GB',
+  'GI',
+  'GR',
+  'HR',
+  'HU',
+  'IE',
+  'IS',
+  'IT',
+  'LI',
+  'LT',
+  'LU',
+  'LV',
+  'MT',
+  'NL',
+  'NO',
+  'PL',
+  'PT',
+  'RO',
+  'SE',
+  'SI',
+  'SK',
+]);
+
+export const requiresSoleProprietorshipAccount = country =>
+  countriesRequiringSoleProprietorshipForIndividuals.has(country);
+
+export const getStripeAccountTokenInfo = ({ country, accountType }) => {
+  const isIndividualInRestrictedCountry =
+    accountType === 'individual' && requiresSoleProprietorshipAccount(country);
+
+  return isIndividualInRestrictedCountry
+    ? {
+        business_type: 'company',
+        company: {
+          structure: 'sole_proprietorship',
+        },
+      }
+    : {
+        business_type: accountType,
+      };
+};
+
+export const getDisplayAccountType = stripeAccountData => {
+  const businessType = stripeAccountData?.business_type;
+  const companyStructure = stripeAccountData?.company?.structure;
+
+  return businessType === 'company' && companyStructure === 'sole_proprietorship'
+    ? 'individual'
+    : businessType;
+};

--- a/src/util/stripeConnect.js
+++ b/src/util/stripeConnect.js
@@ -1,42 +1,31 @@
-const countriesRequiringSoleProprietorshipForIndividuals = new Set([
-  'AT',
-  'BE',
-  'BG',
-  'CH',
-  'CY',
-  'CZ',
-  'DE',
-  'DK',
-  'EE',
-  'ES',
-  'FI',
-  'FR',
-  'GB',
-  'GI',
-  'GR',
-  'HR',
-  'HU',
-  'IE',
-  'IS',
-  'IT',
-  'LI',
-  'LT',
-  'LU',
-  'LV',
-  'MT',
-  'NL',
-  'NO',
-  'PL',
-  'PT',
-  'RO',
-  'SE',
-  'SI',
-  'SK',
-]);
+// Netherlands requires a sole proprietorship for individuals.
+// According to Stripe: "we’re enforcing stricter business type requirements for Netherlands (NL)
+// accounts to ensure compliance with Dutch regulations. This specifically affects
+// how we collect the KvK (Kamer van Koophandel), the unique 8-digit company registration number
+// required for businesses in the Netherlands."
+// https://docs.stripe.com/connect/upcoming-requirements-updates?program=eu-2025#netherlands-business-registration-requirements
+const countriesRequiringSoleProprietorshipForIndividuals = new Set(['NL']);
 
+/**
+ * Whether Connect onboarding for an individual in this country must use a company account with
+ * sole proprietorship structure (Stripe compliance; currently applies to NL).
+ *
+ * @param {string} country - ISO 3166-1 alpha-2 country code
+ * @returns {boolean}
+ */
 export const requiresSoleProprietorshipAccount = country =>
   countriesRequiringSoleProprietorshipForIndividuals.has(country);
 
+/**
+ * Builds `business_type` and optional `company.structure` for Stripe account creation or token
+ * flows when the seller's country and account type trigger sole-proprietorship rules.
+ *
+ * @param {Object} params
+ * @param {string} params.country - ISO 3166-1 alpha-2 country code
+ * @param {string} params.accountType - Stripe business type, e.g. `individual` or `company`
+ * @returns {Object} Either `{ business_type: 'company', company: { structure: 'sole_proprietorship' } }`
+ *   for individuals in restricted countries, or `{ business_type: accountType }` otherwise
+ */
 export const getStripeAccountTokenInfo = ({ country, accountType }) => {
   const isIndividualInRestrictedCountry =
     accountType === 'individual' && requiresSoleProprietorshipAccount(country);
@@ -53,6 +42,14 @@ export const getStripeAccountTokenInfo = ({ country, accountType }) => {
       };
 };
 
+/**
+ * Normalizes Stripe account data for display: company accounts with sole proprietorship structure
+ * are shown as `individual` to match how the seller signed up.
+ *
+ * @param {Object} [stripeAccountData] - Account object with optional `business_type` and `company.structure`
+ * @returns {string|undefined} Display type (`individual` for mapped sole props, otherwise `business_type`, or
+ *   `undefined` when missing)
+ */
 export const getDisplayAccountType = stripeAccountData => {
   const businessType = stripeAccountData?.business_type;
   const companyStructure = stripeAccountData?.company?.structure;

--- a/src/util/stripeConnect.test.js
+++ b/src/util/stripeConnect.test.js
@@ -6,12 +6,13 @@ import {
 
 describe('stripeConnect helpers', () => {
   it('flags restricted countries that require sole proprietorship onboarding', () => {
-    expect(requiresSoleProprietorshipAccount('GB')).toBe(true);
+    expect(requiresSoleProprietorshipAccount('NL')).toBe(true);
+    expect(requiresSoleProprietorshipAccount('GB')).toBe(false);
     expect(requiresSoleProprietorshipAccount('US')).toBe(false);
   });
 
   it('maps individual sellers in restricted countries to company sole proprietorship', () => {
-    expect(getStripeAccountTokenInfo({ country: 'DE', accountType: 'individual' })).toEqual({
+    expect(getStripeAccountTokenInfo({ country: 'NL', accountType: 'individual' })).toEqual({
       business_type: 'company',
       company: {
         structure: 'sole_proprietorship',
@@ -20,7 +21,7 @@ describe('stripeConnect helpers', () => {
   });
 
   it('keeps company sellers unchanged in restricted countries', () => {
-    expect(getStripeAccountTokenInfo({ country: 'DE', accountType: 'company' })).toEqual({
+    expect(getStripeAccountTokenInfo({ country: 'NL', accountType: 'company' })).toEqual({
       business_type: 'company',
     });
   });

--- a/src/util/stripeConnect.test.js
+++ b/src/util/stripeConnect.test.js
@@ -1,0 +1,55 @@
+import {
+  getDisplayAccountType,
+  getStripeAccountTokenInfo,
+  requiresSoleProprietorshipAccount,
+} from './stripeConnect';
+
+describe('stripeConnect helpers', () => {
+  it('flags restricted countries that require sole proprietorship onboarding', () => {
+    expect(requiresSoleProprietorshipAccount('GB')).toBe(true);
+    expect(requiresSoleProprietorshipAccount('US')).toBe(false);
+  });
+
+  it('maps individual sellers in restricted countries to company sole proprietorship', () => {
+    expect(getStripeAccountTokenInfo({ country: 'DE', accountType: 'individual' })).toEqual({
+      business_type: 'company',
+      company: {
+        structure: 'sole_proprietorship',
+      },
+    });
+  });
+
+  it('keeps company sellers unchanged in restricted countries', () => {
+    expect(getStripeAccountTokenInfo({ country: 'DE', accountType: 'company' })).toEqual({
+      business_type: 'company',
+    });
+  });
+
+  it('keeps individual sellers unchanged in unrestricted countries', () => {
+    expect(getStripeAccountTokenInfo({ country: 'US', accountType: 'individual' })).toEqual({
+      business_type: 'individual',
+    });
+  });
+
+  it('shows sole proprietorship accounts as individual in the UI', () => {
+    expect(
+      getDisplayAccountType({
+        business_type: 'company',
+        company: {
+          structure: 'sole_proprietorship',
+        },
+      })
+    ).toBe('individual');
+  });
+
+  it('shows other Stripe business types as-is in the UI', () => {
+    expect(
+      getDisplayAccountType({
+        business_type: 'company',
+        company: {
+          structure: 'private_corporation',
+        },
+      })
+    ).toBe('company');
+  });
+});


### PR DESCRIPTION
Netherlands requires a sole proprietorship for individuals.
According to Stripe: 

> "we’re enforcing stricter business type requirements for Netherlands (NL)
>  accounts to ensure compliance with Dutch regulations. This specifically affects
>  how we collect the KvK (Kamer van Koophandel), the unique 8-digit company registration number
>  required for businesses in the Netherlands."

https://docs.stripe.com/connect/upcoming-requirements-updates?program=eu-2025#netherlands-business-registration-requirements

Related to [PR 822](https://github.com/sharetribe/web-template/pull/822)

Note: we might remove the setting of business_type altogether from Template at some point. In that scenario, it would be set on Stripe's hosted onboarding.
