### PR TITLE
New release v12.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+## [v12.1.0] 2026-07-27
+
 - [change] Remove locales used by Moment.js. Those files were originally used by react-dates
   dependency library, which is no longer used.
   [#879](https://github.com/sharetribe/web-template/pull/879)
@@ -30,6 +32,8 @@ way to update this template, but currently, we follow a pattern:
 - [fix] Fix negotiation email templates [#878](https://github.com/sharetribe/web-template/pull/878)
 - [fix] Fix typo in a default-download email template
   [#877](https://github.com/sharetribe/web-template/pull/877)
+
+  [v12.1.0]: https://github.com/sharetribe/web-template/compare/v12.0.0...v12.1.0
 
 ## [v12.0.0] 2026-07-14
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "12.0.0",
+  "version": "12.1.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
Several updates and fixes. A couple of highlights:
- Add manual download link option to files [#883](https://github.com/sharetribe/web-template/pull/883)
- Remove locales used by Moment.js. Those files were originally used by react-dates
  dependency library, which is no longer used.[#879](https://github.com/sharetribe/web-template/pull/879)

## Translations
**Completely new translations:**
```diff
+   "FileAttachments.downloadFileFallback": "If the download didn't start, {link}.",
+   "FileAttachments.downloadFileFallbackLink": "click this link instead",
```

There were 4 translation keys marked for a wrong component after the introduction of FileAttachments component (v12)

**Removed keys:**
```diff
-   "Message.downloadFile": "Download file {fileName}",
-   "Message.fileDeleted": "Deleted file.",
-   "Message.fileSecurityCheckFailed": "Security check failed. Please contact support.",
-   "Message.fileVerifying": "Scanning the file…",
```

**New keys:**
```diff
+   "FileAttachments.downloadFile": "Download file {fileName}",
+   "FileAttachments.fileDeleted": "Deleted file.",
+   "FileAttachments.fileSecurityCheckFailed": "Security check failed. Please contact support.",
+   "FileAttachments.fileVerifying": "Scanning the file…",
```

## [Changes] v12.1.0

- [change] Remove locales used by Moment.js. Those files were originally used by react-dates
  dependency library, which is no longer used.
  [#879](https://github.com/sharetribe/web-template/pull/879)
- [change] Update sharetribe-flex-sdk to v1.24.1.
  [#886](https://github.com/sharetribe/web-template/pull/886)
- [add] Add currently available translations for DE, ES, FR.
  [#885](https://github.com/sharetribe/web-template/pull/885)
- [add] Add manual download link option to files.
  [#883](https://github.com/sharetribe/web-template/pull/883)
- [change] server/log.js: omit not-found listings from Sentry errors
  [#881](https://github.com/sharetribe/web-template/pull/881)
- [fix] Catch auth thunk rejections to avoid React development overlay.
  [#882](https://github.com/sharetribe/web-template/pull/882)
- [fix] Fix negotiation email templates [#878](https://github.com/sharetribe/web-template/pull/878)
- [fix] Fix typo in a default-download email template
  [#877](https://github.com/sharetribe/web-template/pull/877)

  [Changes]: https://github.com/sharetribe/web-template/compare/v12.0.0...v12.1.0
