### PR TITLE
Stripe SDK: load conditionally and defer loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [change] Stripe.js: load conditionally and defer loading.
+  [#847](https://github.com/sharetribe/web-template/pull/847)
 - [fix] configHelpers.js: Only validate numberConfig for schemaType long
   [#852](https://github.com/sharetribe/web-template/pull/852)
 

--- a/public/index.html
+++ b/public/index.html
@@ -160,13 +160,6 @@
     <div id="root"><!--!body--></div>
     <div id="portal-root"></div>
 
-    <!--
-         Stripe script should be on every page, not just the pages that
-         use the API:
-
-         https://stripe.com/docs/stripe.js#including-stripejs
-       -->
-    <script src="https://js.stripe.com/v3/" crossorigin="anonymous"></script>
     <!--!preloadedStateScript-->
 
     <!--!ssrScripts-->

--- a/src/app.js
+++ b/src/app.js
@@ -316,6 +316,7 @@ export const ServerApp = props => {
       />
     );
   }
+  const initialPathname = new URL(url, 'http://example.com')?.pathname;
 
   return (
     <Configurations appConfig={appConfig}>
@@ -326,7 +327,7 @@ export const ServerApp = props => {
       >
         <Provider store={store}>
           <HelmetProvider context={helmetContext}>
-            <IncludeScripts config={appConfig} initialPathname={url} />
+            <IncludeScripts config={appConfig} initialPathname={initialPathname} />
             <StaticRouter location={url} context={context}>
               <Routes />
             </StaticRouter>

--- a/src/containers/CheckoutPage/StripePaymentForm/StripePaymentForm.js
+++ b/src/containers/CheckoutPage/StripePaymentForm/StripePaymentForm.js
@@ -12,6 +12,7 @@ import { FormattedMessage, injectIntl } from '../../../util/reactIntl';
 import { propTypes } from '../../../util/types';
 import { ensurePaymentMethodCard } from '../../../util/data';
 import { getPropsForCustomTransactionFieldInputs } from '../../../util/fieldHelpers';
+import { STRIPE_JS_LOADED_EVENT } from '../../../util/includeScripts';
 
 import {
   Heading,
@@ -307,33 +308,48 @@ class StripePaymentForm extends Component {
     this.initializeStripeElement = this.initializeStripeElement.bind(this);
     this.handleStripeElementRef = this.handleStripeElementRef.bind(this);
     this.changePaymentMethod = this.changePaymentMethod.bind(this);
+    this.handleStripeJsLoadedEvent = this.handleStripeJsLoadedEvent.bind(this);
     this.finalFormAPI = null;
     this.cardContainer = null;
   }
 
-  componentDidMount() {
-    if (!window.Stripe) {
-      throw new Error('Stripe must be loaded for StripePaymentForm');
+  handleStripeJsLoadedEvent() {
+    if (this.stripe || typeof window === 'undefined' || !window.Stripe) {
+      return;
+    }
+    const publishableKey = this.props.stripePublishableKey;
+    if (!publishableKey) {
+      return;
     }
 
-    const publishableKey = this.props.stripePublishableKey;
-    if (publishableKey) {
-      const {
-        onStripeInitialized,
-        hasHandledCardPayment,
-        defaultPaymentMethod,
-        loadingData,
-      } = this.props;
-      this.stripe = window.Stripe(publishableKey);
-      onStripeInitialized(this.stripe);
+    window.removeEventListener(STRIPE_JS_LOADED_EVENT, this.handleStripeJsLoadedEvent);
 
-      if (!(hasHandledCardPayment || defaultPaymentMethod || loadingData)) {
-        this.initializeStripeElement();
-      }
+    const {
+      onStripeInitialized,
+      hasHandledCardPayment,
+      defaultPaymentMethod,
+      loadingData,
+    } = this.props;
+    this.stripe = window.Stripe(publishableKey);
+    onStripeInitialized(this.stripe);
+
+    if (!(hasHandledCardPayment || defaultPaymentMethod || loadingData)) {
+      this.initializeStripeElement();
     }
   }
 
+  componentDidMount() {
+    const publishableKey = this.props.stripePublishableKey;
+    if (!publishableKey) {
+      return;
+    }
+
+    window.addEventListener(STRIPE_JS_LOADED_EVENT, this.handleStripeJsLoadedEvent);
+    this.handleStripeJsLoadedEvent();
+  }
+
   componentWillUnmount() {
+    window.removeEventListener(STRIPE_JS_LOADED_EVENT, this.handleStripeJsLoadedEvent);
     if (this.card) {
       this.card.removeEventListener('change', this.handleCardValueChange);
       this.card.unmount();

--- a/src/containers/PaymentMethodsPage/PaymentMethodsForm/PaymentMethodsForm.js
+++ b/src/containers/PaymentMethodsPage/PaymentMethodsForm/PaymentMethodsForm.js
@@ -8,6 +8,7 @@ import { Form as FinalForm } from 'react-final-form';
 import classNames from 'classnames';
 
 import { useConfiguration } from '../../../context/configurationContext';
+import { STRIPE_JS_LOADED_EVENT } from '../../../util/includeScripts';
 import { FormattedMessage, useIntl } from '../../../util/reactIntl';
 
 import { Form, PrimaryButton, FieldTextInput, StripePaymentAddress, H4 } from '../../../components';
@@ -99,34 +100,51 @@ class PaymentMethodsForm extends Component {
     this.handleCardValueChange = this.handleCardValueChange.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
     this.paymentForm = this.paymentForm.bind(this);
+    this.handleStripeJsLoadedEvent = this.handleStripeJsLoadedEvent.bind(this);
     this.finalFormAPI = null;
     this.stripe = null;
   }
 
-  componentDidMount() {
-    if (!window.Stripe) {
-      throw new Error('Stripe must be loaded for PaymentMethodsForm');
+  handleStripeJsLoadedEvent() {
+    if (this.stripe || typeof window === 'undefined' || !window.Stripe) {
+      return;
+    }
+    const publishableKey = this.props.config?.stripe?.publishableKey;
+    if (!publishableKey) {
+      return;
     }
 
-    const publishableKey = this.props.config?.stripe?.publishableKey;
-    if (publishableKey) {
-      this.stripe = window.Stripe(publishableKey);
+    window.removeEventListener(STRIPE_JS_LOADED_EVENT, this.handleStripeJsLoadedEvent);
 
-      const elements = this.stripe.elements(stripeElementsOptions);
-      this.card = elements.create('card', { style: cardStyles });
-      this.card.mount(this.cardContainer);
-      this.card.addEventListener('change', this.handleCardValueChange);
-      // EventListener is the only way to simulate breakpoints with Stripe.
-      window.addEventListener('resize', () => {
+    this.stripe = window.Stripe(publishableKey);
+
+    const elements = this.stripe.elements(stripeElementsOptions);
+    this.card = elements.create('card', { style: cardStyles });
+    this.card.mount(this.cardContainer);
+    this.card.addEventListener('change', this.handleCardValueChange);
+    // EventListener is the only way to simulate breakpoints with Stripe.
+    window.addEventListener('resize', () => {
+      if (this.card) {
         if (window.innerWidth < 768) {
           this.card.update({ style: { base: { fontSize: '14px', lineHeight: '24px' } } });
         } else {
           this.card.update({ style: { base: { fontSize: '18px', lineHeight: '24px' } } });
         }
-      });
+      }
+    });
+  }
+
+  componentDidMount() {
+    const publishableKey = this.props.config?.stripe?.publishableKey;
+    if (!publishableKey) {
+      return;
     }
+
+    window.addEventListener(STRIPE_JS_LOADED_EVENT, this.handleStripeJsLoadedEvent);
+    this.handleStripeJsLoadedEvent();
   }
   componentWillUnmount() {
+    window.removeEventListener(STRIPE_JS_LOADED_EVENT, this.handleStripeJsLoadedEvent);
     if (this.card) {
       this.card.removeEventListener('change', this.handleCardValueChange);
       this.card.unmount();

--- a/src/routing/routeConfiguration.js
+++ b/src/routing/routeConfiguration.js
@@ -146,6 +146,9 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
       auth: true,
       component: CheckoutPage,
       setInitialValues: pageDataLoadingAPI.CheckoutPage.setInitialValues,
+      prioritizeLibraryLoading: {
+        stripe: true,
+      },
     },
     {
       path: '/l/:slug/:id/:variant',
@@ -175,6 +178,9 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
       auth: true,
       component: EditListingPage,
       loadData: pageDataLoadingAPI.EditListingPage.loadData,
+      prioritizeLibraryLoading: {
+        stripe: true,
+      },
     },
     {
       path: '/l/:slug/:id/:type/:tab/:returnURLType',
@@ -182,6 +188,9 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
       auth: true,
       component: EditListingPage,
       loadData: pageDataLoadingAPI.EditListingPage.loadData,
+      prioritizeLibraryLoading: {
+        stripe: true,
+      },
     },
 
     // Canonical path should be after the `/l/new` path since they
@@ -344,6 +353,9 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
       authPage: 'LoginPage',
       component: StripePayoutPage,
       loadData: pageDataLoadingAPI.StripePayoutPage.loadData,
+      prioritizeLibraryLoading: {
+        stripe: true,
+      },
     },
     {
       path: '/account/payments/:returnURLType',
@@ -352,6 +364,9 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
       authPage: 'LoginPage',
       component: StripePayoutPage,
       loadData: pageDataLoadingAPI.StripePayoutPage.loadData,
+      prioritizeLibraryLoading: {
+        stripe: true,
+      },
     },
     {
       path: '/account/payment-methods',
@@ -360,6 +375,9 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
       authPage: 'LoginPage',
       component: PaymentMethodsPage,
       loadData: pageDataLoadingAPI.PaymentMethodsPage.loadData,
+      prioritizeLibraryLoading: {
+        stripe: true,
+      },
     },
     {
       path: '/account/manage',

--- a/src/routing/routeConfiguration.js
+++ b/src/routing/routeConfiguration.js
@@ -96,7 +96,9 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
       ...authForPrivateMarketplace,
       component: SearchPage,
       loadData: pageDataLoadingAPI.SearchPage.loadData,
-      prioritizeMapLibraryLoading: isSearchPageWithMap,
+      prioritizeLibraryLoading: {
+        map: isSearchPageWithMap,
+      },
     },
     {
       path: '/s/:listingType',
@@ -104,7 +106,9 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
       ...authForPrivateMarketplace,
       component: SearchPage,
       loadData: pageDataLoadingAPI.SearchPage.loadData,
-      prioritizeMapLibraryLoading: isSearchPageWithMap,
+      prioritizeLibraryLoading: {
+        map: isSearchPageWithMap,
+      },
     },
     {
       path: '/l',
@@ -117,7 +121,9 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
       ...authForPrivateMarketplace,
       component: ListingPage,
       loadData: pageDataLoadingAPI.ListingPage.loadData,
-      prioritizeMapLibraryLoading: true,
+      prioritizeLibraryLoading: {
+        map: true,
+      },
     },
     {
       path: '/l/:slug/:id/make-offer',
@@ -148,7 +154,9 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
       authPage: 'LoginPage',
       component: ListingPage,
       loadData: pageDataLoadingAPI.ListingPage.loadData,
-      prioritizeMapLibraryLoading: true,
+      prioritizeLibraryLoading: {
+        map: true,
+      },
     },
     {
       path: '/l/new',
@@ -184,7 +192,9 @@ const routeConfiguration = (layoutConfig, accessControlConfig) => {
       ...authForPrivateMarketplace,
       component: ListingPage,
       loadData: pageDataLoadingAPI.ListingPage.loadData,
-      prioritizeMapLibraryLoading: true,
+      prioritizeLibraryLoading: {
+        map: true,
+      },
     },
     {
       path: '/u',

--- a/src/util/includeScripts.js
+++ b/src/util/includeScripts.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Helmet } from 'react-helmet-async';
 
 import { useRouteConfiguration } from '../context/routeConfigurationContext';
@@ -6,6 +6,16 @@ import { matchPathname } from '../util/routes';
 
 const MAPBOX_SCRIPT_ID = 'mapbox_GL_JS';
 const GOOGLE_MAPS_SCRIPT_ID = 'GoogleMapsApi';
+const STRIPE_SCRIPT_ID = 'stripe_js_v3';
+
+/** Dispatched on `window` when Stripe.js has loaded (`window.Stripe` is available). */
+export const STRIPE_JS_LOADED_EVENT = 'stripe-js-loaded';
+
+const dispatchStripeJsLoadedEvent = () => {
+  if (typeof window !== 'undefined') {
+    window.dispatchEvent(new CustomEvent(STRIPE_JS_LOADED_EVENT));
+  }
+};
 
 /**
  * Map library is shown on some of the pages, but ReusableMapContainer is used app wide.
@@ -38,8 +48,9 @@ const canDeferStripeLibrary = (initialPathname, routeConfiguration) => {
  * Include scripts (like Map Provider).
  * These scripts are relevant for whole application: location search in Topbar and maps on different pages.
  * However, if you don't need location search and maps, you can just omit this component from app.js
- * Note: another common point to add <scripts>, <links> and <meta> tags is Page.js
- *       and Stripe script is added in public/index.html
+ * Note: another common point to add <scripts>, <links> and <meta> tags is Page.js.
+ *       Stripe.js is injected here when `stripe.publishableKey` is set; consumers can
+ *       wait for {@link STRIPE_JS_LOADED_EVENT} on `window` if the script may still be loading.
  *
  * Note 2: When adding new external scripts/styles/fonts/etc.,
  *         if a Content Security Policy (CSP) is turned on, the new URLs
@@ -77,6 +88,8 @@ export const IncludeScripts = props => {
     // https://docs.stripe.com/js/including
     stripeLibrary.push(
       <script
+        id={STRIPE_SCRIPT_ID}
+        key="stripe_js_v3"
         src="https://js.stripe.com/v3/"
         crossOrigin="anonymous"
         {...deferStripeLibrary}
@@ -202,8 +215,35 @@ export const IncludeScripts = props => {
       if (foundScript) {
         foundScript.addEventListener('load', onMapLibLoaded, { once: true });
       }
+      const stripeScript = addedTags.scriptTags.find(s => s.id === STRIPE_SCRIPT_ID);
+      if (stripeScript) {
+        stripeScript.addEventListener('load', dispatchStripeJsLoadedEvent, { once: true });
+      }
     }
   };
+
+  // After Helmet writes the Stripe script into the document, either dispatch immediately
+  // (Stripe already ran, e.g. cached) or wait for `load` so listeners (e.g. payment forms)
+  // can rely on STRIPE_JS_LOADED_EVENT. Complements onChangeClientState for injected tags.
+  useEffect(() => {
+    if (!stripe?.publishableKey || typeof document === 'undefined') {
+      return undefined;
+    }
+    const script = document.getElementById(STRIPE_SCRIPT_ID);
+    if (!script) {
+      return undefined;
+    }
+
+    if (window.Stripe) {
+      dispatchStripeJsLoadedEvent();
+      return undefined;
+    }
+
+    script.addEventListener('load', dispatchStripeJsLoadedEvent, { once: true });
+    return () => {
+      script.removeEventListener('load', dispatchStripeJsLoadedEvent);
+    };
+  }, [stripe?.publishableKey]);
 
   const allScripts = [...stripeLibrary, ...analyticsLibraries, ...mapLibraries];
   return <Helmet onChangeClientState={onChangeClientState}>{allScripts}</Helmet>;

--- a/src/util/includeScripts.js
+++ b/src/util/includeScripts.js
@@ -25,6 +25,14 @@ const canDeferMapLibrary = (initialPathname, routeConfiguration) => {
   const currentRouteConfig = matchedRoutes.length > 0 ? matchedRoutes[0]?.route : null;
   return currentRouteConfig?.prioritizeLibraryLoading?.map !== true;
 };
+const canDeferStripeLibrary = (initialPathname, routeConfiguration) => {
+  if (!initialPathname) {
+    return false;
+  }
+  const matchedRoutes = matchPathname(initialPathname, routeConfiguration);
+  const currentRouteConfig = matchedRoutes.length > 0 ? matchedRoutes[0]?.route : null;
+  return currentRouteConfig?.prioritizeLibraryLoading?.stripe !== true;
+};
 
 /**
  * Include scripts (like Map Provider).
@@ -38,7 +46,7 @@ const canDeferMapLibrary = (initialPathname, routeConfiguration) => {
  *         should be whitelisted in the policy. Check: server/csp.js
  */
 export const IncludeScripts = props => {
-  const { marketplaceRootURL: rootURL, maps, analytics } = props?.config || {};
+  const { marketplaceRootURL: rootURL, maps, analytics, stripe } = props?.config || {};
   const { googleAnalyticsId, plausibleDomains } = analytics;
 
   const routeConfiguration = useRouteConfiguration();
@@ -56,8 +64,25 @@ export const IncludeScripts = props => {
   const hasGoogleAnalyticsv4Id = googleAnalyticsId?.indexOf('G-') === 0;
 
   // Collect relevant map libraries
+  let stripeLibrary = [];
   let mapLibraries = [];
   let analyticsLibraries = [];
+
+  if (stripe?.publishableKey) {
+    const deferStripeLibrary = canDeferStripeLibrary(props?.initialPathname, routeConfiguration)
+      ? { defer: '' }
+      : {};
+
+    // Stripe script should be on every page, not just the pages that use the API:
+    // https://docs.stripe.com/js/including
+    stripeLibrary.push(
+      <script
+        src="https://js.stripe.com/v3/"
+        crossOrigin="anonymous"
+        {...deferStripeLibrary}
+      ></script>
+    );
+  }
 
   if (isMapboxInUse) {
     // NOTE: remember to update mapbox-sdk.min.js to a new version regularly.
@@ -180,6 +205,6 @@ export const IncludeScripts = props => {
     }
   };
 
-  const allScripts = [...analyticsLibraries, ...mapLibraries];
+  const allScripts = [...stripeLibrary, ...analyticsLibraries, ...mapLibraries];
   return <Helmet onChangeClientState={onChangeClientState}>{allScripts}</Helmet>;
 };

--- a/src/util/includeScripts.js
+++ b/src/util/includeScripts.js
@@ -23,7 +23,7 @@ const canDeferMapLibrary = (initialPathname, routeConfiguration) => {
   }
   const matchedRoutes = matchPathname(initialPathname, routeConfiguration);
   const currentRouteConfig = matchedRoutes.length > 0 ? matchedRoutes[0]?.route : null;
-  return currentRouteConfig?.prioritizeMapLibraryLoading !== true;
+  return currentRouteConfig?.prioritizeLibraryLoading?.map !== true;
 };
 
 /**


### PR DESCRIPTION
Stripe SDK: load conditionally and defer loading if possible.

Changes:
- Refactor routeConfiguration: 'prioritize library loading' feature changed
   `prioritizeLibraryLoading: { map:true, stripe:true }`
- Move stripe.js from index.html to includeScripts.js
- Fix app.js (initialPathName on SSR) pick pathname only
  - Note: he initialPathName setup loads scripts with/without defer depending what was the URL at the time of full page load. (User might have navigated inside the web app after that.)
- Add STRIPE_JS_LOADED_EVENT for rare edge cases.