### PR TITLE
New release v12.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+## [v12.2.0] 2026-08-13
+
 - [change] Listing images can now be re-ordered while editing/creating a listing. Default behaviour
   uses a handle for drag-and-drop functionality, and there is also keyboard support for
   accessibility. [#889](https://github.com/sharetribe/web-template/pull/889)
@@ -38,6 +40,8 @@ way to update this template, but currently, we follow a pattern:
 - [change] Topbar/PriorityLinks: turn the container into a list to improve accessibility.
   [#888](https://github.com/sharetribe/web-template/pull/888)
 - [fix] Harden Mapbox loading [#890](https://github.com/sharetribe/web-template/pull/890)
+
+  [v12.2.0]: https://github.com/sharetribe/web-template/compare/v12.1.0...v12.2.0
 
 ## [v12.1.0] 2026-07-27
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "app",
-  "version": "12.1.0",
+  "version": "12.2.0",
   "private": true,
   "license": "Apache-2.0",
   "dependencies": {


### PR DESCRIPTION
This release contains various new updates and fixes. Some highlights include:
- Support added for sorting images during listing creating/editing
- Multiple improvements to accessibility
- Removal of an additional client-side check for the 15 minute expiration window, which was used for the 3D Secure authentication popup. [#902](https://github.com/sharetribe/web-template/pull/902)
- Improvements to the Mapbox library loading

## Translations changes

### New translation keys:
```diff
+  "EditListingAvailabilityPlanForm.screenreader.deleteEntry": "{hasTimeRange, select, yes {Delete {startTime} to {endTime} from {dayOfWeek} availability} other {Delete {dayOfWeek} availability entry}}",
+  "EditListingPhotosForm.coverImageBadge": "Cover",
+  "InboxSearchForm.screenreader.label": "Sort options for inbox. The inbox updates automatically when you select an option.",
+  "ListingImage.screenreader.currentPosition": "{index} of {count}",
+  "ListingImage.screenreader.dragToReorderImage": "Drag to reorder",
+  "ListingImage.screenreader.moveImageDown": "Move image down - current position {currentPosition}.",
+  "ListingImage.screenreader.moveImageDownDisabled": "Move image down, disabled — last image",
+  "ListingImage.screenreader.moveImageUp": "Move image up - current position {currentPosition}.",
+  "ListingImage.screenreader.moveImageUpDisabled": "Move image up, disabled — first image",
```

### Old translations with updated arguments:
```diff
-  "CheckoutPage.paymentExpiredMessage": "Payment was not completed in 15 minutes. Please go back to {listingLink} and try again.",
+  "CheckoutPage.paymentExpiredMessage": "Payment was not completed in time. Please go back to {listingLink} and try again.",
-  "CheckoutPage.retrievingStripePaymentIntentFailed": "Oops, something went wrong. Please refresh the page. If the error persists, go back to {listingLink} and try again after 15 minutes.",
+  "CheckoutPage.retrievingStripePaymentIntentFailed": "Oops, something went wrong. Please refresh the page. If the error persists, go back to {listingLink} and try again.",
-  "EditListingPage.screenreader.removeImage": "Remove image",
+  "EditListingPage.screenreader.removeImage": "Remove image - current position {currentPosition}.",
-  "TransactionPanel.salePaymentPendingInfo": "{customerName} has 15 minutes to confirm the payment.",
+  "TransactionPanel.salePaymentPendingInfo": "{customerName} still needs to confirm the payment.",
```

## [Changes] 2026-08-13

- [change] Listing images can now be re-ordered while editing/creating a listing. Default behaviour
  uses a handle for drag-and-drop functionality, and there is also keyboard support for
  accessibility. [#889](https://github.com/sharetribe/web-template/pull/889)
- [fix] the default-download process was not taking into use the 1 day expiration time marked on the
  process. [#902](https://github.com/sharetribe/web-template/pull/902)
- [change] When access token expires, we have not shared the token store between sdk.listings.show
  and sdk.exchangeToken calls. This has caused unnecessary retries against those API endpoints.
  [#901](https://github.com/sharetribe/web-template/pull/901)
- [fix] EditListingAvailabilityPlanForm: add screenreader text for delete button and make it a
  semantic button. [#899](https://github.com/sharetribe/web-template/pull/899)
- [change] Update moment-timezone: 0.6.2. > 0.6.3 (also dependabot were earlier updating lodash and
  tmp) [#900](https://github.com/sharetribe/web-template/pull/900)
- [fix] InboxSortForm does not have submit button so we warn the user about immediate change of
  content after sort input has been changed.
  [#892](https://github.com/sharetribe/web-template/pull/892)
- [fix] EditListingPricingPanel: initialValues.price was not there with priceVariants.
  [#892](https://github.com/sharetribe/web-template/pull/893)
- [change] Update CircleCI config to v2.1.
  [#894](https://github.com/sharetribe/web-template/pull/894)
- [change] PaginationLinks: turn the container into a list to improve accessibility.
  [#891](https://github.com/sharetribe/web-template/pull/891)
- [change] Topbar/PriorityLinks: turn the container into a list to improve accessibility.
  [#888](https://github.com/sharetribe/web-template/pull/888)
- [fix] Harden Mapbox loading [#890](https://github.com/sharetribe/web-template/pull/890)

  [v12.2.0]: https://github.com/sharetribe/web-template/compare/v12.1.0...v12.2.0