### PR TITLE
SearchPage.duck.js: fix integer filter preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] SearchPage.duck.js: fix integer filter preparation (configs were mixed)
+  [#848](https://github.com/sharetribe/web-template/pull/848)
 - [fix] ContactDetailsPage.duck.js: fix an 'undefined' bug with saveEmailAndPhoneNumberThunk.
   [#846](https://github.com/sharetribe/web-template/pull/846)
 - [add] Adds codebase support for saving referral ID to user private data on sign-up.

--- a/src/containers/SearchPage/SearchPage.duck.js
+++ b/src/containers/SearchPage/SearchPage.duck.js
@@ -124,7 +124,11 @@ const searchListingsPayloadCreator = ({ searchParams, config }, thunkAPI) => {
    * @returns {Object} The prepared parameter object.
    */
   const prepareIntegerRangeParam = (paramName, params) => {
-    const integerRangeConfig = config.listing.listingFields?.find(f => f.schemaType === 'long');
+    const integerRangeConfig = config.listing.listingFields?.find(f => {
+      const isInteger = f.schemaType === 'long';
+      const isCorrectExtendedDataKey = constructQueryParamName(f.key, f.scope) === paramName;
+      return isInteger && isCorrectExtendedDataKey;
+    });
     const { key, scope } = integerRangeConfig || {};
     const integerParamPrefix = constructQueryParamName(key, scope);
     return paramName.startsWith(integerParamPrefix)


### PR DESCRIPTION
The integer filter was not preparing the range for API using correct config, causing exclusive end adjustment to not be applied in some cases.