### PR TITLE
InboxSearchForm does not have submit button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] InboxSortForm does not have submit button so we warn the user about immediate change of
+  content after sort input has been changed.
+  [#892](https://github.com/sharetribe/web-template/pull/892)
 - [fix] EditListingPricingPanel: initialValues.price was not there with priceVariants.
   [#892](https://github.com/sharetribe/web-template/pull/893)
 - [change] Update CircleCI config to v2.1.

--- a/src/containers/InboxPage/InboxSearchForm/InboxSearchForm.js
+++ b/src/containers/InboxPage/InboxSearchForm/InboxSearchForm.js
@@ -41,7 +41,12 @@ const InboxSearchForm = props => {
         const classes = classNames(rootClassName || css.root, className);
 
         return (
-          <Form onSubmit={handleSubmit} className={classes}>
+          <Form
+            onSubmit={handleSubmit}
+            className={classes}
+            role="search"
+            aria-label={intl.formatMessage({ id: 'InboxSearchForm.screenreader.label' })}
+          >
             <div className={css.sortyByWrapper}>
               <span className={css.sortyBy}>
                 <FormattedMessage id="InboxSearchForm.sortLabel" />

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -559,6 +559,7 @@
   "InboxPage.sortBy.lastMessageAt": "Latest message",
   "InboxPage.sortBy.lastTransitionedAt": "Latest status change",
   "InboxPage.title": "Inbox",
+  "InboxSearchForm.screenreader.label": "Sort options for inbox. The inbox updates automatically when you select an option.",
   "InboxSearchForm.sortLabel": "Sort by:",
   "InquiryForm.heading": "Inquire about {listingTitle}",
   "InquiryForm.messageLabel": "Message to {authorDisplayName}",


### PR DESCRIPTION
and we don't want to add one. Instead, we default to rule G13 by adding aria-label that warns before they change the sort order.

https://www.w3.org/WAI/WCAG22/Techniques/general/G13

## Translations added
```diff
+   "InboxSearchForm.screenreader.label": "Sort options for inbox. The inbox updates automatically when you select an option.",
```