### PR TITLE
richText: coalesce adjacent strings to avoid unnecessary string tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [change] richText.js: coalesce adjacent strings to avoid multiple spaces between words.
+  [#910](https://github.com/sharetribe/web-template/pull/910)
 - [fix] OrderPanel: headings needed different heading levels on listing page vs transaction page.
   [#909](https://github.com/sharetribe/web-template/pull/909)
 - [change] Update sharetribe-flex-sdk to v1.24.2.

--- a/src/util/richText.js
+++ b/src/util/richText.js
@@ -137,6 +137,26 @@ export const linkifyOrWrapLinkSplit = (word, key, options = {}) => {
 };
 
 /**
+ * Merge adjacent string nodes so React does not create separate text nodes for
+ * each word/space (which can make screen readers announce "space" between them).
+ *
+ * @param {Array<node>} nodes mixed strings and React elements
+ * @return {Array<node>} nodes with consecutive strings concatenated
+ */
+export const coalesceAdjacentStrings = nodes =>
+  nodes.reduce((acc, node) => {
+    if (node == null || node === '') {
+      return acc;
+    }
+    if (typeof node === 'string' && typeof acc[acc.length - 1] === 'string') {
+      acc[acc.length - 1] += node;
+      return acc;
+    }
+    acc.push(node);
+    return acc;
+  }, []);
+
+/**
  * Scan text to fill in wrappers for long words and add links.
  * Wrap long words: options should contain longWordMinLength & longWordClass
  * Linkify found links: options should contain "linkify: true" (linkClass is optional)
@@ -146,7 +166,7 @@ export const linkifyOrWrapLinkSplit = (word, key, options = {}) => {
  *
  * @param {String} text check text content
  * @param {Object} options { longWordMinLength, longWordClass, linkify = false, linkClass }
- * @return {Array<node>} returns a child array containing strings and inline elements
+ * @return {string|Array<node>} a string, or a child array containing strings and inline elements
  */
 export const richText = (text, options) => {
   if (typeof text !== 'string') {
@@ -160,13 +180,15 @@ export const richText = (text, options) => {
   const nonWhiteSpaceSequence = /([^\s]+)/gi;
   const breakCharsConfig = breakChars != null ? breakChars : '/';
 
-  return text.split(nonWhiteSpaceSequence).reduce((acc, nextChild, i) => {
-    const parts = flow([
+  const parts = text.split(nonWhiteSpaceSequence).reduce((acc, nextChild, i) => {
+    const nextParts = flow([
       v =>
         v.flatMap(w => linkifyOrWrapLinkSplit(w, i, { linkify, linkClass: linkOrLongWordClass })),
       v => v.flatMap(w => zwspAroundSpecialCharsSplit(w, breakCharsConfig)),
       v => v.map((w, j) => wrapLongWord(w, `${i}${j}`, { longWordMinLength, longWordClass })),
     ])([nextChild]);
-    return acc.concat(parts);
+    return acc.concat(nextParts);
   }, []);
+  const coalescedParts = coalesceAdjacentStrings(parts);
+  return coalescedParts.length === 1 ? coalescedParts[0] : parts;
 };

--- a/src/util/richText.test.js
+++ b/src/util/richText.test.js
@@ -7,6 +7,7 @@ import {
   zwspAroundSpecialCharsSplit,
   linkifyOrWrapLinkSplit,
   wrapLongWord,
+  coalesceAdjacentStrings,
   richText,
 } from './richText';
 
@@ -191,14 +192,37 @@ describe('richText', () => {
     });
   });
 
+  describe('coalesceAdjacentStrings(nodes)', () => {
+    it('should merge adjacent strings and drop empty ones', () => {
+      expect(coalesceAdjacentStrings(['A', ' ', 'bike', '', ' ', "I'm", ' ', 'selling'])).toEqual([
+        "A bike I'm selling",
+      ]);
+    });
+    it('should keep element boundaries and attach spaces to neighboring strings', () => {
+      const longWord = (
+        <span className="longWord">Pneumonoultramicroscopicsilicovolcanoconiosis</span>
+      );
+      expect(coalesceAdjacentStrings(['word', ' ', longWord, ' ', 'is', ' ', 'long'])).toEqual([
+        'word ',
+        longWord,
+        ' is long',
+      ]);
+    });
+  });
+
   describe('richText(text, { longWordMinLength, longWordClass })', () => {
     const options = { longWordMinLength: 10, longWordClass: 'longWord' };
 
     it('should not add anything to strings with short words', () => {
       const wrapper = render(<span>{richText('word word word', options)}</span>);
 
-      const htmlString = wrapper.asFragment().firstChild.outerHTML;
-      expect(htmlString).toEqual('<span>word word word</span>');
+      const span = wrapper.asFragment().firstChild;
+      expect(span.outerHTML).toEqual('<span>word word word</span>');
+      expect(span.childNodes.length).toEqual(1);
+      expect(span.firstChild.nodeType).toEqual(Node.TEXT_NODE);
+    });
+    it('should return a single string for short-word titles', () => {
+      expect(richText("A bike I'm selling", options)).toEqual("A bike I'm selling");
     });
     it('should add span around a string with a single long word', () => {
       const wrapper = render(
@@ -209,10 +233,17 @@ describe('richText', () => {
           )}
         </span>
       );
-      const htmlString = wrapper.asFragment().firstChild.outerHTML;
-      expect(htmlString).toEqual(
+      const span = wrapper.asFragment().firstChild;
+      expect(span.outerHTML).toEqual(
         '<span>word <span class="longWord">Pneumonoultramicroscopicsilicovolcanoconiosis</span> is the longest word</span>'
       );
+      // text + long-word span + text (no lone space text nodes)
+      expect(span.childNodes.length).toEqual(3);
+      expect(span.childNodes[0].nodeType).toEqual(Node.TEXT_NODE);
+      expect(span.childNodes[0].textContent).toEqual('word ');
+      expect(span.childNodes[1].className).toEqual('longWord');
+      expect(span.childNodes[2].nodeType).toEqual(Node.TEXT_NODE);
+      expect(span.childNodes[2].textContent).toEqual(' is the longest word');
     });
     it('should add span around a string with multiple long words', () => {
       const wrapper = render(
@@ -223,10 +254,11 @@ describe('richText', () => {
           )}
         </span>
       );
-      const htmlString = wrapper.asFragment().firstChild.outerHTML;
-      expect(htmlString).toEqual(
+      const span = wrapper.asFragment().firstChild;
+      expect(span.outerHTML).toEqual(
         '<span>word <span class="longWord">Pneumonoultramicroscopicsilicovolcanoconiosis</span> is the longest word - <span class="longWord">Pseudopseudohypoparathyroidism</span> is shorter</span>'
       );
+      expect(span.childNodes.length).toEqual(5);
     });
 
     it('should add span around a string with multiple long words and containing slashes', () => {


### PR DESCRIPTION
Some screenreaders misread those string tokens that were just empty spaces.

Examples:
```jsx
coalesceAdjacentStrings(['A', ' ', 'bike', '', ' ', "I'm", ' ', 'selling'])
//=> "A bike I'm selling"
```

```jsx
const longWord = (<span className="longWord">Pneumonoultramicroscopicsilicovolcanoconiosis</span>);
coalesceAdjacentStrings(['word', ' ', longWord, ' ', 'is', ' ', 'long'])
//=> ['word ', <span className="longWord">Pneumonoultramicroscopicsilicovolcanoconiosis</span>, ' is long']
```

So, this still returns React Nodes for component that tries to render them.