### PR TITLE
Remove locales used by Moment.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [change] Remove locales used by Moment.js. Those files were originally used by react-dates
+  dependency library, which is no longer used.
+  [#879](https://github.com/sharetribe/web-template/pull/879)
 - [change] Update sharetribe-flex-sdk to v1.24.1.
   [#886](https://github.com/sharetribe/web-template/pull/886)
 - [add] Add currently available translations for DE, ES, FR.

--- a/src/app.js
+++ b/src/app.js
@@ -35,7 +35,7 @@ import defaultMessages from './translations/en.json';
 // If you want to change the language of default (fallback) translations,
 // change the imports to match the wanted locale:
 //
-//   1) Change the language in the config.js file!
+//   1) Change the language in Console (/general/localization) and the fallback in configDefault.js
 //   2) Use the `messagesInLocale` import to add the correct translation file.
 //   3) (optionally) To support older browsers you need add the intl-relativetimeformat npm packages
 //      and take it into use in `util/polyfills.js`
@@ -47,8 +47,7 @@ import defaultMessages from './translations/en.json';
 // Step 2:
 // The "./translations/en.json" has generic English translations
 // that should work as a default translation if some translation keys are missing
-// from the hosted translation.json (which can be edited in Console). The other files
-// (e.g. en.json) in that directory has Biketribe themed translations.
+// from the hosted translation.json (which can be edited in Console).
 //
 // If you are using a non-english locale, point `messagesInLocale` to correct <lang>.json file.
 // That way the priority order would be:

--- a/src/app.js
+++ b/src/app.js
@@ -2,8 +2,6 @@ import React, { useEffect } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
 import { BrowserRouter, StaticRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
-import loadable from '@loadable/component';
-import moment from 'moment';
 
 // Configs and store setup
 import defaultConfig from './config/configDefault';
@@ -38,9 +36,8 @@ import defaultMessages from './translations/en.json';
 // change the imports to match the wanted locale:
 //
 //   1) Change the language in the config.js file!
-//   2) Import correct locale rules for Moment library
-//   3) Use the `messagesInLocale` import to add the correct translation file.
-//   4) (optionally) To support older browsers you need add the intl-relativetimeformat npm packages
+//   2) Use the `messagesInLocale` import to add the correct translation file.
+//   3) (optionally) To support older browsers you need add the intl-relativetimeformat npm packages
 //      and take it into use in `util/polyfills.js`
 
 // Note that there is also translations in './translations/countryCodes.js' file
@@ -48,16 +45,6 @@ import defaultMessages from './translations/en.json';
 // This used to collect billing address in StripePaymentAddress on CheckoutPage
 
 // Step 2:
-// If you are using a non-english locale with moment library,
-// you should also import time specific formatting rules for that locale
-// There are 2 ways to do it:
-// - you can add your preferred locale to MomentLocaleLoader or
-// - stop using MomentLocaleLoader component and directly import the locale here.
-// E.g. for French:
-// import 'moment/locale/fr';
-// const hardCodedLocale = process.env.NODE_ENV === 'test' ? 'en' : 'fr';
-
-// Step 3:
 // The "./translations/en.json" has generic English translations
 // that should work as a default translation if some translation keys are missing
 // from the hosted translation.json (which can be edited in Console). The other files
@@ -104,56 +91,13 @@ const localeMessages = isTestEnv
   ? Object.fromEntries(Object.entries(defaultMessages).map(([key]) => [key, key]))
   : addMissingTranslations(defaultMessages, messagesInLocale);
 
-// For customized apps, this dynamic loading of locale files is not necessary.
-// It helps locale change from configDefault.js file or hosted configs, but customizers should probably
-// just remove this and directly import the necessary locale on step 2.
-const MomentLocaleLoader = props => {
-  const { children, locale } = props;
-  const isAlreadyImportedLocale =
-    typeof hardCodedLocale !== 'undefined' && locale === hardCodedLocale;
-
-  // Moment's built-in locale does not need loader
-  const NoLoader = props => <>{props.children()}</>;
-
-  // The default locale is en (en-US). Here we dynamically load one of the other common locales.
-  // However, the default is to include all supported locales package from moment library.
-  const MomentLocale =
-    ['en', 'en-US'].includes(locale) || isAlreadyImportedLocale
-      ? NoLoader
-      : ['fr', 'fr-FR'].includes(locale)
-      ? loadable.lib(() => import(/* webpackChunkName: "fr" */ 'moment/locale/fr'))
-      : ['de', 'de-DE'].includes(locale)
-      ? loadable.lib(() => import(/* webpackChunkName: "de" */ 'moment/locale/de'))
-      : ['es', 'es-ES'].includes(locale)
-      ? loadable.lib(() => import(/* webpackChunkName: "es" */ 'moment/locale/es'))
-      : ['fi', 'fi-FI'].includes(locale)
-      ? loadable.lib(() => import(/* webpackChunkName: "fi" */ 'moment/locale/fi'))
-      : ['nl', 'nl-NL'].includes(locale)
-      ? loadable.lib(() => import(/* webpackChunkName: "nl" */ 'moment/locale/nl'))
-      : loadable.lib(() => import(/* webpackChunkName: "locales" */ 'moment/min/locales.min'));
-
-  return (
-    <MomentLocale>
-      {() => {
-        // Set the Moment locale globally
-        // See: http://momentjs.com/docs/#/i18n/changing-locale/
-        moment.locale(locale);
-        return children;
-      }}
-    </MomentLocale>
-  );
-};
-
 const Configurations = props => {
   const { appConfig, children } = props;
   const routeConfig = routeConfiguration(appConfig.layout, appConfig?.accessControl);
-  const locale = isTestEnv ? 'en' : appConfig.localization.locale;
 
   return (
     <ConfigurationProvider value={appConfig}>
-      <MomentLocaleLoader locale={locale}>
-        <RouteConfigurationProvider value={routeConfig}>{children}</RouteConfigurationProvider>
-      </MomentLocaleLoader>
+      <RouteConfigurationProvider value={routeConfig}>{children}</RouteConfigurationProvider>
     </ConfigurationProvider>
   );
 };

--- a/src/containers/TransactionPage/ActivityFeed/ActivityFeed.js
+++ b/src/containers/TransactionPage/ActivityFeed/ActivityFeed.js
@@ -255,7 +255,9 @@ export const ActivityFeed = props => {
   const items = organizedItems(messages, relevantTransitions, hideOldTransitions);
 
   const messageListItem = message => {
-    const formattedDate = formatDateWithProximity(message.attributes.createdAt, intl, todayString);
+    const formattedDate = formatDateWithProximity(message.attributes.createdAt, intl, todayString, {
+      firstDayOfWeek: config.localization.firstDayOfWeek,
+    });
     const isOwnMessage = currentUser?.id && message?.sender?.id?.uuid === currentUser.id?.uuid;
     const messageComponent = isOwnMessage ? (
       <OwnMessage
@@ -289,7 +291,9 @@ export const ActivityFeed = props => {
   };
 
   const transitionListItem = transition => {
-    const formattedDate = formatDateWithProximity(transition.createdAt, intl, todayString);
+    const formattedDate = formatDateWithProximity(transition.createdAt, intl, todayString, {
+      firstDayOfWeek: config.localization.firstDayOfWeek,
+    });
     const { customer, provider, listing } = transaction || {};
 
     // Initially transition component is empty;

--- a/src/util/dates.js
+++ b/src/util/dates.js
@@ -481,7 +481,9 @@ const getTimeZoneMaybe = timeZone => {
  * @param {Date} date Date to be formatted
  * @param {Object} intl Intl object from react-intl
  * @param {String} todayString translation for the current day
- * @param {Object} [opts] options. Can be used to pass in timeZone. It should represent IANA time zone key.
+ * @param {Object} [opts] options. Can be used to pass in timeZone and firstDayOfWeek.
+ * @param {String} [opts.timeZone] IANA time zone key
+ * @param {0|1|2|3|4|5|6} [opts.firstDayOfWeek] first day of week (0=Sun ... 6=Sat). Defaults to 0.
  *
  * @returns {String} formatted date
  */
@@ -492,7 +494,7 @@ export const formatDateWithProximity = (date, intl, todayString, opts = {}) => {
   }
 
   // If timeZone parameter is set, use it as formatting option
-  const { timeZone } = opts;
+  const { timeZone, firstDayOfWeek = 0 } = opts;
   const timeZoneMaybe = getTimeZoneMaybe(timeZone);
 
   // By default we can use moment() directly but in tests we need to use a specific dates.
@@ -501,6 +503,12 @@ export const formatDateWithProximity = (date, intl, todayString, opts = {}) => {
 
   // isSame: if the two moments have different time zones, the time zone of the first moment will be used for the comparison.
   const localizedNow = timeZoneMaybe.timeZone ? now.tz(timeZone) : now;
+  const nowDate = localizedNow.toDate();
+
+  // Same calendar week using marketplace firstDayOfWeek (not Moment's locale week).
+  const isSameWeek =
+    getStartOfWeek(nowDate, timeZone, firstDayOfWeek).getTime() ===
+    getStartOfWeek(date, timeZone, firstDayOfWeek).getTime();
 
   if (localizedNow.isSame(date, 'day')) {
     // e.g. "Today, 9:10 PM"
@@ -510,7 +518,7 @@ export const formatDateWithProximity = (date, intl, todayString, opts = {}) => {
       ...timeZoneMaybe,
     });
     return `${todayString}, ${formattedTime}`;
-  } else if (localizedNow.isSame(date, 'week')) {
+  } else if (isSameWeek) {
     // e.g.
     // en-US: "Sun 6:02 PM"
     // en-GB: "Sun 18:02"

--- a/src/util/dates.js
+++ b/src/util/dates.js
@@ -320,6 +320,11 @@ export const timeOfDayFromTimeZoneToLocal = (date, timeZone) => {
 /**
  * Get start of time unit (e.g. start of day)
  *
+ * Note: Do not use unit "week" here. Moment's startOf('week') depends on the
+ * locale set for the moment library, which the Webpack build strips out.
+ * ../../config/webpack.config.js (Line ~641).
+ * Use getStartOfWeek(date, timeZone, firstDayOfWeek) instead.
+ *
  * @param {Date} date date instance to be converted
  * @param {String} unit time-unit (e.g. "day")
  * @param {String} timeZone time zone id

--- a/src/util/dates.test.js
+++ b/src/util/dates.test.js
@@ -222,6 +222,16 @@ describe('date utils', () => {
         'Wed 1:51 PM'
       );
     });
+    it('uses firstDayOfWeek when deciding same week vs same year', () => {
+      // intl.now is Thu 2017-11-23; 2017-11-19 is the previous Sunday
+      const d = new Date(Date.UTC(2017, 10, 19, 13, 51));
+      expect(
+        formatDateWithProximity(d, intl, 'Today', { timeZone: 'Etc/UTC', firstDayOfWeek: 0 })
+      ).toEqual('Sun 1:51 PM');
+      expect(
+        formatDateWithProximity(d, intl, 'Today', { timeZone: 'Etc/UTC', firstDayOfWeek: 1 })
+      ).toEqual('Nov 19, 1:51 PM');
+    });
     it('formats a date on same year', () => {
       const d = new Date(Date.UTC(2017, 10, 2, 13, 51));
       expect(formatDateWithProximity(d, intl, 'Today', { timeZone: 'Etc/UTC' })).toEqual(


### PR DESCRIPTION
Moment's own locale files were originally used by `react-dates` dependency library.
That library has been removed a long time ago and, instead, we have used React Intl library for localized date-strings.

This PR removes the last usage where moment's locale files were relied on (same week check inside formatDateWithProximity function) and removes those unnecessary code-splitted locale imports.

**Note**: if you have used 'week' unit with `getStartOf` dates helper, you might want to start using `getStartOfWeek` helper instead - or you need to customize the `getStartOf` so that it gets firstDayOfWeek config through some parameter. (perhaps a new parameter called "options").