### PR TITLE
Harden target path handling

### DIFF
--- a/server/api-util/url.js
+++ b/server/api-util/url.js
@@ -1,0 +1,34 @@
+/**
+ * Returns true when path is safe to use as a same-origin relative redirect path.
+ *
+ * @param {unknown} path
+ * @returns {boolean}
+ */
+const isRelativePath = path =>
+  typeof path === 'string' && path.startsWith('/') && !path.startsWith('//');
+
+/**
+ * Builds an absolute marketplace redirect URL from a relative path.
+ * Falls back when path (or fallback) is missing or unsafe.
+ *
+ * @param {string} rootUrl Marketplace root URL from REACT_APP_MARKETPLACE_ROOT_URL
+ * @param {string} [path] Preferred relative path
+ * @param {string} [fallback='/'] Fallback relative path when path is unsafe
+ * @returns {string}
+ */
+const buildMarketplaceRedirectUrl = (rootUrl, path, fallback = '/') => {
+  const safePath =
+    path && isRelativePath(path) ? path : fallback && isRelativePath(fallback) ? fallback : '/';
+
+  const base = (rootUrl || '').replace(/\/$/, '');
+  if (!base) {
+    return safePath;
+  }
+
+  return `${base}${safePath}`;
+};
+
+module.exports = {
+  isRelativePath,
+  buildMarketplaceRedirectUrl,
+};

--- a/server/api-util/url.test.js
+++ b/server/api-util/url.test.js
@@ -1,0 +1,46 @@
+const { isRelativePath, buildMarketplaceRedirectUrl } = require('./url');
+
+const ROOT_URL = 'https://marketplace.example.com';
+
+describe('isRelativePath()', () => {
+  it('accepts normal app paths', () => {
+    expect(isRelativePath('/')).toBe(true);
+    expect(isRelativePath('/l/listing-id/slug')).toBe(true);
+    expect(isRelativePath('/login?email=test')).toBe(true);
+  });
+
+  it('rejects open-redirect patterns', () => {
+    expect(isRelativePath('//evil.com')).toBe(false);
+    expect(isRelativePath('@evil.com')).toBe(false);
+    expect(isRelativePath('https://evil.com')).toBe(false);
+    expect(isRelativePath('')).toBe(false);
+    expect(isRelativePath(null)).toBe(false);
+  });
+});
+
+describe('buildMarketplaceRedirectUrl()', () => {
+  it('builds a same-origin URL from a safe path', () => {
+    expect(buildMarketplaceRedirectUrl(ROOT_URL, '/l/listing-id/slug')).toBe(
+      'https://marketplace.example.com/l/listing-id/slug'
+    );
+  });
+
+  it('falls back when path is an open-redirect attempt', () => {
+    expect(buildMarketplaceRedirectUrl(ROOT_URL, '@evil.com', '/login')).toBe(
+      'https://marketplace.example.com/login'
+    );
+    expect(buildMarketplaceRedirectUrl(ROOT_URL, '//evil.com', '/')).toBe(
+      'https://marketplace.example.com/'
+    );
+  });
+
+  it('prefers path over fallback when path is safe', () => {
+    expect(buildMarketplaceRedirectUrl(ROOT_URL, '/inbox', '/')).toBe(
+      'https://marketplace.example.com/inbox'
+    );
+  });
+
+  it('returns a relative path when root URL is missing', () => {
+    expect(buildMarketplaceRedirectUrl('', '/login')).toBe('/login');
+  });
+});

--- a/server/api/auth/loginWithIdp.js
+++ b/server/api/auth/loginWithIdp.js
@@ -3,6 +3,7 @@ const https = require('https');
 const sharetribeSdk = require('sharetribe-flex-sdk');
 const log = require('../../log.js');
 const sdkUtils = require('../../api-util/sdk');
+const { buildMarketplaceRedirectUrl, isRelativePath } = require('../../api-util/url');
 
 const CLIENT_ID = process.env.REACT_APP_SHARETRIBE_SDK_CLIENT_ID;
 const CLIENT_SECRET = process.env.SHARETRIBE_SDK_CLIENT_SECRET;
@@ -96,11 +97,8 @@ module.exports = (err, user, req, res, idpClientId, idpId) => {
         // We need to add # to the end of the URL because otherwise Facebook
         // login will add their defaul #_#_ which breaks the routing in frontend.
 
-        if (from) {
-          res.redirect(`${rootUrl}${from}#`);
-        } else {
-          res.redirect(`${rootUrl}${defaultReturn}#`);
-        }
+        const redirectUrl = buildMarketplaceRedirectUrl(rootUrl, from, defaultReturn);
+        res.redirect(`${redirectUrl}#`);
       }
     })
     .catch(() => {
@@ -123,7 +121,7 @@ module.exports = (err, user, req, res, idpClientId, idpId) => {
           lastName: user.lastName,
           idpToken: user.idpToken,
           idpId,
-          from,
+          from: from && isRelativePath(from) ? from : undefined,
           userType,
         },
         {
@@ -131,6 +129,7 @@ module.exports = (err, user, req, res, idpClientId, idpId) => {
         }
       );
 
-      res.redirect(`${rootUrl}${defaultConfirm}#`);
+      const confirmUrl = buildMarketplaceRedirectUrl(rootUrl, defaultConfirm);
+      res.redirect(`${confirmUrl}#`);
     });
 };

--- a/server/api/initiate-login-as.js
+++ b/server/api/initiate-login-as.js
@@ -73,7 +73,8 @@ code_challenge_method=S256`;
 
   res.cookie(stateKey, state, cookieOpts);
   res.cookie(codeVerifierKey, codeVerifier, cookieOpts);
-  if (targetPath) {
+  const isRelativePath = p => typeof p === 'string' && p.startsWith('/') && !p.startsWith('//');
+  if (targetPath && isRelativePath(targetPath)) {
     res.cookie(targetPathKey, targetPath, cookieOpts);
   }
   return res.redirect(location);

--- a/server/api/initiate-login-as.js
+++ b/server/api/initiate-login-as.js
@@ -57,14 +57,16 @@ module.exports = (req, res) => {
   const authorizeServerUrl = `${CONSOLE_URL}/api/authorize-as`;
   const { target_path: targetPath } = req.query || {};
 
-  const location = `${authorizeServerUrl}?\
-response_type=code&\
-client_id=${CLIENT_ID}&\
-redirect_uri=${loginAsRedirectUri}&\
-user_id=${userId}&\
-state=${state}&\
-code_challenge=${codeChallenge}&\
-code_challenge_method=S256`;
+  const authorizeParams = new URLSearchParams({
+    response_type: 'code',
+    client_id: CLIENT_ID,
+    redirect_uri: loginAsRedirectUri,
+    user_id: userId,
+    state,
+    code_challenge: codeChallenge,
+    code_challenge_method: 'S256',
+  });
+  const location = `${authorizeServerUrl}?${authorizeParams.toString()}`;
 
   const cookieOpts = {
     maxAge: 1000 * 30, // 30 seconds

--- a/server/api/initiate-login-as.js
+++ b/server/api/initiate-login-as.js
@@ -1,5 +1,7 @@
 const crypto = require('crypto');
 
+const { isRelativePath } = require('../api-util/url');
+
 const CLIENT_ID = process.env.REACT_APP_SHARETRIBE_SDK_CLIENT_ID;
 const ROOT_URL = process.env.REACT_APP_MARKETPLACE_ROOT_URL;
 const CONSOLE_URL = process.env.SERVER_SHARETRIBE_CONSOLE_URL || 'https://console.sharetribe.com';
@@ -75,7 +77,6 @@ module.exports = (req, res) => {
 
   res.cookie(stateKey, state, cookieOpts);
   res.cookie(codeVerifierKey, codeVerifier, cookieOpts);
-  const isRelativePath = p => typeof p === 'string' && p.startsWith('/') && !p.startsWith('//');
   if (targetPath && isRelativePath(targetPath)) {
     res.cookie(targetPathKey, targetPath, cookieOpts);
   }

--- a/server/api/login-as.js
+++ b/server/api/login-as.js
@@ -33,7 +33,11 @@ module.exports = (req, res) => {
   }
 
   const codeVerifier = req.cookies[codeVerifierKey];
-  const targetPath = req.cookies[targetPathKey];
+  const targetPathRaw = req.cookies[targetPathKey];
+  const isRelativePath = p => typeof p === 'string' && p.startsWith('/') && !p.startsWith('//');
+  const targetPath = targetPathRaw && isRelativePath(targetPathRaw) 
+    ? `${ROOT_URL.replace(/\/$/, '')}${targetPathRaw}`
+    : '/';
 
   // clear state and code verifier cookies
   res.clearCookie(stateKey, { secure: USING_SSL });
@@ -49,6 +53,6 @@ module.exports = (req, res) => {
       redirect_uri: loginAsRedirectUri,
       code_verifier: codeVerifier,
     })
-    .then(() => res.redirect(targetPath || '/'))
+    .then(() => res.redirect(targetPath))
     .catch(() => res.status(401).send('Unable to authenticate as a user'));
 };

--- a/server/api/login-as.js
+++ b/server/api/login-as.js
@@ -1,4 +1,5 @@
 const sdkUtils = require('../api-util/sdk');
+const { buildMarketplaceRedirectUrl } = require('../api-util/url');
 
 const CLIENT_ID = process.env.REACT_APP_SHARETRIBE_SDK_CLIENT_ID;
 const ROOT_URL = process.env.REACT_APP_MARKETPLACE_ROOT_URL;
@@ -34,10 +35,7 @@ module.exports = (req, res) => {
 
   const codeVerifier = req.cookies[codeVerifierKey];
   const targetPathRaw = req.cookies[targetPathKey];
-  const isRelativePath = p => typeof p === 'string' && p.startsWith('/') && !p.startsWith('//');
-  const targetPath = targetPathRaw && isRelativePath(targetPathRaw) 
-    ? `${ROOT_URL.replace(/\/$/, '')}${targetPathRaw}`
-    : '/';
+  const targetPath = buildMarketplaceRedirectUrl(ROOT_URL, targetPathRaw);
 
   // clear state and code verifier cookies
   res.clearCookie(stateKey, { secure: USING_SSL });


### PR DESCRIPTION
There were a couple of _open redirection_ issues found from the codebase. For malicious actors, these are somewhat intriguing opportunities to direct a user into a phishing site - if the attacker has managed to convince a user to click a link that has been tampered. Perhaps, through a phishing email. We highly recommend updating the codebase to avoid these Open redirections that were found.

The attack could be something like this:
1. Attacker creates a malicious login link (that actually leads to a marketplace)
2. Open redirect bug leads the user to malicious site after successful login 
    (Note: marketplace data is not leaked, there's just a redirection possibility)
3. Attacker could create some UI on the malicious site that asks phishing info "To complete the signup, fill this form"
