### PR TITLE
configHelpers: Reworked mergeSortConfig to better account for missing hosted sort options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] Fixes a bug where listing metadata fields were not shown in the sort dropdown if the default sorting config is missing
+  [#835](https://github.com/sharetribe/web-template/pull/835)
 - [fix] Fix an error in a negotiation email template
   [#837](https://github.com/sharetribe/web-template/pull/837)
 - [change] Update README.md to mention the NODE_ENV environment variable.

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -1536,14 +1536,6 @@ const validSortConfig = config => {
 };
 
 const mergeSortConfig = (hostedSortConfig, defaultSortConfig, omitRelevance, listingFields) => {
-  if (hostedSortConfig == null) {
-    return {
-      ...defaultSortConfig,
-      // Disable SortBy component if there are less than 2 options
-      active: defaultSortConfig.options.length > 1,
-    };
-  }
-
   // Flag filters to remove if the default sorting option is toggled off in Console
   const removeByKey = {
     createdAt: !hostedSortConfig?.newest,
@@ -1558,7 +1550,12 @@ const mergeSortConfig = (hostedSortConfig, defaultSortConfig, omitRelevance, lis
   // and returns primaryOptions and secondaryOptions. primaryOptions are prepended to the
   // sort options and secondaryOptions are appended.
   const { primaryOptions, secondaryOptions } = getSortOptionsFromListingFields(listingFields);
-  const filteredDefaults = defaultSortConfig.options.filter(option => !removeByKey[option.key]);
+  // hostedSortConfig can be undefined if listing search settings have not been updated in Console,
+  // in which case there's no need to filter out any options
+  const filteredDefaults =
+    hostedSortConfig == null
+      ? defaultSortConfig.options
+      : defaultSortConfig.options.filter(option => !removeByKey[option.key]);
   const options = [...primaryOptions, ...filteredDefaults, ...secondaryOptions];
 
   return {


### PR DESCRIPTION
Fixes a bug where listing metadata fields were not shown in the sort dropdown if the default sorting config is missing