### PR TITLE
New release version 11.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,16 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+## [v11.1.0] 2026-05-18
+
 - [fix] SearchPage.duck.js: fix integer filter preparation (configs were mixed)
   [#848](https://github.com/sharetribe/web-template/pull/848)
 - [fix] ContactDetailsPage.duck.js: fix an 'undefined' bug with saveEmailAndPhoneNumberThunk.
   [#846](https://github.com/sharetribe/web-template/pull/846)
 - [add] Adds codebase support for saving referral ID to user private data on sign-up.
   [#826](https://github.com/sharetribe/web-template/pull/826)
+
+  [v11.1.0]: https://github.com/sharetribe/web-template/compare/v11.0.2...v11.1.0
 
 ## [v11.0.2] 2026-04-29
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "11.0.2",
+  "version": "11.1.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This release contains template support for the upcoming referral ID feature: Users can define referral sources per user type in Console which will save referral data to a user's private data when provided with a properly formatted referral link.

This also contains fixes addressing an 'undefined' bug in the contact details page and integer filter issues in search page.

## [Changes](https://github.com/sharetribe/web-template/compare/v11.0.2...v11.1.0) 2026-05-18
- [fix] SearchPage.duck.js: fix integer filter preparation (configs were mixed)
  [#848](https://github.com/sharetribe/web-template/pull/848)
- [fix] ContactDetailsPage.duck.js: fix an 'undefined' bug with saveEmailAndPhoneNumberThunk.
  [#846](https://github.com/sharetribe/web-template/pull/846)
- [add] Adds codebase support for saving referral ID to user private data on sign-up.
  [#826](https://github.com/sharetribe/web-template/pull/826)