### PR TITLE
InboxSortBy: sortLabel had strange margin-right on the mobile layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] Fix a layout bug with InboxSortBy component.
+  [#839](https://github.com/sharetribe/web-template/pull/839)
 - [fix] Fix a bug with UserCard showMore button.
   [#838](https://github.com/sharetribe/web-template/pull/838)
 - [fix] Fixes a bug where listing metadata fields were not shown in the sort dropdown if the default

--- a/src/containers/InboxPage/InboxSearchForm/InboxSortBy.module.css
+++ b/src/containers/InboxPage/InboxSearchForm/InboxSortBy.module.css
@@ -84,7 +84,6 @@
   min-height: 35px;
 
   padding: 0 18px;
-  margin: 0 9px 0 0;
 
   transition: all var(--transitionStyleButton);
   cursor: pointer;


### PR DESCRIPTION
<img width="222" height="117" alt="Screenshot 2026-04-28 at 13 43 38" src="https://github.com/user-attachments/assets/e4f50d50-a898-49e1-b3b8-6b860ae30007" />
