### PR TITLE
Fix some color mismatches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] DatePicker: fix the background color of selected dates to match the primary button color.
+  [#825](https://github.com/sharetribe/web-template/pull/825)
 - [add] Add support for a new user, listing, and transaction field schema type: shortText
   [#812](https://github.com/sharetribe/web-template/pull/812)
 - [add] Add currently available translations for DE, ES, FR.

--- a/src/containers/ContactDetailsPage/ContactDetailsForm/ContactDetailsForm.module.css
+++ b/src/containers/ContactDetailsPage/ContactDetailsForm/ContactDetailsForm.module.css
@@ -55,7 +55,8 @@
 .emailVerified {
   composes: infoText;
   color: var(--colorSuccess);
-  background-image: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M6.52 9.098c-.163.188-.397.3-.646.31h-.032c-.238 0-.466-.094-.635-.263L2.783 6.732c-.353-.35-.354-.92-.003-1.273.35-.353.92-.354 1.272-.004L5.794 7.19l4.59-5.278C9.287.738 7.73 0 6 0 2.686 0 0 2.686 0 6c0 3.313 2.686 6 6 6 3.313 0 6-2.687 6-6 0-.91-.21-1.772-.573-2.545L6.52 9.098z" fill="%232ECC71" fill-rule="evenodd"/></svg>');
+  background-image: url('data:image/svg+xml;utf8,<svg width="12" height="12" viewBox="0 0 12 12" xmlns="http://www.w3.org/2000/svg"><path d="M6.52 9.098c-.163.188-.397.3-.646.31h-.032c-.238 0-.466-.094-.635-.263L2.783 6.732c-.353-.35-.354-.92-.003-1.273.35-.353.92-.354 1.272-.004L5.794 7.19l4.59-5.278C9.287.738 7.73 0 6 0 2.686 0 0 2.686 0 6c0 3.313 2.686 6 6 6 3.313 0 6-2.687 6-6 0-.91-.21-1.772-.573-2.545L6.52 9.098z" fill="%23138041" fill-rule="evenodd"/></svg>');
+  background-position-y: 2px;
 }
 
 .emailUnverified {


### PR DESCRIPTION
ContactDetailsPage: the emailVerified badge (svg icon inside css file) used the old success color.
(The color was made darker as part of accessibility improvements projects.)