### PR TITLE
SearchPage variants: getListingsById creates a new array on every call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] SearchPage variants: getListingsById creates a new array on every call. This adds a memoized
+  selector factory and uses it instead. [#829](https://github.com/sharetribe/web-template/pull/829)
+
 ## [v11.0.0] 2026-04-14
 
 This major release is centered on the template ejection from sharetribe-scripts (our fork of Create

--- a/src/containers/SearchPage/SearchPageWithGrid.js
+++ b/src/containers/SearchPage/SearchPageWithGrid.js
@@ -1,10 +1,10 @@
-import React, { Component, useCallback } from 'react';
+import React, { Component, useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import classNames from 'classnames';
 
 import { FormattedMessage } from '../../util/reactIntl';
 import { parse } from '../../util/urlHelpers';
-import { getListingsById } from '../../ducks/marketplaceData.duck';
+import { makeGetListingsByIdSelector } from '../../ducks/marketplaceData.duck';
 import { manageDisableScrolling, isScrollingDisabled } from '../../ducks/ui.duck';
 
 import { Page } from '../../components';
@@ -340,13 +340,14 @@ export class SearchPageComponent extends Component {
  */
 const SearchPage = props => {
   const dispatch = useDispatch();
+  const selectListingsById = useMemo(makeGetListingsByIdSelector, []);
 
   const currentUser = useSelector(state => state.user?.currentUser);
   const { pagination, searchInProgress, searchListingsError, searchParams } = useSelector(
     state => state.SearchPage
   );
   const listings = useSelector(state =>
-    getListingsById(state, state.SearchPage.currentPageResultIds)
+    selectListingsById(state, state.SearchPage.currentPageResultIds)
   );
   const scrollingDisabled = useSelector(state => isScrollingDisabled(state));
 

--- a/src/containers/SearchPage/SearchPageWithMap.js
+++ b/src/containers/SearchPage/SearchPageWithMap.js
@@ -1,4 +1,4 @@
-import React, { Component, useCallback } from 'react';
+import React, { Component, useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import debounce from 'lodash/debounce';
 import classNames from 'classnames';
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import { isOriginInUse } from '../../util/search';
 import { parse } from '../../util/urlHelpers';
 import { createResourceLocatorString, pathByRouteName } from '../../util/routes';
-import { getListingsById } from '../../ducks/marketplaceData.duck';
+import { makeGetListingsByIdSelector } from '../../ducks/marketplaceData.duck';
 import { manageDisableScrolling, isScrollingDisabled } from '../../ducks/ui.duck';
 
 import { ModalInMobile, Page } from '../../components';
@@ -500,6 +500,7 @@ export class SearchPageComponent extends Component {
  */
 const SearchPage = props => {
   const dispatch = useDispatch();
+  const selectListingsById = useMemo(makeGetListingsByIdSelector, []);
 
   const currentUser = useSelector(state => state.user?.currentUser);
   const {
@@ -510,7 +511,7 @@ const SearchPage = props => {
     activeListingId,
   } = useSelector(state => state.SearchPage);
   const listings = useSelector(state =>
-    getListingsById(state, state.SearchPage.currentPageResultIds)
+    selectListingsById(state, state.SearchPage.currentPageResultIds)
   );
   const scrollingDisabled = useSelector(state => isScrollingDisabled(state));
 

--- a/src/ducks/marketplaceData.duck.js
+++ b/src/ducks/marketplaceData.duck.js
@@ -1,4 +1,4 @@
-import { createSlice } from '@reduxjs/toolkit';
+import { createSelector, createSlice } from '@reduxjs/toolkit';
 import { updatedEntities, denormalisedEntities } from '../util/data';
 
 // ================ Redux Toolkit Slice ================ //
@@ -40,6 +40,27 @@ export const getListingsById = (state, listingIds) => {
   const throwIfNotFound = false;
   return denormalisedEntities(entities, resources, throwIfNotFound);
 };
+
+/**
+ * Create a memoized selector that returns denormalized listings for `listingIds`.
+ *
+ * Use this with `useMemo(makeGetListingsByIdSelector, [])` inside components
+ * so each component instance has a stable selector cache.
+ *
+ * @returns {(state: Object, listingIds: Array<UUID>) => Array<Object>}
+ */
+export const makeGetListingsByIdSelector = () =>
+  createSelector(
+    [state => state.marketplaceData?.entities, (_state, listingIds = []) => listingIds],
+    (entities = {}, listingIds = []) => {
+      const resources = listingIds.map(id => ({
+        id,
+        type: 'listing',
+      }));
+      const throwIfNotFound = false;
+      return denormalisedEntities(entities, resources, throwIfNotFound);
+    }
+  );
 
 /**
  * Get the denormalised entities from the given entity references.


### PR DESCRIPTION
This adds a memoized selector factory and uses it instead.

Without this, you might notice React/Redux warning:
"Selector unknown returned a different result when called with the same parameters. This can lead to unnecessary rerenders."