### PR TITLE
Harden Mapbox loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] Harden Mapbox loading [#890](https://github.com/sharetribe/web-template/pull/890)
+
 ## [v12.1.0] 2026-07-27
 
 - [change] Remove locales used by Moment.js. Those files were originally used by react-dates

--- a/src/components/LocationAutocompleteInput/GeocoderMapbox.js
+++ b/src/components/LocationAutocompleteInput/GeocoderMapbox.js
@@ -75,7 +75,10 @@ class GeocoderMapbox {
     if (!libLoaded) {
       throw new Error('Mapbox libraries are required for GeocoderMapbox');
     }
-    if (!this._client && window?.mapboxgl?.accessToken) {
+    if (!window.mapboxgl.accessToken) {
+      throw new Error('Mapbox access token is not yet available');
+    }
+    if (!this._client) {
       this._client = window.mapboxSdk({
         accessToken: window.mapboxgl.accessToken,
       });

--- a/src/util/includeScripts.js
+++ b/src/util/includeScripts.js
@@ -245,6 +245,42 @@ export const IncludeScripts = props => {
     };
   }, [stripe?.publishableKey]);
 
+  // The render-time assignment above (isMapboxLoaded check) and onChangeClientState's
+  // 'load' listener both miss one case: on a server-rendered page, the mapbox-gl.js
+  // script tag already exists in the initial HTML with the same Helmet-managed
+  // attributes React would render on hydration, so React Helmet Async treats it as
+  // unchanged and never reports it through onChangeClientState's addedTags - the
+  // 'load' listener above is never attached to it. This effect closes that gap by
+  // checking directly against the DOM/window on mount, independent of Helmet's
+  // added/removed tag diffing.
+  useEffect(() => {
+    if (!isMapboxInUse || typeof window === 'undefined') {
+      return undefined;
+    }
+
+    const assignAccessToken = () => {
+      if (window.mapboxgl && !window.mapboxgl.accessToken) {
+        window.mapboxgl.accessToken = mapboxAccessToken;
+      }
+    };
+
+    assignAccessToken();
+
+    if (window.mapboxgl) {
+      return undefined;
+    }
+
+    const script = document.getElementById(MAPBOX_SCRIPT_ID);
+    if (!script) {
+      return undefined;
+    }
+
+    script.addEventListener('load', assignAccessToken, { once: true });
+    return () => {
+      script.removeEventListener('load', assignAccessToken);
+    };
+  }, [isMapboxInUse, mapboxAccessToken]);
+
   const allScripts = [...stripeLibrary, ...analyticsLibraries, ...mapLibraries];
   return <Helmet onChangeClientState={onChangeClientState}>{allScripts}</Helmet>;
 };


### PR DESCRIPTION
Fix an issue where a full page load might leave the Mapbox token unassigned: on a full page load (SSR + hydration) where the browser hasn't finished downloading/executing the external `mapbox-gl.js` script in `includeScripts.js` by the exact moment `IncludeScripts` first renders client-side, `window.mapboxgl.accessToken` never gets set for the rest of that page's lifetime.

The associated error that this fix is addressing is `TypeError: Cannot read properties of undefined (reading 'geocoding')`

