### PR TITLE
Fix order panel heading level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] OrderPanel: headings needed different heading levels on listing page vs transaction page.
+  [#909](https://github.com/sharetribe/web-template/pull/909)
 - [change] Update sharetribe-flex-sdk to v1.24.2.
   [#907](https://github.com/sharetribe/web-template/pull/907)
 - [add] Add currently available translations for DE, ES, FR.

--- a/src/components/OrderPanel/BookingDatesForm/BookingDatesForm.js
+++ b/src/components/OrderPanel/BookingDatesForm/BookingDatesForm.js
@@ -621,6 +621,7 @@ export const BookingDatesForm = props => {
           onFetchTimeSlots,
           form: formApi,
           finePrintComponent: FinePrint,
+          sectionHeadingAs = 'h3',
         } = formRenderProps;
         const { startDate, endDate } = values?.bookingDates ? values.bookingDates : {};
         const priceVariantName = values?.priceVariantName || null;
@@ -828,7 +829,7 @@ export const BookingDatesForm = props => {
 
             {showEstimatedBreakdown ? (
               <div className={css.priceBreakdownContainer}>
-                <H6 as="h3" className={css.bookingBreakdownTitle}>
+                <H6 as={sectionHeadingAs} className={css.bookingBreakdownTitle}>
                   <FormattedMessage id="BookingDatesForm.priceBreakdownTitle" />
                 </H6>
                 <hr className={css.totalDivider} />

--- a/src/components/OrderPanel/BookingFixedDurationForm/BookingFixedDurationForm.js
+++ b/src/components/OrderPanel/BookingFixedDurationForm/BookingFixedDurationForm.js
@@ -147,6 +147,7 @@ export const BookingFixedDurationForm = props => {
           payoutDetailsWarning,
           isOwnListing,
           finePrintComponent: FinePrint,
+          sectionHeadingAs = 'h3',
         } = formRenderProps;
 
         const startTime = values?.bookingStartTime ? values.bookingStartTime : null;
@@ -239,7 +240,7 @@ export const BookingFixedDurationForm = props => {
 
             {showEstimatedBreakdown ? (
               <div className={css.priceBreakdownContainer}>
-                <H6 as="h3" className={css.bookingBreakdownTitle}>
+                <H6 as={sectionHeadingAs} className={css.bookingBreakdownTitle}>
                   <FormattedMessage id="BookingFixedDurationForm.priceBreakdownTitle" />
                 </H6>
                 <hr className={css.totalDivider} />

--- a/src/components/OrderPanel/BookingTimeForm/BookingTimeForm.js
+++ b/src/components/OrderPanel/BookingTimeForm/BookingTimeForm.js
@@ -144,6 +144,7 @@ export const BookingTimeForm = props => {
           payoutDetailsWarning,
           isOwnListing,
           finePrintComponent: FinePrint,
+          sectionHeadingAs = 'h3',
         } = formRenderProps;
 
         const startTime = values?.bookingStartTime ? values.bookingStartTime : null;
@@ -241,7 +242,7 @@ export const BookingTimeForm = props => {
 
             {showEstimatedBreakdown ? (
               <div className={css.priceBreakdownContainer}>
-                <H6 as="h3" className={css.bookingBreakdownTitle}>
+                <H6 as={sectionHeadingAs} className={css.bookingBreakdownTitle}>
                   <FormattedMessage id="BookingTimeForm.priceBreakdownTitle" />
                 </H6>
                 <hr className={css.totalDivider} />

--- a/src/components/OrderPanel/DigitalDownloadForm/DigitalDownloadForm.js
+++ b/src/components/OrderPanel/DigitalDownloadForm/DigitalDownloadForm.js
@@ -46,6 +46,7 @@ const renderForm = formRenderProps => {
     onFetchTransactionLineItems,
     marketplaceName,
     finePrintComponent: FinePrint,
+    sectionHeadingAs = 'h3',
   } = formRenderProps;
 
   const classes = classNames(rootClassName || css.root, className);
@@ -69,7 +70,7 @@ const renderForm = formRenderProps => {
     <Form id={formId} onSubmit={handleSubmit} className={classes}>
       {showBreakdown ? (
         <div className={css.breakdownWrapper}>
-          <H6 as="h3" className={css.bookingBreakdownTitle}>
+          <H6 as={sectionHeadingAs} className={css.bookingBreakdownTitle}>
             <FormattedMessage id="DigitalDownloadForm.breakdownTitle" />
           </H6>
           <hr className={css.totalDivider} />
@@ -110,6 +111,7 @@ const renderForm = formRenderProps => {
  * @param {Function} props.onSubmit - The function to handle the form submission
  * @param {boolean} props.isOwnListing - Whether the listing is owned by the current user
  * @param {string} [props.payoutDetailsWarning] - Warning about payout details
+ * @param {'h2'|'h3'} [props.sectionHeadingAs='h3'] - Semantic heading level for form section titles
  * @returns {JSX.Element}
  */
 const DigitalDownloadForm = props => {

--- a/src/components/OrderPanel/OrderPanel.js
+++ b/src/components/OrderPanel/OrderPanel.js
@@ -271,6 +271,7 @@ const hasValidPriceVariants = priceVariants => {
  * @param {string} props.marketplaceCurrency - The currency used in the marketplace
  * @param {number} props.dayCountAvailableForBooking - Number of days available for booking
  * @param {string} props.marketplaceName - Name of the marketplace
+ * @param {'h2'|'h3'} [props.sectionHeadingAs='h3'] - Semantic heading level for form section titles (under the panel title)
  *
  * @returns {JSX.Element} Component that displays the order panel with appropriate form
  */
@@ -312,6 +313,7 @@ const OrderPanel = props => {
     showListingImage,
     hideAuthorInfo,
     hidePrice,
+    sectionHeadingAs = 'h3',
   } = props;
 
   const publicData = listing?.attributes?.publicData || {};
@@ -422,6 +424,7 @@ const OrderPanel = props => {
     fetchLineItemsInProgress,
     fetchLineItemsError,
     payoutDetailsWarning,
+    sectionHeadingAs,
   };
 
   const showClosedListingHelpText = listing.id && isClosed;

--- a/src/components/OrderPanel/ProductOrderForm/ProductOrderForm.js
+++ b/src/components/OrderPanel/ProductOrderForm/ProductOrderForm.js
@@ -61,6 +61,7 @@ const DeliveryMethodMaybe = props => {
     hasStock,
     formId,
     intl,
+    sectionHeadingAs,
   } = props;
   const showDeliveryMethodSelector = displayDeliveryMethod && hasMultipleDeliveryMethods;
   const showSingleDeliveryMethod = displayDeliveryMethod && deliveryMethod;
@@ -84,7 +85,7 @@ const DeliveryMethodMaybe = props => {
     </FieldSelect>
   ) : showSingleDeliveryMethod ? (
     <div className={css.deliveryField}>
-      <H3 rootClassName={css.singleDeliveryMethodLabel}>
+      <H3 as={sectionHeadingAs} rootClassName={css.singleDeliveryMethodLabel}>
         {intl.formatMessage({ id: 'ProductOrderForm.deliveryMethodLabel' })}
       </H3>
       <p className={css.singleDeliveryMethodSelected}>
@@ -134,6 +135,7 @@ const renderForm = formRenderProps => {
     payoutDetailsWarning,
     marketplaceName,
     values,
+    sectionHeadingAs = 'h3',
   } = formRenderProps;
 
   // Note: don't add custom logic before useEffect
@@ -257,11 +259,12 @@ const renderForm = formRenderProps => {
         hasStock={hasStock}
         formId={formId}
         intl={intl}
+        sectionHeadingAs={sectionHeadingAs}
       />
 
       {showBreakdown ? (
         <div className={css.breakdownWrapper}>
-          <H6 as="h3" className={css.bookingBreakdownTitle}>
+          <H6 as={sectionHeadingAs} className={css.bookingBreakdownTitle}>
             <FormattedMessage id="ProductOrderForm.breakdownTitle" />
           </H6>
           <hr className={css.totalDivider} />
@@ -323,6 +326,7 @@ const renderForm = formRenderProps => {
  * @param {boolean} props.fetchLineItemsInProgress - Whether the line items are being fetched
  * @param {propTypes.error} props.fetchLineItemsError - The error for fetching the line items
  * @param {Function} props.onContactUser - The function to contact the user
+ * @param {'h2'|'h3'} [props.sectionHeadingAs='h3'] - Semantic heading level for form section titles
  * @returns {JSX.Element}
  */
 const ProductOrderForm = props => {

--- a/src/containers/ListingPage/ListingPageCarousel.js
+++ b/src/containers/ListingPage/ListingPageCarousel.js
@@ -326,6 +326,7 @@ export const ListingPageComponent = props => {
                   <FormattedMessage id="ListingPage.orderTitle" values={{ title: richTitle }} />
                 </H4>
               }
+              sectionHeadingAs="h2"
               payoutDetailsWarning={payoutDetailsWarning}
               author={ensuredAuthor}
               onManageDisableScrolling={onManageDisableScrolling}

--- a/src/containers/ListingPage/ListingPageCoverPhoto.js
+++ b/src/containers/ListingPage/ListingPageCoverPhoto.js
@@ -350,6 +350,7 @@ export const ListingPageComponent = props => {
                   <FormattedMessage id="ListingPage.orderTitle" values={{ title: richTitle }} />
                 </H4>
               }
+              sectionHeadingAs="h2"
               payoutDetailsWarning={payoutDetailsWarning}
               author={ensuredAuthor}
               onManageDisableScrolling={onManageDisableScrolling}


### PR DESCRIPTION
OrderPanel needs to use different heading levels on listing page vs transaction page.
This PR solves it by adding a new property: `sectionHeadingAs`