### PR TITLE
AuthenticationPage: Auth thunks use .unwrap(), so failures reject.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] Catch auth thunk rejections to avoid React development overlay.
+  [#882](https://github.com/sharetribe/web-template/pull/882)
 - [fix] Fix negotiation email templates
   [#878](https://github.com/sharetribe/web-template/pull/878)
 - [fix] Fix typo in a default-download email template

--- a/src/containers/AuthenticationPage/AuthenticationPage.js
+++ b/src/containers/AuthenticationPage/AuthenticationPage.js
@@ -535,14 +535,22 @@ const AuthenticationPage = props => {
     [entities]
   );
 
-  const submitLogin = useCallback(({ email, password }) => dispatch(login(email, password)), [
-    dispatch,
-  ]);
-  const submitSignup = useCallback(params => dispatch(signup(params)), [dispatch]);
-  const submitSingupWithIdp = useCallback(params => dispatch(signupWithIdp(params)), [dispatch]);
-  const onResendVerificationEmail = useCallback(() => dispatch(sendVerificationEmail()), [
-    dispatch,
-  ]);
+  // Auth thunks use .unwrap(), so failures reject. Swallow those here: the forms
+  // already render loginError / signupError / confirmError from Redux (same as
+  // pre-RTK thunks, which caught inside the duck and did not reject).
+  const submitLogin = useCallback(
+    ({ email, password }) => dispatch(login(email, password)).catch(() => {}),
+    [dispatch]
+  );
+  const submitSignup = useCallback(params => dispatch(signup(params)).catch(() => {}), [dispatch]);
+  const submitSingupWithIdp = useCallback(
+    params => dispatch(signupWithIdp(params)).catch(() => {}),
+    [dispatch]
+  );
+  const onResendVerificationEmail = useCallback(
+    () => dispatch(sendVerificationEmail()).catch(() => {}),
+    [dispatch]
+  );
   const onManageDisableScrolling = useCallback(
     (componentId, disableScrolling) =>
       dispatch(manageDisableScrolling(componentId, disableScrolling)),


### PR DESCRIPTION
Localhost:3000 shows error panel because of those uncaught errors.