### PR TITLE
LoadableComponentErrorBoundary: add auto-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [change] LoadableComponentErrorBoundary.js: add auto-reload and persist listing order data to
+  sessionStorage on ListingPage. [#913](https://github.com/sharetribe/web-template/pull/913)
 - [fix] CustomLinksMenu: post-a-new-listing link was not hidden after signup.
   [#912](https://github.com/sharetribe/web-template/pull/912)
 - [fix] Topbar: search form keeps modified value on mobile layout over modal re-opening.

--- a/src/containers/CheckoutPage/CheckoutPage.duck.js
+++ b/src/containers/CheckoutPage/CheckoutPage.duck.js
@@ -7,6 +7,10 @@ import { storableError } from '../../util/errors';
 import * as log from '../../util/log';
 import { setCurrentUserHasOrders, fetchCurrentUser } from '../../ducks/user.duck';
 
+import { storeData } from './CheckoutPageSessionHelpers';
+
+const CHECKOUT_PAGE_SESSION_KEY = 'CheckoutPage';
+
 // ================ Async thunks ================ //
 
 ////////////////////
@@ -518,8 +522,24 @@ const checkoutPageSlice = createSlice({
   },
 });
 
-// Export the action creators
-export const { setInitialValues } = checkoutPageSlice.actions;
+const { setInitialValues: setInitialValuesAction } = checkoutPageSlice.actions;
+
+/**
+ * Set CheckoutPage Redux state and optionally persist listing + order data to sessionStorage.
+ * Persistence lets checkout recover after a full page reload before the page mounts
+ * (e.g. ChunkLoadError auto-reload while navigating ListingPage → CheckoutPage).
+ *
+ * @param {Object} initialValues
+ * @param {boolean} [saveToSessionStorage=true]
+ * @returns {Object} Redux action
+ */
+export const setInitialValues = (initialValues, saveToSessionStorage = true) => {
+  if (saveToSessionStorage) {
+    const { listing, orderData, transaction } = initialValues;
+    storeData(orderData, listing, transaction || null, CHECKOUT_PAGE_SESSION_KEY);
+  }
+  return setInitialValuesAction(initialValues);
+};
 
 // Export the reducer
 export default checkoutPageSlice.reducer;

--- a/src/containers/CheckoutPage/CheckoutPage.js
+++ b/src/containers/CheckoutPage/CheckoutPage.js
@@ -25,7 +25,7 @@ import { savePaymentMethod } from '../../ducks/paymentMethods.duck';
 import { IconSpinner, NamedRedirect, Page, TopbarSimplified } from '../../components';
 
 // Session helpers file needs to be imported before CheckoutPageWithPayment and CheckoutPageWithInquiryProcess
-import { storeData, clearData, handlePageData } from './CheckoutPageSessionHelpers';
+import { clearData, handlePageData } from './CheckoutPageSessionHelpers';
 
 // Import modules from this directory
 import {
@@ -277,14 +277,8 @@ const CheckoutPage = props => {
   );
 };
 
-// setInitialValues is used to clear redux state and ensure it matches the data
-// of the listing the user is currently viewing
-CheckoutPage.setInitialValues = (initialValues, saveToSessionStorage = false) => {
-  if (saveToSessionStorage) {
-    const { listing, orderData } = initialValues;
-    storeData(orderData, listing, null, STORAGE_KEY);
-  }
-  return setInitialValues(initialValues);
-};
+// Kept for callers that attach setInitialValues on the page component.
+// Route config uses pageDataLoadingAPI => CheckoutPage.duck setInitialValues (same behavior).
+CheckoutPage.setInitialValues = setInitialValues;
 
 export default CheckoutPage;

--- a/src/containers/ListingPage/ListingPage.shared.js
+++ b/src/containers/ListingPage/ListingPage.shared.js
@@ -415,7 +415,6 @@ export const handleSubmit = parameters => values => {
   const {
     history,
     params,
-    currentUser,
     getListing,
     callSetInitialValues,
     onInitializeCardPaymentData,
@@ -473,8 +472,9 @@ export const handleSubmit = parameters => values => {
     confirmPaymentError: null,
   };
 
-  const saveToSessionStorage = !currentUser;
+  const saveToSessionStorage = true;
 
+  // Persist before navigation so a full reload (e.g. ChunkLoadError recovery) can resume checkout.
   // Customize the state of the CheckoutPage with the current listing and the selected orderData
   const { setInitialValues } = findRouteByRouteName('CheckoutPage', routes);
   callSetInitialValues(setInitialValues, initialValues, saveToSessionStorage);

--- a/src/routing/LoadableComponentErrorBoundary/LoadableComponentErrorBoundary.js
+++ b/src/routing/LoadableComponentErrorBoundary/LoadableComponentErrorBoundary.js
@@ -4,6 +4,41 @@ import appSettings from '../../config/settings';
 
 import { LoadableComponentErrorBoundaryPage } from './LoadableComponentErrorBoundaryPage';
 
+const CHUNK_LOAD_RELOAD_KEY = 'LoadableComponentErrorBoundary.reloaded';
+
+const tryGetChunkLoadReloadFlag = () => {
+  try {
+    if (typeof window === 'undefined' || !window.sessionStorage) {
+      return null;
+    }
+    return window.sessionStorage.getItem(CHUNK_LOAD_RELOAD_KEY) === 'true';
+  } catch (e) {
+    return null;
+  }
+};
+
+const trySetChunkLoadReloadFlag = () => {
+  try {
+    if (typeof window === 'undefined' || !window.sessionStorage) {
+      return false;
+    }
+    window.sessionStorage.setItem(CHUNK_LOAD_RELOAD_KEY, 'true');
+    return true;
+  } catch (e) {
+    return false;
+  }
+};
+
+const tryClearChunkLoadReloadFlag = () => {
+  try {
+    if (typeof window !== 'undefined' && window.sessionStorage) {
+      window.sessionStorage.removeItem(CHUNK_LOAD_RELOAD_KEY);
+    }
+  } catch (e) {
+    // Ignore unavailable sessionStorage (e.g. private mode restrictions).
+  }
+};
+
 // Use ErrorBoyndary to catch ChunkLoadError
 // https://reactjs.org/docs/error-boundaries.html
 class LoadableComponentErrorBoundary extends Component {
@@ -15,6 +50,39 @@ class LoadableComponentErrorBoundary extends Component {
   static getDerivedStateFromError(error) {
     // Update state so the next render will show the fallback UI.
     return { error };
+  }
+
+  componentDidCatch(error) {
+    // After a deploy, long-lived tabs can request removed chunk files.
+    // Reload once so the browser picks up the new HTML/chunk map.
+    if (error?.name !== 'ChunkLoadError' || typeof window === 'undefined') {
+      return;
+    }
+
+    const hasReloaded = tryGetChunkLoadReloadFlag();
+    if (hasReloaded === true) {
+      return;
+    }
+
+    // Only reload when we can persist the guard; otherwise the error page is shown.
+    if (hasReloaded === false && trySetChunkLoadReloadFlag()) {
+      window.location.reload();
+    }
+  }
+
+  componentDidMount() {
+    this.clearReloadFlagWhenHealthy();
+  }
+
+  componentDidUpdate() {
+    this.clearReloadFlagWhenHealthy();
+  }
+
+  clearReloadFlagWhenHealthy() {
+    // Successful render means current chunks work; allow a future deploy to reload once again.
+    if (!this.state.error) {
+      tryClearChunkLoadReloadFlag();
+    }
   }
 
   render() {


### PR DESCRIPTION
LoadableComponentErrorBoundary: add auto-reload

In addition:
- CheckoutPage setInitialValues: persist listing order data to sessionStorage before checkout so reload can resume the flow. 
  This could happen with:
  - LoadableComponentErrorBoundary.js
    - Due to changes in previous commit
  - Authentication through SSO provider
    - This was an old feature that was buggy after code-splitting.