### PR TITLE
Fix scrollToMessage and streamline file download behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ way to update this template, but currently, we follow a pattern:
   [#863](https://github.com/sharetribe/web-template/pull/863)
 - [fix] Fix file storage domain default value
   [#862](https://github.com/sharetribe/web-template/pull/862)
+- [fix] Fix scrollToMessage and streamline file download behavior
+  [#861](https://github.com/sharetribe/web-template/pull/861)
 - [add] Add currently available translations for DE, ES, FR.
   [#859](https://github.com/sharetribe/web-template/pull/859)
 

--- a/src/components/FileUpload/FileUpload.js
+++ b/src/components/FileUpload/FileUpload.js
@@ -159,7 +159,7 @@ const FileUpload = props => {
     <button
       type="button"
       className={classNames(css.fileNameDownloadable)}
-      onClick={() => onDownloadFile(file.id.uuid, true)}
+      onClick={() => onDownloadFile(file.id, true)}
     >
       <FileName name={name} />
     </button>

--- a/src/containers/TransactionPage/TransactionPage.duck.js
+++ b/src/containers/TransactionPage/TransactionPage.duck.js
@@ -1195,27 +1195,33 @@ const transactionPageSlice = createSlice({
       // downloadFile cases
       .addCase(downloadFileThunk.pending, (state, action) => {
         const { fileAttachmentId } = action.meta.arg;
-        state.fileDownloads[fileAttachmentId.uuid] = {
-          inProgress: true,
-          error: null,
-        };
+        if (fileAttachmentId) {
+          state.fileDownloads[fileAttachmentId.uuid] = {
+            inProgress: true,
+            error: null,
+          };
+        }
       })
       .addCase(downloadFileThunk.fulfilled, (state, action) => {
         const fileAttachmentId = action.payload;
-        state.fileDownloads[fileAttachmentId.uuid] = {
-          inProgress: false,
-          error: null,
-        };
+        if (fileAttachmentId) {
+          state.fileDownloads[fileAttachmentId.uuid] = {
+            inProgress: false,
+            error: null,
+          };
+        }
       })
       .addCase(downloadFileThunk.rejected, (state, action) => {
         if (!action.payload) {
           return;
         }
         const { fileAttachmentId, error } = action.payload;
-        state.fileDownloads[fileAttachmentId.uuid] = {
-          inProgress: false,
-          error,
-        };
+        if (fileAttachmentId) {
+          state.fileDownloads[fileAttachmentId.uuid] = {
+            inProgress: false,
+            error,
+          };
+        }
       })
       // pollForMessageFileVerification cases
       .addCase(pollForMessageFileVerificationThunk.pending, (state, action) => {

--- a/src/containers/TransactionPage/TransactionPage.js
+++ b/src/containers/TransactionPage/TransactionPage.js
@@ -614,7 +614,7 @@ export const TransactionPageComponent = props => {
   };
 
   const scrollToMessage = messageId => {
-    const selector = `#msg-${messageId.uuid}`;
+    const selector = `#msg-${messageId}`;
     const el = document.querySelector(selector);
     if (el) {
       el.scrollIntoView({ block: 'start', behavior: 'smooth' });


### PR DESCRIPTION
- Use the right message id to scroll to message
- Use the same shape of file id for own file download as for sent message download
- Add guards for fileAttachmentId before handling state.fileDownloads