### PR TITLE
Update moment timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [change] Update moment-timezone: 0.6.2. > 0.6.3 (also dependabot were earlier updating lodash and
+  tmp) [#900](https://github.com/sharetribe/web-template/pull/900)
 - [fix] InboxSortForm does not have submit button so we warn the user about immediate change of
   content after sort input has been changed.
   [#892](https://github.com/sharetribe/web-template/pull/892)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lodash": "4.18.1",
     "mapbox-gl-multitouch": "^1.0.3",
     "moment": "^2.30.1",
-    "moment-timezone": "^0.6.2",
+    "moment-timezone": "^0.6.3",
     "passport": "^0.7.0",
     "passport-facebook": "^3.0.0",
     "passport-google-oauth": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11252,10 +11252,10 @@ module-details-from-path@^1.0.4:
   resolved "https://registry.yarnpkg.com/module-details-from-path/-/module-details-from-path-1.0.4.tgz#b662fdcd93f6c83d3f25289da0ce81c8d9685b94"
   integrity sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==
 
-moment-timezone@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.6.2.tgz#a704cca03ee502f0df6edd42efcdcc61ee03190e"
-  integrity sha512-lDsQv8FoGdBUdf0+TjGsq2orxKuXdwFlQ6Zw6TX3xIcTwTfEpCLyKqvEauvCHJ8iu3KBV8+uPhlv70YsNGdUBQ==
+moment-timezone@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.6.3.tgz#e386bad3116567a44477653ad6543b071bc153b7"
+  integrity sha512-pVEPA/HCFHHbwJ130ywnzYuZpkEGcP6Daa/OwNebpA18MybeFHmQilAGGovXgWijQ8vQtmud9jZrziUBgsykfg==
   dependencies:
     moment "^2.29.4"
 


### PR DESCRIPTION
for reference:

```txt
Release 2026c - 2026-07-08 10:23:58 -0700

  Briefly:
    Alberta moved to permanent -06 on 2026-06-18.
    Morocco moves to permanent +00 on 2026-09-20.

  Changes to future timestamps

    Alberta’s 2026-03-08 spring forward was its last foreseeable clock
    change, as it moved to permanent -06 thereafter.  (Thanks to Roozbeh
    Pournader and others.)  Model this with its traditional abbreviation
    CST.  Although the change to permanent -06 legally took place on
    2026-06-18, temporarily model the change to occur on 2026-11-01 at
    02:00 instead, for the same reason we introduced a similarly
    temporary hack for British Columbia in 2026b.

      Although another TZDB release will likely be needed soon because
      Northwest Territories will likely follow Alberta, the legal
      formalities have not yet taken place.

    Morocco plans to move back to permanent UTC, without daylight
    saving time transitions, on 2026-09-20 at 02:00.  This also
    affects Western Sahara.
```