### PR TITLE
When access token expires, we have not shared the token store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [change] When access token expires, we have not shared the token store between sdk.listings.show
+  and sdk.exchangeToken calls. This has caused unnecessary retries against those API endpoints.
+  [#901](https://github.com/sharetribe/web-template/pull/901)
 - [fix] EditListingAvailabilityPlanForm: add screenreader text for delete button and make it a
-  semantic button. [#901](https://github.com/sharetribe/web-template/pull/901)
+  semantic button. [#899](https://github.com/sharetribe/web-template/pull/899)
 - [change] Update moment-timezone: 0.6.2. > 0.6.3 (also dependabot were earlier updating lodash and
   tmp) [#900](https://github.com/sharetribe/web-template/pull/900)
 - [fix] InboxSortForm does not have submit button so we warn the user about immediate change of

--- a/server/api-util/README.md
+++ b/server/api-util/README.md
@@ -397,16 +397,27 @@ Core SDK utilities for interacting with the Sharetribe APIs.
 
 **Main Functions:**
 
-#### `getSdk(req, res)`
+#### `createCookieTokenStore(req, res)`
+
+Creates an Express cookie token store for the current request/response. Use the same store with both
+`getSdk` and `getTrustedSdk` in one request so a mid-request access-token refresh is visible to
+token exchange (the store keeps the refreshed token in memory; `req.cookies` is not mutated).
+
+#### `getSdk(req, res, tokenStore?)`
 
 Creates an SDK instance that calls Sharetribe APIs (authentication API, Marketplace API and Content
 Delivery API). If the authenticated user's session token is found in cookies, the SDK takes it into
-account.
+account. Pass an optional `tokenStore` from `createCookieTokenStore` when the same request will also
+call `getTrustedSdk`.
 
-#### `getTrustedSdk(req)`
+#### `getTrustedSdk(req, res, tokenStore?)`
 
 Creates a trusted SDK instance with elevated privileges by exchanging the user's token for a trusted
-token using the client secret.
+token using the client secret. Pass the same `tokenStore` used with `getSdk` in this request when
+available so `exchangeToken` uses that live store (including any mid-request refresh). If omitted, a
+new cookie store is created with `req`/`res` so a refresh during exchange can still update
+`Set-Cookie`. The resulting trusted SDK always keeps the trusted token in a memory store so it is
+never written to the browser cookie.
 
 **Additional Utilities:**
 

--- a/server/api-util/sdk.js
+++ b/server/api-util/sdk.js
@@ -49,15 +49,18 @@ const memoryStore = token => {
   return store;
 };
 
-// Read the user token from the request cookie
-const getUserToken = req => {
-  const cookieTokenStore = sharetribeSdk.tokenStore.expressCookieStore({
+// Cookie token store shared between getSdk and getTrustedSdk in the same request.
+// Important: expressCookieStore keeps a refreshed token in memory (and Set-Cookie on res),
+// but does not mutate req.cookies. To avoid multiple retries of outdated access token,
+// callers must pass this same store into getTrustedSdk.
+const createCookieTokenStore = (req, res) =>
+  sharetribeSdk.tokenStore.expressCookieStore({
     clientId: CLIENT_ID,
     req,
+    res,
     secure: USING_SSL,
   });
-  return cookieTokenStore.getToken();
-};
+exports.createCookieTokenStore = createCookieTokenStore;
 
 exports.serialize = data => {
   return sharetribeSdk.transit.write(data, { typeHandlers, verbose: TRANSIT_VERBOSE });
@@ -120,18 +123,15 @@ exports.handleError = (res, error, options = {}) => {
 
 // The access token is read from cookie (request) and potentially saved into the cookie (response).
 // This keeps session updated between server and browser even if the token is re-issued.
-exports.getSdk = (req, res) => {
+// Pass an optional tokenStore (from createCookieTokenStore) when the same request later calls
+// getTrustedSdk, so a mid-request refresh is visible to token exchange.
+exports.getSdk = (req, res, tokenStore) => {
   return sharetribeSdk.createInstance({
     transitVerbose: TRANSIT_VERBOSE,
     clientId: CLIENT_ID,
     httpAgent,
     httpsAgent,
-    tokenStore: sharetribeSdk.tokenStore.expressCookieStore({
-      clientId: CLIENT_ID,
-      req,
-      res,
-      secure: USING_SSL,
-    }),
+    tokenStore: tokenStore || createCookieTokenStore(req, res),
     typeHandlers,
     ...baseUrlMaybe,
     ...assetCdnBaseUrlMaybe,
@@ -139,8 +139,13 @@ exports.getSdk = (req, res) => {
 };
 
 // Trusted token is powerful, it should not be passed away from the server.
-exports.getTrustedSdk = req => {
-  const userToken = getUserToken(req);
+// When this request already used getSdk and may have refreshed the session, pass the same
+// cookie tokenStore so exchangeToken uses the current access/refresh token pair.
+exports.getTrustedSdk = (req, res, tokenStore) => {
+  // Prefer the shared cookie store when available so exchangeToken (and any refresh it
+  // triggers) reads/writes the live session token. Otherwise create a cookie store with
+  // res so a refresh during exchange can still update Set-Cookie.
+  const exchangeTokenStore = tokenStore || createCookieTokenStore(req, res);
 
   // Initiate an SDK instance for token exchange
   const sdk = sharetribeSdk.createInstance({
@@ -149,7 +154,7 @@ exports.getTrustedSdk = req => {
     clientSecret: CLIENT_SECRET,
     httpAgent,
     httpsAgent,
-    tokenStore: memoryStore(userToken),
+    tokenStore: exchangeTokenStore,
     typeHandlers,
     ...baseUrlMaybe,
   });
@@ -166,7 +171,7 @@ exports.getTrustedSdk = req => {
       clientId: CLIENT_ID,
 
       // Important! Do not use a cookieTokenStore here but a memoryStore
-      // instead so that we don't leak the token back to browser client.
+      // instead so that we don't leak the trusted token back to browser client.
       tokenStore: memoryStore(trustedToken),
 
       httpAgent,

--- a/server/api/delete-account.js
+++ b/server/api/delete-account.js
@@ -1,4 +1,10 @@
-const { getSdk, getTrustedSdk, handleError, serialize } = require('../api-util/sdk');
+const {
+  createCookieTokenStore,
+  getSdk,
+  getTrustedSdk,
+  handleError,
+  serialize,
+} = require('../api-util/sdk');
 
 const stripeRelatedStatesForBookings = [
   'state/pending-payment',
@@ -32,7 +38,9 @@ const HAS_INCOMPLETE_TRANSACTIONS =
 module.exports = (req, res) => {
   const { currentPassword } = req.body || {};
 
-  const sdk = getSdk(req, res);
+  // Share one cookie token store so a refresh during transactions.query is reused for exchangeToken.
+  const tokenStore = createCookieTokenStore(req, res);
+  const sdk = getSdk(req, res, tokenStore);
 
   // Booking states that contain Stripe payment processing
   const ongoingBookingsWithIncompletePaymentProcessing = () =>
@@ -72,7 +80,7 @@ module.exports = (req, res) => {
       if (hasOngoingTransactionsWithIncompletePaymentProcessing(responses)) {
         throw new Error(HAS_INCOMPLETE_TRANSACTIONS);
       }
-      return getTrustedSdk(req);
+      return getTrustedSdk(req, res, tokenStore);
     })
     .then(trustedSdk => {
       return trustedSdk.currentUser.delete({ currentPassword, deleteFromStripe: true });

--- a/server/api/initiate-privileged.js
+++ b/server/api/initiate-privileged.js
@@ -2,6 +2,7 @@ const sharetribeSdk = require('sharetribe-flex-sdk');
 const { transactionLineItems } = require('../api-util/lineItems');
 const { isIntentionToMakeOffer } = require('../api-util/negotiation');
 const {
+  createCookieTokenStore,
   getSdk,
   getTrustedSdk,
   handleError,
@@ -51,7 +52,9 @@ const getMetadata = (orderData, transition) => {
 module.exports = (req, res) => {
   const { isSpeculative, orderData, bodyParams, queryParams } = req.body || {};
   const transitionName = bodyParams.transition;
-  const sdk = getSdk(req, res);
+  // Share one cookie token store so a refresh during listings.show is reused for exchangeToken.
+  const tokenStore = createCookieTokenStore(req, res);
+  const sdk = getSdk(req, res, tokenStore);
   let lineItems = null;
   let metadataMaybe = {};
 
@@ -72,7 +75,7 @@ module.exports = (req, res) => {
       );
       metadataMaybe = getMetadata(orderData, transitionName);
 
-      return getTrustedSdk(req);
+      return getTrustedSdk(req, res, tokenStore);
     })
     .then(trustedSdk => {
       const { params } = bodyParams;

--- a/server/api/transition-privileged.js
+++ b/server/api/transition-privileged.js
@@ -10,6 +10,7 @@ const {
   throwErrorIfNegotiationOfferHasInvalidHistory,
 } = require('../api-util/negotiation');
 const {
+  createCookieTokenStore,
   getSdk,
   getTrustedSdk,
   handleError,
@@ -116,7 +117,9 @@ const getUpdatedMetadata = (orderData, transition, existingMetadata) => {
 module.exports = (req, res) => {
   const { isSpeculative, orderData, bodyParams, queryParams } = req.body || {};
 
-  const sdk = getSdk(req, res);
+  // Share one cookie token store so a refresh during transactions.show is reused for exchangeToken.
+  const tokenStore = createCookieTokenStore(req, res);
+  const sdk = getSdk(req, res, tokenStore);
   const transitionName = bodyParams.transition;
   let lineItems = null;
   let metadataMaybe = {};
@@ -151,7 +154,7 @@ module.exports = (req, res) => {
 
       metadataMaybe = getUpdatedMetadata(orderData, transitionName, existingMetadata);
 
-      return getTrustedSdk(req);
+      return getTrustedSdk(req, res, tokenStore);
     })
     .then(trustedSdk => {
       // Pass role based params to make sure that protectedData only contains protected data


### PR DESCRIPTION
between sdk.listings.show and sdk.exchangeToken calls. This has caused unnecessary retries against those API endpoints.

This changes the parameter signature of these functions:

`getSdk(req, res)` => `getSdk(req, res, tokenStore?)`
`getTrustedSdk(req)` => `getTrustedSdk(req, res, tokenStore?)`