### PR TITLE
Fix an error in one negotiation email template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] Fix an error in a negotiation email template
+  [#837](https://github.com/sharetribe/web-template/pull/837)
 - [change] Update README.md to mention the NODE_ENV environment variable.
   [#836](https://github.com/sharetribe/web-template/pull/836)
 - [add] Add currently available translations for DE, ES, FR.

--- a/ext/transaction-processes/default-negotiation/templates/negotiation-new-offer-from-request/negotiation-new-offer-from-request-html.html
+++ b/ext/transaction-processes/default-negotiation/templates/negotiation-new-offer-from-request/negotiation-new-offer-from-request-html.html
@@ -40,7 +40,7 @@
                             <tr>
                               <td>
                                 <td>
-                                  <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848;margin-bottom:1px">{{t "NegotiationNewOfferFromRequest.UnitPriceLabel" "Offer"}}</p>
+                                  <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848;margin-bottom:1px">{{t "NegotiationNewOfferFromRequest.LineTotalForOfferLabel" "Offer"}}</p>
                                 </td>
                                 <td style="text-align:right">
                                   <p style="font-size:16px;line-height:1.4;margin:16px 0;color:#484848;margin-bottom:1px">{{> format-money money=line-total}}</p>


### PR DESCRIPTION
`ext/transaction-processes/default-negotiation/templates/negotiation-new-offer-from-request/ `

  **negotiation-new-offer-from-request-html.html**:
- "line-item/offer" row contained a wrong translation key: _NegotiationNewOfferFromRequest.UnitPriceLabel_ 
  It's now swapped to **_NegotiationNewOfferFromRequest.LineTotalForOfferLabel_**