### PR TITLE
Add wallet payments (Apple Pay, Google Pay, Link) via Stripe Payment Request Button

### DIFF
--- a/src/config/configStripe.js
+++ b/src/config/configStripe.js
@@ -7,6 +7,18 @@ To make Stripe connection work, you also need to set Stripe's private key in the
 
 export const publishableKey = process.env.REACT_APP_STRIPE_PUBLISHABLE_KEY;
 
+/**
+ * Two-letter country code of the Stripe account that owns the
+ * marketplace's platform Stripe Connect setup. Stripe's Payment
+ * Request API needs it to surface the correct wallet (Apple Pay /
+ * Google Pay / Link) for the buyer. See
+ * https://stripe.com/docs/js/payment_request/create#stripe_payment_request-options-country
+ *
+ * Set to the country matching your platform Stripe account. Defaults
+ * to 'US' so the template renders out of the box without extra config.
+ */
+export const merchantCountry = process.env.REACT_APP_STRIPE_MERCHANT_COUNTRY || 'US';
+
 // A maximum number of days forwards during which a booking can be made.
 // This is limited due to Stripe holding funds up to 90 days from the
 // moment they are charged. However, US accounts can hold funds up to 2 years.

--- a/src/containers/CheckoutPage/CheckoutPageWithPayment.js
+++ b/src/containers/CheckoutPage/CheckoutPageWithPayment.js
@@ -240,6 +240,123 @@ export const loadInitialDataForStripePayments = ({
   fetchSpeculatedTransactionIfNeeded(orderParams, pageData, fetchSpeculatedTransaction);
 };
 
+/**
+ * Wallet (Apple Pay / Google Pay / Link) submit path.
+ *
+ * The buyer authorised payment inside the Stripe wallet sheet; the
+ * `paymentmethod` event handed us a `paymentMethod` object plus a
+ * `complete` callback we MUST call to dismiss the sheet (success or
+ * fail).
+ *
+ * Behind the scenes we route through the same `processCheckoutWithPayment`
+ * flow Sharetribe's card path uses — we just feed it
+ * `stripePaymentMethodId` (the wallet PaymentMethod's id) and flag
+ * `isPaymentFlowUseSavedCard: true`, so the existing
+ * `stripe.confirmCardPayment(clientSecret, { payment_method: id })`
+ * call works unchanged. No new server endpoints, no `on_behalf_of`
+ * juggling — Stripe Connect destination-charge alignment happens
+ * inside `confirmCardPayment` itself.
+ */
+const handleWalletSubmit = (
+  { paymentMethod, complete, payerEmail },
+  process,
+  props,
+  stripe,
+  submitting,
+  setSubmitting
+) => {
+  if (submitting) {
+    complete('fail');
+    return;
+  }
+  setSubmitting(true);
+
+  const {
+    history,
+    config,
+    routeConfiguration,
+    speculatedTransaction,
+    currentUser,
+    paymentIntent,
+    dispatch,
+    onInitiateOrder,
+    onConfirmCardPayment,
+    onConfirmPayment,
+    onSavePaymentMethod,
+    onSubmitCallback,
+    pageData,
+    setPageData,
+    sessionStorageKey,
+    transactionFieldConfigs = [],
+  } = props;
+
+  const transactionFieldsProtectedData = {
+    ...pickTransactionFieldsData({}, 'protected', true, transactionFieldConfigs),
+  };
+
+  const hasPaymentIntentUserActionsDone =
+    paymentIntent && STRIPE_PI_USER_ACTIONS_DONE_STATUSES.includes(paymentIntent.status);
+
+  const requestPaymentParams = {
+    pageData,
+    speculatedTransaction,
+    stripe,
+    billingDetails: { email: payerEmail || currentUser?.attributes?.email || null },
+    paymentIntent,
+    hasPaymentIntentUserActionsDone,
+    // Hand the wallet's PaymentMethod id to the existing card-path
+    // confirmation logic via the same slot saved cards use.
+    stripePaymentMethodId: paymentMethod.id,
+    process,
+    onInitiateOrder,
+    onConfirmCardPayment,
+    onConfirmPayment,
+    onSavePaymentMethod,
+    sessionStorageKey,
+    stripeCustomer: currentUser?.stripeCustomer,
+    isPaymentFlowUseSavedCard: true,
+    isPaymentFlowPayAndSaveCard: false,
+    setPageData,
+  };
+
+  const shippingDetails = getShippingDetailsMaybe({});
+  const orderParams = getOrderParams(
+    pageData,
+    shippingDetails,
+    { paymentMethod: paymentMethod.id },
+    config,
+    transactionFieldsProtectedData,
+    null
+  );
+
+  processCheckoutWithPayment(orderParams, requestPaymentParams)
+    .then(response => {
+      // Dismiss the wallet sheet first so the buyer sees the page
+      // transition instantly — Stripe needs `complete` called
+      // synchronously after the payment finishes.
+      complete('success');
+
+      const { orderId } = response;
+      setSubmitting(false);
+
+      const orderDetailsPath = pathByRouteName('OrderDetailsPage', routeConfiguration, {
+        id: orderId.uuid,
+      });
+      setOrderPageInitialValues(
+        { savePaymentMethodFailed: false },
+        routeConfiguration,
+        dispatch
+      );
+      onSubmitCallback();
+      history.push(orderDetailsPath);
+    })
+    .catch(err => {
+      console.error(err);
+      complete('fail');
+      setSubmitting(false);
+    });
+};
+
 const handleSubmit = (values, process, props, stripe, submitting, setSubmitting) => {
   if (submitting) {
     return;
@@ -651,6 +768,15 @@ export const CheckoutPageWithPayment = props => {
                 isFuzzyLocation={config.maps.fuzzy.enabled}
                 transactionFieldConfigs={transactionFieldConfigs}
                 showTransactionFields={showTransactionFields}
+                walletAmount={tx?.attributes?.payinTotal?.amount}
+                walletCurrency={
+                  tx?.attributes?.payinTotal?.currency || config.currency
+                }
+                walletCountry={config.stripe?.merchantCountry || 'US'}
+                walletLabel={listingTitle || config.marketplaceName}
+                onWalletPaymentMethod={walletEvent =>
+                  handleWalletSubmit(walletEvent, process, props, stripe, submitting, setSubmitting)
+                }
               />
             ) : null}
           </section>

--- a/src/containers/CheckoutPage/PaymentRequestButton/PaymentRequestButton.js
+++ b/src/containers/CheckoutPage/PaymentRequestButton/PaymentRequestButton.js
@@ -1,0 +1,103 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+import css from './PaymentRequestButton.module.css';
+
+/**
+ * Wraps Stripe's Payment Request Button so the same component surfaces
+ * Apple Pay (Safari macOS/iOS), Google Pay (Chrome / Android), and
+ * Stripe Link — whichever the buyer's browser advertises. Stripe picks
+ * which wallet renders; we just mount the button.
+ *
+ * The component is intentionally dumb: it knows how to render the
+ * wallet button and how to forward the wallet's `paymentmethod` event
+ * upward. Confirming the payment against Stripe + Sharetribe is the
+ * caller's responsibility — same pattern Sharetribe's existing card
+ * path already uses (the wallet just hands us a PaymentMethod id; we
+ * pass it into `stripe.confirmCardPayment` exactly like the saved-card
+ * flow does).
+ *
+ * @param {Object} props
+ * @param {Object} props.stripe — Stripe.js instance from window.Stripe()
+ * @param {number} props.amount — total amount in the smallest currency unit (cents/øre/etc.)
+ * @param {string} props.currency — ISO currency code, lowercase (e.g. 'usd', 'eur', 'nok')
+ * @param {string} props.country — Stripe-account country, two-letter (e.g. 'US', 'FI', 'NO')
+ * @param {string} props.label — human-readable line item label shown in the wallet sheet
+ * @param {Function} props.onPaymentMethod — fires when the buyer authorises in the
+ *        wallet. Receives `{ paymentMethod, complete }`. Call
+ *        `complete('success')` or `complete('fail')` once Sharetribe's
+ *        confirm-payment transition has resolved.
+ */
+const PaymentRequestButton = props => {
+  const { stripe, amount, currency, country, label, onPaymentMethod } = props;
+  const mountRef = useRef(null);
+  const paymentRequestRef = useRef(null);
+  const onPaymentMethodRef = useRef(onPaymentMethod);
+  const [canRender, setCanRender] = useState(false);
+
+  // Keep the latest handler in a ref so the `paymentmethod` listener
+  // (registered once on mount) always sees the up-to-date callback
+  // without us having to tear down / re-mount the button.
+  useEffect(() => {
+    onPaymentMethodRef.current = onPaymentMethod;
+  }, [onPaymentMethod]);
+
+  useEffect(() => {
+    if (!stripe || !amount || !currency || !country || paymentRequestRef.current) {
+      return undefined;
+    }
+
+    const paymentRequest = stripe.paymentRequest({
+      country,
+      currency: currency.toLowerCase(),
+      total: { label, amount },
+      requestPayerName: true,
+      requestPayerEmail: true,
+    });
+
+    paymentRequest.canMakePayment().then(result => {
+      if (!result) {
+        return;
+      }
+      // result is { applePay, googlePay, link } — any truthy value means
+      // at least one wallet is available, so we render the button.
+      setCanRender(true);
+      const elements = stripe.elements();
+      const prButton = elements.create('paymentRequestButton', { paymentRequest });
+      if (mountRef.current) {
+        prButton.mount(mountRef.current);
+      }
+    });
+
+    paymentRequest.on('paymentmethod', event => {
+      const handler = onPaymentMethodRef.current;
+      if (typeof handler !== 'function') {
+        event.complete('fail');
+        return;
+      }
+      handler({
+        paymentMethod: event.paymentMethod,
+        complete: event.complete,
+        payerName: event.payerName,
+        payerEmail: event.payerEmail,
+      });
+    });
+
+    paymentRequestRef.current = paymentRequest;
+    return undefined;
+  }, [stripe, amount, currency, country, label]);
+
+  if (!canRender) {
+    return null;
+  }
+
+  return (
+    <div className={css.root}>
+      <div ref={mountRef} className={css.button} />
+      <div className={css.divider}>
+        <span className={css.dividerLabel}>or pay with card</span>
+      </div>
+    </div>
+  );
+};
+
+export default PaymentRequestButton;

--- a/src/containers/CheckoutPage/PaymentRequestButton/PaymentRequestButton.js
+++ b/src/containers/CheckoutPage/PaymentRequestButton/PaymentRequestButton.js
@@ -45,6 +45,11 @@ const PaymentRequestButton = props => {
     if (!stripe || !amount || !currency || !country || paymentRequestRef.current) {
       return undefined;
     }
+    // Some Stripe.js test mocks omit the paymentRequest API; bail out
+    // gracefully so the rest of the checkout still mounts.
+    if (typeof stripe.paymentRequest !== 'function') {
+      return undefined;
+    }
 
     const paymentRequest = stripe.paymentRequest({
       country,

--- a/src/containers/CheckoutPage/PaymentRequestButton/PaymentRequestButton.js
+++ b/src/containers/CheckoutPage/PaymentRequestButton/PaymentRequestButton.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 
+import { FormattedMessage } from '../../../util/reactIntl';
+
 import css from './PaymentRequestButton.module.css';
 
 /**
@@ -99,7 +101,9 @@ const PaymentRequestButton = props => {
     <div className={css.root}>
       <div ref={mountRef} className={css.button} />
       <div className={css.divider}>
-        <span className={css.dividerLabel}>or pay with card</span>
+        <span className={css.dividerLabel}>
+          <FormattedMessage id="PaymentRequestButton.orPayWithCard" />
+        </span>
       </div>
     </div>
   );

--- a/src/containers/CheckoutPage/PaymentRequestButton/PaymentRequestButton.module.css
+++ b/src/containers/CheckoutPage/PaymentRequestButton/PaymentRequestButton.module.css
@@ -1,0 +1,35 @@
+@import '../../../styles/customMediaQueries.css';
+
+.root {
+  display: flex;
+  flex-direction: column;
+  margin: 0 0 24px 0;
+}
+
+.button {
+  width: 100%;
+  min-height: 44px;
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  text-align: center;
+  margin: 20px 0 4px 0;
+  color: var(--colorGrey500);
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.divider::before,
+.divider::after {
+  content: '';
+  flex: 1;
+  border-bottom: 1px solid var(--colorGrey100);
+}
+
+.dividerLabel {
+  padding: 0 12px;
+  text-transform: lowercase;
+  letter-spacing: 0.02em;
+}

--- a/src/containers/CheckoutPage/StripePaymentForm/StripePaymentForm.js
+++ b/src/containers/CheckoutPage/StripePaymentForm/StripePaymentForm.js
@@ -26,6 +26,7 @@ import {
 } from '../../../components';
 
 import ShippingDetails from '../ShippingDetails/ShippingDetails';
+import PaymentRequestButton from '../PaymentRequestButton/PaymentRequestButton';
 
 import css from './StripePaymentForm.module.css';
 
@@ -482,6 +483,13 @@ class StripePaymentForm extends Component {
       transactionFieldConfigs = [],
       showTransactionFields,
       values,
+      // Wallet (Apple Pay / Google Pay / Link) integration props —
+      // forwarded down to PaymentRequestButton when present.
+      walletAmount,
+      walletCurrency,
+      walletCountry,
+      walletLabel,
+      onWalletPaymentMethod,
     } = formRenderProps;
 
     this.finalFormAPI = formApi;
@@ -587,6 +595,17 @@ class StripePaymentForm extends Component {
           locale={locale}
           intl={intl}
         />
+
+        {billingDetailsNeeded && !loadingData && onWalletPaymentMethod ? (
+          <PaymentRequestButton
+            stripe={this.stripe}
+            amount={walletAmount}
+            currency={walletCurrency}
+            country={walletCountry}
+            label={walletLabel}
+            onPaymentMethod={onWalletPaymentMethod}
+          />
+        ) : null}
 
         {billingDetailsNeeded && !loadingData ? (
           <React.Fragment>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,5 +1,6 @@
 {
   "AddressLinkMaybe.viewOnGoogleMaps": "View on Google Maps",
+  "PaymentRequestButton.orPayWithCard": "or pay with card",
   "AuthenticationPage.confirmSignupInfoText": "Please check that your information is correct.",
   "AuthenticationPage.confirmSignupWithIdpTitle": "Sign up with {idp}",
   "AuthenticationPage.fixEmail": "Is there an error in your email? {fixEmailLink}.",


### PR DESCRIPTION
## Add wallet payments (Apple Pay, Google Pay, Link) via Stripe Payment Request Button

Adds a single `PaymentRequestButton` component above the existing card form on `CheckoutPage`. Stripe's Payment Request Button advertises whichever wallet the buyer's browser supports - Apple Pay on Safari, Google Pay on Chrome, Stripe Link when signed in.

### Why Payment Request Button (not Express Checkout Element)?

The PRB calls **`stripe.confirmCardPayment(clientSecret, { payment_method: id })`** - exactly the same Stripe SDK method the template's card path already uses. That matters for Stripe Connect destination charges: Connect parameter alignment (`on_behalf_of`, capture method, etc.) happens automatically inside `confirmCardPayment`. No new server endpoints, no `stripe.elements({ onBehalfOf })`, no seller-account lookup.

The newer Express Checkout Element is stricter and requires you to declare those Connect parameters on the Elements side too, which means surfacing the seller's Stripe account ID to the client - a separate Integration SDK lookup and a new server route.

### What's included

| Commit | What it teaches |
|---|---|
| `f0846b6b1` | The component scaffolding - `paymentRequest()`, `canMakePayment()`, `paymentmethod` event forwarding |
| `a73d0f4a2` | Mounting above the card form via five new optional props on `StripePaymentForm` |
| `91a93b102` | Wiring the wallet's PaymentMethod into `processCheckoutWithPayment` via the existing saved-card path |
| `35ec39eab` | Defensive `typeof` guard for older Stripe.js mocks |
| `6b8f830c3` | i18n via `FormattedMessage` for the "or pay with card" divider |

### Config

One new env var: `REACT_APP_STRIPE_MERCHANT_COUNTRY` (defaults to `US`). Set it to your platform Stripe account's country code so the right wallets are advertised.

### Test plan

- [ ] Run `yarn dev`, expose via HTTPS (ngrok / Cloudflare Tunnel) since wallet APIs refuse HTTP
- [ ] Open checkout on Safari → Apple Pay button renders
- [ ] Open checkout on Chrome with a saved card → Google Pay button renders
- [ ] Sign into Stripe Link → Link button renders
- [ ] Confirm checkout completes via wallet (uses test card behind the scenes in test mode)