### PR TITLE
Topbar: Fix mobile main search keeping modified value over re-opening the modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] Topbar: search form keeps modified value on mobile layout over modal re-opening.
+  [#911](https://github.com/sharetribe/web-template/pull/911)
 - [change] richText.js: coalesce adjacent strings to avoid multiple spaces between words.
   [#910](https://github.com/sharetribe/web-template/pull/910)
 - [fix] OrderPanel: headings needed different heading levels on listing page vs transaction page.

--- a/src/containers/TopbarContainer/Topbar/Topbar.js
+++ b/src/containers/TopbarContainer/Topbar/Topbar.js
@@ -405,17 +405,19 @@ const TopbarComponent = props => {
         onManageDisableScrolling={onManageDisableScrolling}
         focusElementId={MOBILE_SEARCH_BUTTON_ID}
       >
-        <div className={css.searchContainer}>
-          <TopbarSearchForm
-            onSubmit={handleSubmit}
-            initialValues={initialSearchFormValues}
-            isMobile
-            appConfig={config}
-          />
-          <p className={css.mobileHelp}>
-            <FormattedMessage id="Topbar.mobileSearchHelp" />
-          </p>
-        </div>
+        {isMobileSearchOpen ? (
+          <div className={css.searchContainer}>
+            <TopbarSearchForm
+              onSubmit={handleSubmit}
+              initialValues={initialSearchFormValues}
+              isMobile
+              appConfig={config}
+            />
+            <p className={css.mobileHelp}>
+              <FormattedMessage id="Topbar.mobileSearchHelp" />
+            </p>
+          </div>
+        ) : null}
       </Modal>
       <ModalMissingInformation
         id="MissingInformationReminder"


### PR DESCRIPTION
Topbar: search form keeps modified value on mobile layout over modal re-opening

In other words:
1. If someone has written "cat" and pressed enter.
2. Then opened the search modal again and continued with "cat memes" without submitting the value
3. Then after closing & opening the modal, they still see "cat memes"
but the active search term is still "cat"

This fixes it so that re-opening the modal, reloads the form using currently active
search term.