### PR TITLE
EditListingPage: harden image upload against conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ way to update this template, but currently, we follow a pattern:
 
 ## Upcoming version 2026-XX-XX
 
+- [fix] EditListingPage: fix a bug with listing image ids (duplicates were not removed on some edge
+  cases). [#919](https://github.com/sharetribe/web-template/pull/919)
 - [fix] Menu.js: this.menu is null when the component is unmounting (ref callback receives null).
   [#918](https://github.com/sharetribe/web-template/pull/918)
 - [fix] ListingCard: aria-label was not showing the price value.

--- a/src/containers/EditListingPage/EditListingPage.duck.js
+++ b/src/containers/EditListingPage/EditListingPage.duck.js
@@ -2,6 +2,7 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 
 import { omit } from '../../util/common';
 import { types as sdkTypes, file as sdkFile, createImageVariantConfig } from '../../util/sdkLoader';
+import { uniqueListingImageApiIds } from './EditListingPage.shared';
 import { denormalisedResponseEntities } from '../../util/data';
 import {
   getDefaultTimeZoneOnBrowser,
@@ -40,12 +41,8 @@ const getArrayOfNItems = n =>
     .map((v, i) => i + 1)
     .slice(1);
 
-// Return an array of image ids
-const imageIds = images => {
-  // For newly uploaded image the UUID can be found from "img.imageId"
-  // and for existing listing images the id is "img.id"
-  return images ? images.map(img => img.imageId || img.id) : null;
-};
+// Return a de-duplicated array of image ids for the API call
+const imageIds = uniqueListingImageApiIds;
 
 // After listing creation & update, we want to make sure that uploadedImages state is cleaned
 const updateUploadedImagesState = (state, payload) => {

--- a/src/containers/EditListingPage/EditListingPage.js
+++ b/src/containers/EditListingPage/EditListingPage.js
@@ -20,6 +20,7 @@ import {
 import { LISTING_STATE_DRAFT, LISTING_STATE_PENDING_APPROVAL, propTypes } from '../../util/types';
 import { isErrorNoPermissionToPostListings } from '../../util/errors';
 import { ensureOwnListing } from '../../util/data';
+import { listingImageApiId, listingImageIdString } from './EditListingPage.shared';
 import { hasPermissionToPostListings, isUserAuthorized } from '../../util/userHelpers';
 import { getMarketplaceEntities } from '../../ducks/marketplaceData.duck';
 import { manageDisableScrolling, isScrollingDisabled } from '../../ducks/ui.duck';
@@ -76,20 +77,24 @@ const pickRenderableImages = (
   // Images not yet connected to the listing
   const unattachedImages = uploadedImageIdsInOrder.map(i => uploadedImages[i]);
   const allImages = currentListingImages.concat(unattachedImages);
+  const removedImageIdStrings = new Set(removedImageIds.map(listingImageIdString).filter(Boolean));
 
   const pickImagesAndIds = (imgs, img) => {
-    const imgId = img.imageId || img.id;
+    const apiId = listingImageApiId(img);
+    const idString = listingImageIdString(apiId);
     // Pick only unique images that are not marked to be removed
-    const shouldInclude = !imgs.imageIds.includes(imgId) && !removedImageIds.includes(imgId);
+    const shouldInclude =
+      idString && !imgs.imageIdStrings.has(idString) && !removedImageIdStrings.has(idString);
     if (shouldInclude) {
       imgs.imageEntities.push(img);
-      imgs.imageIds.push(imgId);
+      imgs.imageIdStrings.add(idString);
     }
     return imgs;
   };
 
   // Return array of image entities. Something like: [{ id, imageId, type, attributes }, ...]
-  return allImages.reduce(pickImagesAndIds, { imageEntities: [], imageIds: [] }).imageEntities;
+  return allImages.reduce(pickImagesAndIds, { imageEntities: [], imageIdStrings: new Set() })
+    .imageEntities;
 };
 
 /**

--- a/src/containers/EditListingPage/EditListingPage.shared.js
+++ b/src/containers/EditListingPage/EditListingPage.shared.js
@@ -1,0 +1,52 @@
+/**
+ * Shared helpers for EditListingPage (listing image entities during edit/create flows).
+ * Image ids may be SDK UUID instances, uuid strings, or temporary client ids.
+ */
+
+/**
+ * Normalize an image id value to a comparable string.
+ *
+ * @param {string|Object} [idValue] - UUID instance, uuid string, or temp id
+ * @returns {string|undefined}
+ */
+export const listingImageIdString = idValue =>
+  typeof idValue === 'string' ? idValue : idValue?.uuid;
+
+/**
+ * Return identifier strings for an image entity (covers id/imageId across lifecycle).
+ *
+ * @param {Object} [image] - Listing image entity from API or upload state
+ * @returns {string[]}
+ */
+export const listingImageIdentifierStrings = image =>
+  [image?.id, image?.imageId].map(listingImageIdString).filter(Boolean);
+
+/**
+ * Return the API image id for an image entity (imageId preferred over id).
+ *
+ * @param {Object} [image] - Listing image entity from API or upload state
+ * @returns {string|Object|undefined}
+ */
+export const listingImageApiId = image => image?.imageId || image?.id;
+
+/**
+ * Map images to API ids, preserving order and removing duplicates by uuid string.
+ *
+ * @param {Object[]|null|undefined} images - Listing image entities
+ * @returns {Array|null}
+ */
+export const uniqueListingImageApiIds = images => {
+  if (!images) {
+    return null;
+  }
+  const seen = new Set();
+  return images.reduce((ids, img) => {
+    const apiId = listingImageApiId(img);
+    const idString = listingImageIdString(apiId);
+    if (idString && !seen.has(idString)) {
+      seen.add(idString);
+      ids.push(apiId);
+    }
+    return ids;
+  }, []);
+};

--- a/src/containers/EditListingPage/EditListingPage.shared.test.js
+++ b/src/containers/EditListingPage/EditListingPage.shared.test.js
@@ -1,0 +1,64 @@
+import { types as sdkTypes } from '../../util/sdkLoader';
+import {
+  listingImageApiId,
+  listingImageIdString,
+  listingImageIdentifierStrings,
+  uniqueListingImageApiIds,
+} from './EditListingPage.shared';
+
+const { UUID } = sdkTypes;
+const uuid = '11111111-1111-1111-1111-111111111111';
+
+describe('EditListingPage.shared', () => {
+  describe('listingImageIdString', () => {
+    it('returns string ids as-is', () => {
+      expect(listingImageIdString('temp_123')).toBe('temp_123');
+    });
+
+    it('returns uuid from SDK UUID instances', () => {
+      expect(listingImageIdString(new UUID(uuid))).toBe(uuid);
+    });
+  });
+
+  describe('listingImageIdentifierStrings', () => {
+    it('returns both temp id and image uuid when present', () => {
+      const image = { id: 'temp_123', imageId: new UUID(uuid) };
+      expect(listingImageIdentifierStrings(image)).toEqual(['temp_123', uuid]);
+    });
+  });
+
+  describe('listingImageApiId', () => {
+    it('prefers imageId over id', () => {
+      const imageId = new UUID(uuid);
+      const image = { id: 'temp_123', imageId };
+      expect(listingImageApiId(image)).toBe(imageId);
+    });
+  });
+
+  describe('uniqueListingImageApiIds', () => {
+    it('removes duplicate API ids that differ only by UUID object reference', () => {
+      const listingImage = { id: new UUID(uuid), type: 'image' };
+      const uploadedImage = { id: 'temp_123', imageId: new UUID(uuid), type: 'image' };
+
+      const result = uniqueListingImageApiIds([listingImage, uploadedImage]);
+
+      expect(result).toHaveLength(1);
+      expect(listingImageIdString(result[0])).toBe(uuid);
+    });
+
+    it('preserves order for unique images', () => {
+      const idA = new UUID('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa');
+      const idB = new UUID('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb');
+      const images = [{ id: idA }, { id: idB }];
+
+      const result = uniqueListingImageApiIds(images);
+
+      expect(result).toEqual([idA, idB]);
+    });
+
+    it('returns null for nullish input', () => {
+      expect(uniqueListingImageApiIds(null)).toBeNull();
+      expect(uniqueListingImageApiIds(undefined)).toBeNull();
+    });
+  });
+});

--- a/src/containers/EditListingPage/EditListingWizard/EditListingPhotosPanel/EditListingPhotosForm.js
+++ b/src/containers/EditListingPage/EditListingWizard/EditListingPhotosPanel/EditListingPhotosForm.js
@@ -12,6 +12,7 @@ import { FormattedMessage, useIntl } from '../../../../util/reactIntl';
 import { propTypes } from '../../../../util/types';
 import { nonEmptyArray, composeValidators } from '../../../../util/validators';
 import { isUploadImageOverLimitError } from '../../../../util/errors';
+import { listingImageIdentifierStrings } from '../../EditListingPage.shared';
 
 // Import shared components
 import { Button, Form, AspectRatioWrapper, NamedLink } from '../../../../components';
@@ -21,12 +22,6 @@ import ListingImage from './ListingImage';
 import css from './EditListingPhotosForm.module.css';
 
 const ACCEPT_IMAGES = 'image/*';
-
-// Matches an image across id/imageId as since which one is set changes over its lifecycle
-const imageIdentifiers = image =>
-  [image?.id, image?.imageId]
-    .map(idValue => (typeof idValue === 'string' ? idValue : idValue?.uuid))
-    .filter(Boolean);
 
 // Split out of the main bundle - only fetched once this form actually mounts.
 const Sortable = loadable.lib(() => import(/* webpackChunkName: "sortablejs" */ 'sortablejs'));
@@ -262,12 +257,12 @@ export const EditListingPhotosForm = props => {
     if (!form || propsImages.length === 0) {
       return;
     }
-    const currentImages = form.getState().values.images || [];
     propsImages.forEach(image => {
-      const ids = imageIdentifiers(image);
+      const currentImages = form.getState().values.images || [];
+      const ids = listingImageIdentifierStrings(image);
       // Find index of this image in the form's current images if it exists
       const index = currentImages.findIndex(existing =>
-        imageIdentifiers(existing).some(id => ids.includes(id))
+        listingImageIdentifierStrings(existing).some(id => ids.includes(id))
       );
       if (index === -1) {
         // New upload, not in the form yet


### PR DESCRIPTION
There was some rare edge cases which allowed duplicate images (ids) to be sent to API (ownListings.update).