### PR TITLE
Improve Sentry errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [change] log.js: improve error handling and capture API errors better for Sentry.
+  [#915](https://github.com/sharetribe/web-template/pull/915)
 - [fix] Add imgix.net to CSP / connect-src.
   [#914](https://github.com/sharetribe/web-template/pull/914)
 - [change] LoadableComponentErrorBoundary.js: add auto-reload and persist listing order data to

--- a/server/log.js
+++ b/server/log.js
@@ -42,7 +42,18 @@ exports.setupExpressErrorHandler = app => {
 };
 
 const responseAPIErrors = error => {
-  return error && error.data && error.data.errors ? error.data.errors : [];
+  if (!error) {
+    return [];
+  }
+  // SDK / Axios errors attach Marketplace API errors under data.errors
+  if (error?.data?.errors) {
+    return error.data.errors;
+  }
+  // storableError() plain objects use apiErrors
+  if (error.apiErrors) {
+    return error.apiErrors;
+  }
+  return [];
 };
 
 const responseApiErrorInfo = err =>
@@ -50,7 +61,27 @@ const responseApiErrorInfo = err =>
     status: e.status,
     code: e.code,
     meta: e.meta,
+    details: e.details,
   }));
+
+/**
+ * Sentry truncates nested plain objects in extra.__serialized__ (normalizeDepth),
+ * which turns apiErrors into useless "[Object]" strings. Always capture a real Error.
+ */
+const toCapturableError = e => {
+  if (e instanceof Error) {
+    return e;
+  }
+  const err = new Error(e?.message || 'Unknown error');
+  err.name = e?.name || 'Error';
+  if (e?.status != null) {
+    err.status = e.status;
+  }
+  if (e?.statusText != null) {
+    err.statusText = e.statusText;
+  }
+  return err;
+};
 
 /**
  * Logs a error. If Sentry client is set up
@@ -73,7 +104,7 @@ exports.error = (e, code, data, options = {}) => {
       Object.keys(extra).forEach(key => {
         scope.setExtra(key, extra[key]);
       });
-      Sentry.captureException(e);
+      Sentry.captureException(toCapturableError(e));
     });
   }
   // Let's log always to stdout

--- a/src/containers/CheckoutPage/CheckoutPage.duck.js
+++ b/src/containers/CheckoutPage/CheckoutPage.duck.js
@@ -391,6 +391,9 @@ export const speculateTransaction = (
   transitionName,
   isPrivilegedTransition
 ) => dispatch => {
+  // Errors are stored in Redux via rejectWithValue (and logged in the payload creator).
+  // Do not unwrap: fire-and-forget callers would otherwise get unhandled rejections of
+  // plain storableError objects, which Sentry serializes as apiErrors: ["[Object]"].
   return dispatch(
     speculateTransactionThunk({
       orderParams,
@@ -399,7 +402,7 @@ export const speculateTransaction = (
       transitionName,
       isPrivilegedTransition,
     })
-  ).unwrap();
+  );
 };
 
 ///////////////////////////
@@ -428,7 +431,8 @@ export const stripeCustomerThunk = createAsyncThunk(
 );
 // Backward compatible wrapper function for stripeCustomer
 export const stripeCustomer = () => dispatch => {
-  return dispatch(stripeCustomerThunk({})).unwrap();
+  // Same as speculateTransaction: avoid unhandled unwrap rejections for fire-and-forget callers.
+  return dispatch(stripeCustomerThunk({}));
 };
 
 // ================ Slice ================ //

--- a/src/containers/ListingPage/ListingPage.duck.js
+++ b/src/containers/ListingPage/ListingPage.duck.js
@@ -363,7 +363,10 @@ export const fetchTransactionLineItemsThunk = createAsyncThunk(
 );
 // Backward compatible wrapper for the thunk
 export const fetchTransactionLineItems = ({ orderData, listingId, isOwnListing }) => dispatch => {
-  return dispatch(fetchTransactionLineItemsThunk({ orderData, listingId, isOwnListing })).unwrap();
+  // Errors are stored in Redux via rejectWithValue (and logged in the payload creator).
+  // Do not unwrap: OrderPanel callers are fire-and-forget and would otherwise create
+  // unhandled rejections of plain storableError objects in Sentry.
+  return dispatch(fetchTransactionLineItemsThunk({ orderData, listingId, isOwnListing }));
 };
 
 // ================ Slice ================ //

--- a/src/ducks/paymentMethods.duck.js
+++ b/src/ducks/paymentMethods.duck.js
@@ -93,7 +93,7 @@ export const updatePaymentMethod = stripePaymentMethodId => (dispatch, getState,
       return dispatch(addPaymentMethod(stripePaymentMethodId));
     })
     .catch(e => {
-      log.error(storableError(e), 'updating-payment-method-failed');
+      log.error(e, 'updating-payment-method-failed');
     });
 };
 

--- a/src/util/log.js
+++ b/src/util/log.js
@@ -73,7 +73,18 @@ const printAPIErrorsAsConsoleTable = apiErrors => {
 };
 
 const responseAPIErrors = error => {
-  return error && error.data && error.data.errors ? error.data.errors : [];
+  if (!error) {
+    return [];
+  }
+  // SDK / Axios errors attach Marketplace API errors under data.errors
+  if (error?.data?.errors) {
+    return error.data.errors;
+  }
+  // storableError() plain objects use apiErrors (see util/errors.js)
+  if (error.apiErrors) {
+    return error.apiErrors;
+  }
+  return [];
 };
 
 const responseApiErrorInfo = err =>
@@ -83,6 +94,25 @@ const responseApiErrorInfo = err =>
     meta: e.meta,
     details: e.details,
   }));
+
+/**
+ * Sentry truncates nested plain objects in extra.__serialized__ (normalizeDepth),
+ * which turns apiErrors into useless "[Object]" strings. Always capture a real Error.
+ */
+const toCapturableError = e => {
+  if (e instanceof Error) {
+    return e;
+  }
+  const err = new Error(e?.message || 'Unknown error');
+  err.name = e?.name || 'Error';
+  if (e?.status != null) {
+    err.status = e.status;
+  }
+  if (e?.statusText != null) {
+    err.statusText = e.statusText;
+  }
+  return err;
+};
 
 /**
  * Logs an exception. If Sentry is configured
@@ -103,7 +133,7 @@ export const error = (e, code, data) => {
       Object.keys(extra).forEach(key => {
         scope.setExtra(key, extra[key]);
       });
-      Sentry.captureException(e);
+      Sentry.captureException(toCapturableError(e));
     });
 
     printAPIErrorsAsConsoleTable(apiErrors);


### PR DESCRIPTION
Sentry truncates nested plain objects in extra.__serialized__ (normalizeDepth), which turns apiErrors into useless "[Object]" strings