### PR TITLE
richText.js: coalescedParts should have been returned 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] richText.js: return coalesced strings instead of the previous array of strings.
+  [#916](https://github.com/sharetribe/web-template/pull/916)
 - [change] log.js: improve error handling and capture API errors better for Sentry.
   [#915](https://github.com/sharetribe/web-template/pull/915)
 - [fix] Add imgix.net to CSP / connect-src.

--- a/src/util/richText.js
+++ b/src/util/richText.js
@@ -190,5 +190,5 @@ export const richText = (text, options) => {
     return acc.concat(nextParts);
   }, []);
   const coalescedParts = coalesceAdjacentStrings(parts);
-  return coalescedParts.length === 1 ? coalescedParts[0] : parts;
+  return coalescedParts.length === 1 ? coalescedParts[0] : coalescedParts;
 };


### PR DESCRIPTION
instead of just parts

#910 did not always use coalescedParts due to some copy-paste issue.