### PR TITLE
configHelpers.js: Only validate numberConfig for schemaType long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] configHelpers.js: Only validate numberConfig for schemaType long
+  [#852](https://github.com/sharetribe/web-template/pull/852)
+
 ## [v11.1.0] 2026-05-18
 
 - [fix] SearchPage.duck.js: fix integer filter preparation (configs were mixed)

--- a/src/util/configHelpers.js
+++ b/src/util/configHelpers.js
@@ -695,7 +695,16 @@ const validShowConfig = config => {
 };
 
 // numberConfig is passed along with listing fields that use the schema type `long`
-const validNumberConfig = config => {
+const validNumberConfig = (config, schemaType) => {
+  const shouldHaveNumberConfig = schemaType === 'long';
+
+  if (!shouldHaveNumberConfig) {
+    // A field might have an obsolete numberConfig that no longer
+    // matches the field's schema type. If that is the case, return
+    // a valid result and remove the obsolete number config
+    return [true, {}];
+  }
+
   const { minimum, maximum } = config;
   const integerConfig = { minimum, maximum, step: 1 };
 
@@ -847,7 +856,7 @@ const validListingFields = (listingFields, listingTypesInUse, categoriesInUse) =
             : name === 'scope'
             ? validEnumString('scope', value, scopeOptions, 'public')
             : name === 'numberConfig'
-            ? validNumberConfig(value)
+            ? validNumberConfig(value, schemaType)
             : name === 'includeForListingTypes'
             ? validListingTypesForBuiltInSetup(value, listingTypesInUse)
             : name === 'listingTypeConfig'
@@ -908,7 +917,7 @@ const validTransactionFields = transactionFields => {
             : name === 'scope'
             ? validEnumString('scope', value, scopeOptions, 'protected')
             : name === 'numberConfig'
-            ? validNumberConfig(value)
+            ? validNumberConfig(value, schemaType)
             : name === 'schemaType'
             ? validEnumString('schemaType', value, EXTENDED_DATA_SCHEMA_TYPES)
             : name === 'enumOptions'
@@ -975,7 +984,7 @@ const validUserFields = (userFields, userTypesInUse) => {
             : name === 'enumOptions'
             ? validSchemaOptions(value, schemaType)
             : name === 'numberConfig'
-            ? validNumberConfig(value)
+            ? validNumberConfig(value, schemaType)
             : name === 'showConfig'
             ? validUserShowConfig(value)
             : name === 'userTypeConfig'


### PR DESCRIPTION
Fix an issue where a Console-created config has an obsolete numberConfig defined for a non-numeric schema type.