### PR TITLE
Adjust nl individual stripe accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [change] Update Stripe Connect account requirements for Netherlands. Individual accounts are
+  supported now for users without access to the Stripe dashboard.
+  [#871](https://github.com/sharetribe/web-template/pull/871)
+
 ## [v11.2.2] 2026-06-26
 
 - [fix] Fix open redirect vulnerabilities that could be abused for phishing attacks.

--- a/src/util/stripeConnect.js
+++ b/src/util/stripeConnect.js
@@ -1,10 +1,15 @@
-// Netherlands requires a sole proprietorship for individuals.
-// According to Stripe: "we’re enforcing stricter business type requirements for Netherlands (NL)
-// accounts to ensure compliance with Dutch regulations. This specifically affects
-// how we collect the KvK (Kamer van Koophandel), the unique 8-digit company registration number
-// required for businesses in the Netherlands."
+// Netherlands used to require a sole proprietorship for individuals.
+// This code pattern is reflecting that requirement.
+// According to Stripe: "Starting May 14, 2026, connected accounts representing individuals or
+// unincorporated entities that don’t have access to a Stripe-hosted Dashboard are no longer
+// required to provide a KvK number.
+// Connected accounts representing individuals or unincorporated entities that have access to
+// the full Stripe Dashboard or the Express Dashboard must still provide a KvK number."
 // https://docs.stripe.com/connect/upcoming-requirements-updates?program=eu-2025#netherlands-business-registration-requirements
-const countriesRequiringSoleProprietorshipForIndividuals = new Set(['NL']);
+// Note: this code pattern can still be used by changing the set of countries to `new Set(['NL']);`
+// However, since Template works with custom Connect accounts, hiding Stripe dashboard,
+// the sole proprietorship requirement is not needed.
+const countriesRequiringSoleProprietorshipForIndividuals = new Set([]);
 
 /**
  * Whether Connect onboarding for an individual in this country must use a company account with
@@ -13,7 +18,7 @@ const countriesRequiringSoleProprietorshipForIndividuals = new Set(['NL']);
  * @param {string} country - ISO 3166-1 alpha-2 country code
  * @returns {boolean}
  */
-export const requiresSoleProprietorshipAccount = country =>
+const requiresSoleProprietorshipAccount = country =>
   countriesRequiringSoleProprietorshipForIndividuals.has(country);
 
 /**

--- a/src/util/stripeConnect.test.js
+++ b/src/util/stripeConnect.test.js
@@ -1,24 +1,17 @@
-import {
-  getDisplayAccountType,
-  getStripeAccountTokenInfo,
-  requiresSoleProprietorshipAccount,
-} from './stripeConnect';
+import { getDisplayAccountType, getStripeAccountTokenInfo } from './stripeConnect';
 
 describe('stripeConnect helpers', () => {
-  it('flags restricted countries that require sole proprietorship onboarding', () => {
-    expect(requiresSoleProprietorshipAccount('NL')).toBe(true);
-    expect(requiresSoleProprietorshipAccount('GB')).toBe(false);
-    expect(requiresSoleProprietorshipAccount('US')).toBe(false);
-  });
-
-  it('maps individual sellers in restricted countries to company sole proprietorship', () => {
-    expect(getStripeAccountTokenInfo({ country: 'NL', accountType: 'individual' })).toEqual({
-      business_type: 'company',
-      company: {
-        structure: 'sole_proprietorship',
-      },
-    });
-  });
+  // NOTE: this test is disabled because the sole proprietorship requirement is not needed for
+  // Template with custom Connect accounts, hiding Stripe dashboard.
+  //
+  // it('maps individual sellers in restricted countries to company sole proprietorship', () => {
+  //   expect(getStripeAccountTokenInfo({ country: 'NL', accountType: 'individual' })).toEqual({
+  //     business_type: 'company',
+  //     company: {
+  //       structure: 'sole_proprietorship',
+  //     },
+  //   });
+  // });
 
   it('keeps company sellers unchanged in restricted countries', () => {
     expect(getStripeAccountTokenInfo({ country: 'NL', accountType: 'company' })).toEqual({


### PR DESCRIPTION
Update Stripe Connect account requirements for Netherlands. Individual accounts are supported now for users without access to the Stripe dashboard (which is what our custom connect accounts are).