### PR TITLE
Improve accessibility pagination links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [change] PaginationLinks: turn the container into a list to improve accessibility.
+  [#891](https://github.com/sharetribe/web-template/pull/891)
 - [change] Topbar/PriorityLinks: turn the container into a list to improve accessibility.
   [#888](https://github.com/sharetribe/web-template/pull/888)
 - [fix] Harden Mapbox loading [#890](https://github.com/sharetribe/web-template/pull/890)

--- a/src/components/PaginationLinks/PaginationLinks.js
+++ b/src/components/PaginationLinks/PaginationLinks.js
@@ -133,21 +133,26 @@ export const PaginationLinks = props => {
     const isCurrentPage = v === page;
     const pageClassNames = classNames(css.toPageLink, { [css.currentPage]: isCurrentPage });
     return typeof v === 'number' ? (
-      <NamedLink
-        key={v}
-        className={pageClassNames}
-        name={pageName}
-        params={pagePathParams}
-        to={{ search: stringify({ ...pageSearchParams, page: v }) }}
-        title={intl.formatMessage({ id: 'PaginationLinks.toPage' }, { page: v })}
-        ariaLabel={intl.formatMessage({ id: 'PaginationLinks.toPage' }, { page: v })}
+      <li key={v} className={css.pageNumberListItem}>
+        <NamedLink
+          className={pageClassNames}
+          name={pageName}
+          params={pagePathParams}
+          to={{ search: stringify({ ...pageSearchParams, page: v }) }}
+          title={intl.formatMessage({ id: 'PaginationLinks.toPage' }, { page: v })}
+          ariaLabel={intl.formatMessage({ id: 'PaginationLinks.toPage' }, { page: v })}
+        >
+          {v}
+        </NamedLink>
+      </li>
+    ) : (
+      <li
+        key={`pagination_gap_${paginationGapKey()}`}
+        className={classNames(css.pageNumberListItem, css.paginationGap)}
+        aria-hidden="true"
       >
         {v}
-      </NamedLink>
-    ) : (
-      <span key={`pagination_gap_${paginationGapKey()}`} className={css.paginationGap}>
-        {v}
-      </span>
+      </li>
     );
   });
 
@@ -163,7 +168,7 @@ export const PaginationLinks = props => {
   return (
     <nav className={classes}>
       {prevPage ? prevLinkEnabled : prevLinkDisabled}
-      <div className={pageNumberListClassNames}>{pageNumbersNavLinks}</div>
+      <ul className={pageNumberListClassNames}>{pageNumbersNavLinks}</ul>
       {nextPage ? nextLinkEnabled : nextLinkDisabled}
     </nav>
   );

--- a/src/components/PaginationLinks/PaginationLinks.module.css
+++ b/src/components/PaginationLinks/PaginationLinks.module.css
@@ -46,6 +46,19 @@
 .pageNumberList {
   display: flex;
   justify-content: space-between;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+/* Override global `li` padding from marketplaceDefaults.*/
+.pageNumberListItem {
+  display: flex;
+  padding: 0;
+
+  @media (--viewportMedium) {
+    padding: 0;
+  }
 }
 
 /**

--- a/src/components/PaginationLinks/__snapshots__/PaginationLinks.test.js.snap
+++ b/src/components/PaginationLinks/__snapshots__/PaginationLinks.test.js.snap
@@ -21,18 +21,22 @@ exports[`PaginationLinks should match snapshot with both links disabled 1`] = `
       />
     </svg>
   </div>
-  <div
+  <ul
     class="pageNumberList pageNumberList1Items"
   >
-    <a
-      aria-label="PaginationLinks.toPage"
-      class="toPageLink currentPage"
-      href="/s?page=1&param=foobar"
-      title="PaginationLinks.toPage"
+    <li
+      class="pageNumberListItem"
     >
-      1
-    </a>
-  </div>
+      <a
+        aria-label="PaginationLinks.toPage"
+        class="toPageLink currentPage"
+        href="/s?page=1&param=foobar"
+        title="PaginationLinks.toPage"
+      >
+        1
+      </a>
+    </li>
+  </ul>
   <div
     class="next"
   >
@@ -77,34 +81,46 @@ exports[`PaginationLinks should match snapshot with both links enabled 1`] = `
       />
     </svg>
   </a>
-  <div
+  <ul
     class="pageNumberList pageNumberList3Items"
   >
-    <a
-      aria-label="PaginationLinks.toPage"
-      class="toPageLink"
-      href="/s?page=1&param=foobar"
-      title="PaginationLinks.toPage"
+    <li
+      class="pageNumberListItem"
     >
-      1
-    </a>
-    <a
-      aria-label="PaginationLinks.toPage"
-      class="toPageLink currentPage"
-      href="/s?page=2&param=foobar"
-      title="PaginationLinks.toPage"
+      <a
+        aria-label="PaginationLinks.toPage"
+        class="toPageLink"
+        href="/s?page=1&param=foobar"
+        title="PaginationLinks.toPage"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="pageNumberListItem"
     >
-      2
-    </a>
-    <a
-      aria-label="PaginationLinks.toPage"
-      class="toPageLink"
-      href="/s?page=3&param=foobar"
-      title="PaginationLinks.toPage"
+      <a
+        aria-label="PaginationLinks.toPage"
+        class="toPageLink currentPage"
+        href="/s?page=2&param=foobar"
+        title="PaginationLinks.toPage"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="pageNumberListItem"
     >
-      3
-    </a>
-  </div>
+      <a
+        aria-label="PaginationLinks.toPage"
+        class="toPageLink"
+        href="/s?page=3&param=foobar"
+        title="PaginationLinks.toPage"
+      >
+        3
+      </a>
+    </li>
+  </ul>
   <a
     aria-label="PaginationLinks.next"
     class="next"
@@ -149,34 +165,46 @@ exports[`PaginationLinks should match snapshot with prev disabled and next enabl
       />
     </svg>
   </div>
-  <div
+  <ul
     class="pageNumberList pageNumberList3Items"
   >
-    <a
-      aria-label="PaginationLinks.toPage"
-      class="toPageLink currentPage"
-      href="/s?page=1&param=foobar"
-      title="PaginationLinks.toPage"
+    <li
+      class="pageNumberListItem"
     >
-      1
-    </a>
-    <a
-      aria-label="PaginationLinks.toPage"
-      class="toPageLink"
-      href="/s?page=2&param=foobar"
-      title="PaginationLinks.toPage"
+      <a
+        aria-label="PaginationLinks.toPage"
+        class="toPageLink currentPage"
+        href="/s?page=1&param=foobar"
+        title="PaginationLinks.toPage"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="pageNumberListItem"
     >
-      2
-    </a>
-    <a
-      aria-label="PaginationLinks.toPage"
-      class="toPageLink"
-      href="/s?page=3&param=foobar"
-      title="PaginationLinks.toPage"
+      <a
+        aria-label="PaginationLinks.toPage"
+        class="toPageLink"
+        href="/s?page=2&param=foobar"
+        title="PaginationLinks.toPage"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="pageNumberListItem"
     >
-      3
-    </a>
-  </div>
+      <a
+        aria-label="PaginationLinks.toPage"
+        class="toPageLink"
+        href="/s?page=3&param=foobar"
+        title="PaginationLinks.toPage"
+      >
+        3
+      </a>
+    </li>
+  </ul>
   <a
     aria-label="PaginationLinks.next"
     class="next"
@@ -224,34 +252,46 @@ exports[`PaginationLinks should match snapshot with prev enabled and next disabl
       />
     </svg>
   </a>
-  <div
+  <ul
     class="pageNumberList pageNumberList3Items"
   >
-    <a
-      aria-label="PaginationLinks.toPage"
-      class="toPageLink"
-      href="/s?page=1&param=foobar"
-      title="PaginationLinks.toPage"
+    <li
+      class="pageNumberListItem"
     >
-      1
-    </a>
-    <a
-      aria-label="PaginationLinks.toPage"
-      class="toPageLink"
-      href="/s?page=2&param=foobar"
-      title="PaginationLinks.toPage"
+      <a
+        aria-label="PaginationLinks.toPage"
+        class="toPageLink"
+        href="/s?page=1&param=foobar"
+        title="PaginationLinks.toPage"
+      >
+        1
+      </a>
+    </li>
+    <li
+      class="pageNumberListItem"
     >
-      2
-    </a>
-    <a
-      aria-label="PaginationLinks.toPage"
-      class="toPageLink currentPage"
-      href="/s?page=3&param=foobar"
-      title="PaginationLinks.toPage"
+      <a
+        aria-label="PaginationLinks.toPage"
+        class="toPageLink"
+        href="/s?page=2&param=foobar"
+        title="PaginationLinks.toPage"
+      >
+        2
+      </a>
+    </li>
+    <li
+      class="pageNumberListItem"
     >
-      3
-    </a>
-  </div>
+      <a
+        aria-label="PaginationLinks.toPage"
+        class="toPageLink currentPage"
+        href="/s?page=3&param=foobar"
+        title="PaginationLinks.toPage"
+      >
+        3
+      </a>
+    </li>
+  </ul>
   <div
     class="next"
   >


### PR DESCRIPTION
PaginationLinks: turn the link container into a `<ul>` list to improve accessibility.