### PR TITLE
Improve topbar custom links menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [change] CustomLinksMenu: refactor rendering order to improve hydration behavior.
+  [#872](https://github.com/sharetribe/web-template/pull/872)
 - [change] Update Stripe Connect account requirements for Netherlands. Individual accounts are
   supported now for users without access to the Stripe dashboard.
   [#871](https://github.com/sharetribe/web-template/pull/871)

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
 
 import PriorityLinks, { CreateListingMenuLink } from './PriorityLinks';
 import LinksMenu from './LinksMenu';
@@ -120,8 +121,8 @@ const CustomLinksMenu = ({
   ]);
 
   const [layoutData, setLayoutData] = useState({
-    priorityLinks: links,
-    menuLinks: links,
+    priorityLinks: [],
+    menuLinks: [],
     containerWidth: 0,
   });
 
@@ -195,20 +196,32 @@ const CustomLinksMenu = ({
     return <CreateListingMenuLink customLinksMenuClass={css.createListingLinkOnly} />;
   }
 
-  const styleMaybe = mounted ? { style: { width: `${containerWidth}px` } } : {};
-  const isMeasured = !!links?.[0]?.width;
+  const linksMeasured = !!links?.[0]?.width;
+  const moreLabelMeasured = moreLabelWidth > 0;
+  const layoutComputed = containerWidth > 0;
+  const hasLinksToLayout = links.length > 0;
+  const layoutReady = !hasLinksToLayout || (linksMeasured && moreLabelMeasured && layoutComputed);
+
   const hasMenuLinks = menuLinks?.length > 0;
-  const hasPriorityLinks = isMeasured && priorityLinks.length > 0;
+  const hasPriorityLinks = linksMeasured && priorityLinks.length > 0;
+
+  // Render LinksMenu while measuring (hidden via layoutPending), then only when menu links exist.
+  const showLinksMenu = mounted && links.length > 0 && (!layoutReady || hasMenuLinks);
+
+  const containerClassName = classNames(css.customLinksMenu, {
+    [css.layoutPending]: !layoutReady,
+  });
+  const containerStyle = layoutReady ? { width: `${containerWidth}px` } : undefined;
 
   return (
-    <div className={css.customLinksMenu} ref={containerRef} {...styleMaybe}>
+    <div className={containerClassName} ref={containerRef} style={containerStyle}>
       <PriorityLinks links={links} priorityLinks={priorityLinks} setLinks={setLinks} />
-      {mounted && hasMenuLinks ? (
+      {showLinksMenu ? (
         <LinksMenu
           id="linksMenu"
           currentPage={currentPage}
-          links={menuLinks}
-          showMoreLabel={hasPriorityLinks}
+          links={layoutReady ? menuLinks : links}
+          showMoreLabel={layoutReady && hasPriorityLinks}
           moreLabelWidth={moreLabelWidth}
           setMoreLabelWidth={setMoreLabelWidth}
           intl={intl}

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.module.css
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/CustomLinksMenu.module.css
@@ -4,6 +4,9 @@
   justify-content: right;
   height: 100%;
 }
+.layoutPending {
+  visibility: hidden;
+}
 .createListingLinkOnly {
   display: flex;
   justify-content: right;

--- a/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/PriorityLinks.js
+++ b/src/containers/TopbarContainer/Topbar/TopbarDesktop/CustomLinksMenu/PriorityLinks.js
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef } from 'react';
-import ReactDOM from 'react-dom';
 import classNames from 'classnames';
 
 import { FormattedMessage } from '../../../../../util/reactIntl';
@@ -83,7 +82,6 @@ const PriorityLinks = props => {
   }, [containerRef]);
 
   const { links, priorityLinks } = props;
-  const isServer = typeof window === 'undefined';
   const isMeasured = links?.[0]?.width && (priorityLinks.length === 0 || priorityLinks?.[0]?.width);
   const styleWrapper = !!isMeasured
     ? {}
@@ -100,21 +98,14 @@ const PriorityLinks = props => {
       };
   const linkConfigs = isMeasured ? priorityLinks : links;
 
-  return isMeasured || isServer ? (
+  // Always render inline in the Topbar tree so SSR and the initial client render match.
+  // (Portaling to document.body caused hydration mismatches.)
+  return (
     <div className={css.priorityLinkWrapper} {...styleWrapper} ref={containerRef}>
       {linkConfigs.map((linkConfig, index) => {
         return <PriorityLink key={`${linkConfig.text}_${index}`} linkConfig={linkConfig} />;
       })}
     </div>
-  ) : (
-    ReactDOM.createPortal(
-      <div className={css.priorityLinkWrapper} {...styleWrapper} ref={containerRef}>
-        {linkConfigs.map((linkConfig, index) => {
-          return <PriorityLink key={`${linkConfig.text}_${index}`} linkConfig={linkConfig} />;
-        })}
-      </div>,
-      document.body
-    )
   );
 };
 


### PR DESCRIPTION
- PriorityLinks: render inline in the Topbar so SSR and the initial client render match.
- CustomLinksMenu: make empty initial layout and then gate the render with layoutReady