### PR TITLE
AvailabilityPlanEntry: fix delete button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] EditListingAvailabilityPlanForm: add screenreader text for delete button and make it a
+  semantic button. [#901](https://github.com/sharetribe/web-template/pull/901)
 - [change] Update moment-timezone: 0.6.2. > 0.6.3 (also dependabot were earlier updating lodash and
   tmp) [#900](https://github.com/sharetribe/web-template/pull/900)
 - [fix] InboxSortForm does not have submit button so we warn the user about immediate change of

--- a/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/EditListingAvailabilityPlanForm/AvailabilityPlanEntries.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/EditListingAvailabilityPlanForm/AvailabilityPlanEntries.js
@@ -186,6 +186,7 @@ const getEntryBoundaries = (entries, findStartHours) => index => {
  * @component
  * @param {Object} props - The component props
  * @param {string} props.name - the name of the form field/input
+ * @param {string} props.dayOfWeek - the shorthand for the day of week. E.g. 'mon'
  * @param {Number} props.index - the index in the Final Form Array for the current dayOfWeek
  * @param {Array<String>} props.availableStartHours - array of strings represeting start hours: '00:00', '01:00', etc.
  * @param {Array<String>} props.availableEndHours - array of strings represeting end hours: '01:00', '02:00', etc.
@@ -201,6 +202,7 @@ const getEntryBoundaries = (entries, findStartHours) => index => {
 const TimeRangeSelects = props => {
   const {
     name,
+    dayOfWeek,
     index,
     availableStartHours,
     availableEndHours,
@@ -212,6 +214,20 @@ const TimeRangeSelects = props => {
     useMultipleSeats,
     intl,
   } = props;
+  const entry = entries[index];
+  const dayLabel = intl.formatMessage({
+    id: `EditListingAvailabilityPlanForm.dayOfWeek.${dayOfWeek}`,
+  });
+  const hasTimeRange = Boolean(entry?.startTime && entry?.endTime);
+  const deleteAriaLabel = intl.formatMessage(
+    { id: 'EditListingAvailabilityPlanForm.screenreader.deleteEntry' },
+    {
+      dayOfWeek: dayLabel,
+      hasTimeRange: hasTimeRange ? 'yes' : 'no',
+      startTime: hasTimeRange ? localizedHourStrings(entry.startTime, intl) : null,
+      endTime: hasTimeRange ? localizedHourStrings(entry.endTime, intl) : null,
+    }
+  );
   return (
     <div className={css.segmentWrapper} key={name}>
       <div className={css.segment}>
@@ -281,7 +297,12 @@ const TimeRangeSelects = props => {
       ) : (
         <FieldHidden name={`${name}.seats`} value={1} />
       )}
-      <InlineTextButton rootClassName={css.fieldArrayDelete} type="button" onClick={onRemove}>
+      <InlineTextButton
+        rootClassName={css.fieldArrayDelete}
+        type="button"
+        onClick={onRemove}
+        aria-label={deleteAriaLabel}
+      >
         <IconDelete rootClassName={css.deleteIcon} />
         <FormattedMessage id="EditListingAvailabilityPlanForm.delete" />
       </InlineTextButton>
@@ -449,6 +470,7 @@ const AvailabilityPlanEntries = props => {
                   <TimeRangeSelects
                     key={name}
                     name={name}
+                    dayOfWeek={dayOfWeek}
                     index={index}
                     useMultipleSeats={useMultipleSeats}
                     availableStartHours={availableStartHours}

--- a/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/EditListingAvailabilityPlanForm/AvailabilityPlanEntries.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/EditListingAvailabilityPlanForm/AvailabilityPlanEntries.js
@@ -281,10 +281,10 @@ const TimeRangeSelects = props => {
       ) : (
         <FieldHidden name={`${name}.seats`} value={1} />
       )}
-      <div className={css.fieldArrayDelete} onClick={onRemove} style={{ cursor: 'pointer' }}>
+      <InlineTextButton rootClassName={css.fieldArrayDelete} type="button" onClick={onRemove}>
         <IconDelete rootClassName={css.deleteIcon} />
         <FormattedMessage id="EditListingAvailabilityPlanForm.delete" />
-      </div>
+      </InlineTextButton>
     </div>
   );
 };

--- a/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/EditListingAvailabilityPlanForm/AvailabilityPlanEntries.module.css
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingAvailabilityPanel/EditListingAvailabilityPlanForm/AvailabilityPlanEntries.module.css
@@ -146,6 +146,16 @@
 }
 
 .fieldArrayDelete {
+  /* Reset <button> defaults; keep appearance of the previous non-button control */
+  display: inline;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  letter-spacing: inherit;
+  text-decoration: none;
   cursor: pointer;
 
   &:hover {

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -232,6 +232,7 @@
   "EditListingAvailabilityPlanForm.hoursOfOperationTitle": "Weekly default schedule",
   "EditListingAvailabilityPlanForm.plus1Day": "+1 day",
   "EditListingAvailabilityPlanForm.saveSchedule": "Save schedule",
+  "EditListingAvailabilityPlanForm.screenreader.deleteEntry": "{hasTimeRange, select, yes {Delete {startTime} to {endTime} from {dayOfWeek} availability} other {Delete {dayOfWeek} availability entry}}",
   "EditListingAvailabilityPlanForm.selectTime": "Select time",
   "EditListingAvailabilityPlanForm.startTimePlaceholder": "Start",
   "EditListingAvailabilityPlanForm.timezonePickerTitle": "Select a time zone",


### PR DESCRIPTION
There is a "delete" button attached to availability plan entries.
- But it was not a semantic `<button>` element
- It was not clear from screenreader output what the entry was about - i.e. start & end
  - New entry does not have range set yet.

### New translation key
```json
  "EditListingAvailabilityPlanForm.screenreader.deleteEntry": "{hasTimeRange, select, yes {Delete {startTime} to {endTime} from {dayOfWeek} availability} other {Delete {dayOfWeek} availability entry}}",
```

i.e.
- Delete {startTime} to {endTime} from {dayOfWeek} availability
- Delete {dayOfWeek} availability entry